### PR TITLE
[Reviewed: Mike] Fix memory leak by freeing associated URI JSON arrays

### DIFF
--- a/sprout/registrar.cpp
+++ b/sprout/registrar.cpp
@@ -557,6 +557,7 @@ void process_register_request(pjsip_rx_data* rdata)
                                                   &associated_uri);
     pjsip_msg_add_hdr(tdata->msg, associated_uri_hdr);
   }
+  delete uris;
 
   // Send the response.
   status = pjsip_endpt_send_response2(stack_data.endpt, rdata, tdata, NULL, NULL);

--- a/sprout/stateful_proxy.cpp
+++ b/sprout/stateful_proxy.cpp
@@ -1460,6 +1460,7 @@ void proxy_calculate_targets(pjsip_msg* msg,
 
       delete aor_data;
     }
+    delete uris;
   }
 }
 


### PR DESCRIPTION
Valgrind pointed out we were leaking the associated URI JSON arrays.  We should be deleting them.
