### PR TITLE
[No reviewer] Fix memory issues around AsChainLink lifetime and reinstate disabled test

### DIFF
--- a/sprout/ut/stateful_proxy_test.cpp
+++ b/sprout/ut/stateful_proxy_test.cpp
@@ -3131,7 +3131,7 @@ TEST_F(IscTest, DefaultHandlingContinueNonResponsive)
 
 
 // Test DefaultHandling=CONTINUE for a responsive AS that returns an error.
-TEST_F(IscTest, DISABLED_DefaultHandlingContinueResponsiveError)
+TEST_F(IscTest, DefaultHandlingContinueResponsiveError)
 {
   register_uri(_store, _hss_connection, "6505551234", "homedomain", "sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob");
   _hss_connection->set_user_ifc("sip:6505551234@homedomain",


### PR DESCRIPTION
Fixed the final memory issue that resulted in a leaking AsChain object.  This seems to also have fixed the problem with the new test case, so I've reenabled that as well.
