### PR TITLE
[Reviewer Matt] Issue 90 - stop 487 responses propagating upstream after a redirect.

### DIFF
--- a/include/stateful_proxy.h
+++ b/include/stateful_proxy.h
@@ -139,7 +139,7 @@ public:
   void on_new_client_response(UACTransaction* uac_data, pjsip_rx_data *rdata);
   void on_client_not_responding(UACTransaction* uac_data);
   void on_tsx_state(pjsip_event* event);
-  void cancel_pending_uac_tsx(int st_code, bool dissociate_uac=false);
+  void cancel_pending_uac_tsx(int st_code, bool dissociate_uac);
   pj_status_t handle_final_response();
 
   void register_proxy(CallServices::Terminating* proxy);

--- a/sprout/stateful_proxy.cpp
+++ b/sprout/stateful_proxy.cpp
@@ -583,7 +583,7 @@ void process_cancel_request(pjsip_rx_data* rdata)
   // we receive final response from the UAC INVITE transaction.
   LOG_DEBUG("%s - Cancel for UAS transaction", invite_uas->obj_name);
   UASTransaction *uas_data = UASTransaction::get_from_tsx(invite_uas);
-  uas_data->cancel_pending_uac_tsx(0);
+  uas_data->cancel_pending_uac_tsx(0, false);
 
   // Unlock UAS tsx because it is locked in find_tsx()
   pj_grp_lock_release(invite_uas->grp_lock);
@@ -3094,7 +3094,7 @@ void UACTransaction::exit_context()
   {
     // Deleting the transaction implicitly releases the group lock.
     delete this;
-  } 
+  }
   else
   {
     // Release the group lock.


### PR DESCRIPTION
Matt

Can you review this fix.  I've tested running the UTs and the live tests and testing the scenario live.  The big comment in cancel_pending_uac_tsx should explain exactly what the fix is about.

Mike
