### PR TITLE
Handle auth without cred

### DIFF
--- a/sprout/authentication.cpp
+++ b/sprout/authentication.cpp
@@ -243,10 +243,10 @@ pj_bool_t authenticate_rx_request(pjsip_rx_data* rdata)
 
     if (auth_hdr->credential.digest.response.slen == 0)
     {
-      // No response, so the authorization header was likely added by Bono, so
-			// remove it.
-			LOG_DEBUG("Remove authorization header added by Bono");
-			pj_list_erase(auth_hdr);
+      // No response supplied, don't use this authorization header for
+      // digest attempt.
+      LOG_DEBUG("Remove authorization header without response");
+      pj_list_erase(auth_hdr);
     }
   }
 


### PR DESCRIPTION
Some clients will send an Authorization header with just the username and realm on it for their first REGISTER.  These are not to be deemed an attempt to respond to a challenge so we shouldn't pass them to pjsip_auth_srv_verify().

This may be useful for distinguishing bono-created Authorization headers too (as bono will never add a response by itself).
