### PR TITLE
[Reviewer Keith] Commonalise common operations on Route headers

### DIFF
--- a/include/pjutils.h
+++ b/include/pjutils.h
@@ -101,12 +101,14 @@ namespace PJUtils
   // Route headers.
   pjsip_uri* next_hop(pjsip_msg* msg);
 
-  /// Checks whether the next route header in the message refers to this node,
-  // and optionally returns the header.
+  /// Checks whether the next Route header in the message refers to this node,
+  // and optionally returns the header.  If there are no Route headers it
+  // returns false.
   pj_bool_t is_next_route_local(const pjsip_msg* msg, const void* start, pjsip_route_hdr** hdr);
 
   /// Checks whether the top route header in the message refers to this node,
-  // and optionally returns the headers.
+  // and optionally returns the headers.  If there no Route headers it returns
+  // false.
   inline pj_bool_t is_top_route_local(const pjsip_msg* msg, pjsip_route_hdr** hdr)
   {
     return is_next_route_local(msg, NULL, hdr);

--- a/sprout/pjutils.cpp
+++ b/sprout/pjutils.cpp
@@ -228,7 +228,7 @@ void PJUtils::add_integrity_protected_indication(pjsip_tx_data* tdata)
 pjsip_uri* PJUtils::next_hop(pjsip_msg* msg)
 {
   pjsip_route_hdr* route_hdr = (pjsip_route_hdr*)pjsip_msg_find_hdr(msg, PJSIP_H_ROUTE, NULL);
-  LOG_DEBUG("Destination is %s", (route_hdr != NULL) ? "top route header" : "Request-URI");
+  LOG_DEBUG("Next hop node is encoded in %s", (route_hdr != NULL) ? "top route header" : "Request-URI");
   return (route_hdr != NULL) ? route_hdr->name_addr.uri : msg->line.req.uri;
 }
 

--- a/sprout/stateful_proxy.cpp
+++ b/sprout/stateful_proxy.cpp
@@ -770,8 +770,8 @@ pj_status_t proxy_process_edge_routing(pjsip_rx_data *rdata,
   {
     // Non-register request.  First check for double Record-Routing and remove
     // extra Route header.
-    pjsip_route_hdr* r1;
-    pjsip_route_hdr* r2;
+    pjsip_route_hdr* r1 = NULL;
+    pjsip_route_hdr* r2 = NULL;
 
     if ((PJUtils::is_top_route_local(tdata->msg, &r1)) &&
         (PJUtils::is_next_route_local(tdata->msg, r1, &r2)))


### PR DESCRIPTION
There were some common memes that kept cropping up in Sprout (in fact mostly in Bono/IBCF paths) relating to handling of Route headers, so I decided to commonalise some of this into a few PJUtils methods.

I've tested it with the UT, but haven't run the live tests over it.  I watch out for live tests on staging once it is merged, but the UTs seem to cover this code quite well so I think it's unlikely anything is broken.

Mike
