### PR TITLE
Make 1000ms the default, and improve var names.

### DIFF
--- a/include/zmq_lvc.h
+++ b/include/zmq_lvc.h
@@ -50,7 +50,7 @@ extern "C" {
 class LastValueCache
 {
 public:
-  LastValueCache(int statcount, std::string *statnames, long poll_timeout);
+  LastValueCache(int statcount, std::string *statnames, long poll_timeout_ms = 1000);
   ~LastValueCache();
   void* get_internal_publisher(std::string statname);
   void run();
@@ -66,7 +66,7 @@ private:
   void *_context;
   int _statcount;
   std::string *_statnames;
-  const long _poll_timeout;
+  const long _poll_timeout_ms;
   volatile bool _terminate;
 
   /// A bound 0MQ socket per statistic, for use by the internal

--- a/sprout/stack.cpp
+++ b/sprout/stack.cpp
@@ -553,8 +553,7 @@ pj_status_t init_stack(const std::string& system_name,
   }
 
   stack_data.stats_aggregator = new LastValueCache(Statistic::known_stats_count(),
-                                                   Statistic::known_stats(),
-                                                   1000);
+                                                   Statistic::known_stats());
 
   return PJ_SUCCESS;
 }

--- a/sprout/zmq_lvc.cpp
+++ b/sprout/zmq_lvc.cpp
@@ -54,10 +54,10 @@
  */
 LastValueCache::LastValueCache(int statcount,
                                std::string *statnames,
-                               long poll_timeout) :  //< Poll period in milliseconds
+                               long poll_timeout_ms) :  //< Poll period in milliseconds
   _statcount(statcount),
   _statnames(statnames),
-  _poll_timeout(poll_timeout),
+  _poll_timeout_ms(poll_timeout_ms),
   _terminate(false)
 {
   LOG_DEBUG("Initializing statistics aggregator");
@@ -153,7 +153,7 @@ void LastValueCache::run()
 
     // Poll for an event
     LOG_DEBUG("Poll for %d items", _statcount + 1);
-    int rc = zmq_poll(items, _statcount + 1, _poll_timeout);
+    int rc = zmq_poll(items, _statcount + 1, _poll_timeout_ms);
     assert(rc >= 0 || errno == EINTR);
 
     for (int ii = 0; ii < _statcount; ii++)


### PR DESCRIPTION
Use a default poll timeout for the LastValueCache, to make the
production code cleaner.

Explicitly add `_ms` to the name of the timeout variable, so it's
clear what the unit is.
