### PR TITLE
Allow relative builds

### DIFF
--- a/debian/bono.install
+++ b/debian/bono.install
@@ -1,2 +1,2 @@
-../../build/bin/sprout usr/share/clearwater/bin
-../../bono.root/* /
+build/bin/sprout usr/share/clearwater/bin
+bono.root/* /

--- a/debian/clearwater-sip-stress-stats.install
+++ b/debian/clearwater-sip-stress-stats.install
@@ -1,1 +1,1 @@
-../../scripts/sipp-stats/clearwater-sipp-stats-*.gem /usr/share/clearwater/gems/
+scripts/sipp-stats/clearwater-sipp-stats-*.gem /usr/share/clearwater/gems/

--- a/debian/clearwater-sip-stress.install
+++ b/debian/clearwater-sip-stress.install
@@ -1,3 +1,3 @@
-../../clearwater-sip-stress.root/* /
-../../modules/sipp/sipp usr/share/clearwater/sip-stress/
-../../tests/load/call_load2.xml usr/share/clearwater/sip-stress/
+clearwater-sip-stress.root/* /
+modules/sipp/sipp usr/share/clearwater/sip-stress/
+tests/load/call_load2.xml usr/share/clearwater/sip-stress/

--- a/debian/restund.install
+++ b/debian/restund.install
@@ -1,3 +1,3 @@
-../../usr/sbin/restund usr/share/clearwater/bin
-../../usr/lib/restund/modules/* usr/share/clearwater/lib
-../../restund.root/* /
+usr/sbin/restund usr/share/clearwater/bin
+usr/lib/restund/modules/* usr/share/clearwater/lib
+restund.root/* /

--- a/debian/sprout-libs.install
+++ b/debian/sprout-libs.install
@@ -1,2 +1,2 @@
-../../usr/lib/*.so usr/share/clearwater/lib
-../../usr/lib/*.so.* usr/share/clearwater/lib
+usr/lib/*.so usr/share/clearwater/lib
+usr/lib/*.so.* usr/share/clearwater/lib

--- a/debian/sprout.install
+++ b/debian/sprout.install
@@ -1,2 +1,2 @@
-../../build/bin/sprout usr/share/clearwater/bin
-../../sprout.root/* /
+build/bin/sprout usr/share/clearwater/bin
+sprout.root/* /


### PR DESCRIPTION
This change allows building sprout/bono from any folder (even `/home/<user>/src/sprout`!).  Tested by building from `/home/<user>/sprout/`, `/home/<user>/src/sprout/` and `/home/<user>/src-github/sprout/`.
