### PR TITLE
[Reviewer: Mike] Include math.h from utils.h to build on GCC versions where log and pow are not built in

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -37,6 +37,7 @@
 #ifndef UTILS_H_
 #define UTILS_H_
 
+#include <math.h>
 #include <algorithm>
 #include <functional>
 #include <string>


### PR DESCRIPTION
Mike, a trivial review for you: we now use log() and pow() in include/utils.h.  In GCC 4.6, these seem to be built-in but in other versions you need to include math.h.  It's safe to always do this, so I've done so.  I've built sprout and run UTs.  I haven't run live tests because I'm pretty sure this is safe.
