### PR TITLE
Don't use .next() to get next AsChainLink in AS chain for redirect 

### DIFF
--- a/sprout/stateful_proxy.cpp
+++ b/sprout/stateful_proxy.cpp
@@ -2778,7 +2778,7 @@ bool UASTransaction::redirect_int(pjsip_uri* target, int code)
 
     // Kick off outgoing processing for the new request.  Continue the
     // existing AsChain. This will trigger orig-cdiv handling.
-    handle_non_cancel(ServingState(&SessionCase::Terminating, _as_chain_link.next()));
+    handle_non_cancel(ServingState(&SessionCase::Terminating, _as_chain_link));
   }
   else
   {


### PR DESCRIPTION
It's unnecessary and can hit and assert if at end of chain.  It's unnecessary because in a redirect case we only need to know about the original chain so we know to switch to a new target and start terminating services again - exactly where we are in the chain doesn't matter.
