### PR TITLE
[Reviewer: Matt] Wait until transactions have expired.

### DIFF
--- a/sprout/ut/stateful_proxy_test.cpp
+++ b/sprout/ut/stateful_proxy_test.cpp
@@ -1196,10 +1196,12 @@ TEST_F(StatefulProxyTest, TestForkedFlow3)
   // Send 183 back from one of them
   inject_msg(respond_to_txdata(_tdata[_uris[0]], 183));
   // Nothing happens yet!
+  poll();
   ASSERT_EQ(0, txdata_count());
 
   // Send final error from another of them
   inject_msg(respond_to_txdata(_tdata[_uris[1]], 404));
+  poll();
 
   // Gets acknowledged directly by us
   ASSERT_EQ(1, txdata_count());


### PR DESCRIPTION
Required to avoid spurious memory leaks.

We don't do a real wait, of course - we fake one.
