### PR TITLE
[Reviewer: Andy] Default ENUM server correctly (fixes #47)

### DIFF
--- a/debian/bono.init.d
+++ b/debian/bono.init.d
@@ -80,7 +80,8 @@ log_directory=/var/log/$NAME
 #
 get_settings()
 {
-        # Pull in the settings for this node.
+        # Set up defaults and then pull in the settings for this node.
+        sas_server=0.0.0.0
         . /etc/clearwater/config
 
         # Set up defaults for user settings then pull in any overrides.

--- a/debian/sprout.init.d
+++ b/debian/sprout.init.d
@@ -80,7 +80,9 @@ log_directory=/var/log/$NAME
 #
 get_settings()
 {
-        # Pull in the settings for this node.
+        # Set up defaults and then pull in the settings for this node.
+        enum_server=127.0.0.1
+        sas_server=0.0.0.0
         . /etc/clearwater/config
 
         # Pull in the current cluster configuration (creating a default if it does not exist).


### PR DESCRIPTION
Andy, please can you review this trivial tweak to correctly default ENUM and SAS servers if they're not present in /etc/clearwater/config?
