### PR TITLE
Strip loose routes when forwarding upstream

### DIFF
--- a/include/aschain.h
+++ b/include/aschain.h
@@ -57,6 +57,7 @@ extern "C" {
 struct target
 {
   pj_bool_t from_store;
+  pj_bool_t upstream_route;
   std::string aor;
   std::string binding_id;
   pjsip_uri* uri;

--- a/sprout/aschain.cpp
+++ b/sprout/aschain.cpp
@@ -239,7 +239,8 @@ AsChainLink::on_initial_request(CallServices* call_services,
 
     // Start defining the new target.
     target* as_target = new target;
-    as_target->from_store = false;
+    as_target->from_store = PJ_FALSE;
+    as_target->upstream_route = PJ_FALSE;
     as_target->transport = NULL;
 
     // Request-URI should remain unchanged


### PR DESCRIPTION
Strip out `Route:` headers on all messages proxied from Bono to Sprout.  In particular, the UE might (should) have added a `Route:` header matching the `Service-Route:` we send back on the `REGISTER` response (see #42).

In any case, if we're proxying the message up to Sprout, we're taking ownership of the message's route and shouldn't allow loose-routing.
