### PR TITLE
[Reviewer Matt] Fixes #111 - add locking around authorized_ids/default_id members

### DIFF
--- a/include/flowtable.h
+++ b/include/flowtable.h
@@ -66,9 +66,9 @@ public:
   /// Returns a reference to the flow token.
   inline const std::string& token() const { return _token; };
 
-  std::string asserted_identity(pjsip_uri* preferred_identity) const;
+  std::string asserted_identity(pjsip_uri* preferred_identity);
 
-  std::string default_identity() const;
+  std::string default_identity();
 
   void set_identity(const pjsip_uri* uri, bool is_default, int expires);
 


### PR DESCRIPTION
Matt

Can you review.  I've run the UTs over the change, but otherwise there isn't much I can do to test that the fix works short of running stress, which probably isn't worth it for such a simple change.

Mike
