### PR TITLE
[Reviewer: Andy] Fix statistics parsing - columns have moved

### DIFF
--- a/scripts/sipp-stats/lib/clearwater-sipp-stats.rb
+++ b/scripts/sipp-stats/lib/clearwater-sipp-stats.rb
@@ -92,6 +92,11 @@ loop do
   begin 
     line = f.readline
     fields = line.split ';'
+    # Pull out fields
+    #  4 - "2_REGISTER_Sent", i.e. number of initial REGISTERs sent
+    # 28 - "10_REGISTER_Sent", i.e. number of re-REGISTERs sent
+    # 44 - "17_INVITE_Sent", i.e. number of INVITEs sent
+    # 92 - "35_200_Recv", i.e. number of 200 OKs to BYEs received
     stats = fields.values_at(4, 28, 44, 92)
 
     # Calculate the deltas.  If we've not yet seen two real sets of values


### PR DESCRIPTION
Andy,

Please can you review?  A couple of weeks back, I tweaked the sipp scripts because we'd enabled per-user authentication on REGISTERs.  Unfortunately, I didn't spot the stats parsing.  This fix remedies that.
- The first column is before my tweak, so doesn't change.
- The second and third columns are after my tweak, so move ahead by 12 columns.
- The fourth column is also after my tweak, so would move ahead by 12 columns, except its previous position was misleading (it was on the post-call delay, not the receipt of the last message of the call), so I've fixed that up by only moving it forward by 8.

I've tested this live.

Matt
