### PR TITLE
[Reviewer Andy] Add CONNECT-TIMEOUT configuration to libmemcached startup

### DIFF
--- a/sprout/memcachedstore.cpp
+++ b/sprout/memcachedstore.cpp
@@ -98,6 +98,7 @@ namespace RegData {
       options += "--SERVER=" + (*i) + " ";
     }
     options += "--BINARY-PROTOCOL";
+    options += " --CONNECT_TIMEOUT=200";
     options += " --POOL-MIN=" + to_string<int>(pool_size, std::dec) + " --POOL-MAX=" + to_string<int>(pool_size, std::dec);
 
     _pool = memcached_pool(options.c_str(), options.length());


### PR DESCRIPTION
Andy

Can you review my fix to https://github.com/Metaswitch/sprout/issues/143.  I've tested it by running the UTs, running the live tests, then stopping memcached on my sprout node, running the basic call test again and verifying that the REGISTERs fail almost immediately with a 500 Server Error.

If you want to verify against the API docs, see http://docs.libmemcached.org/libmemcached_configuration.html.

Mike
