### PR TITLE
[Reviewer Matt] Make sure statelessly forwarded responses use the right transport

### DIFF
--- a/sprout/stateful_proxy.cpp
+++ b/sprout/stateful_proxy.cpp
@@ -275,9 +275,9 @@ static pj_bool_t proxy_on_rx_response(pjsip_rx_data *rdata)
 
   // Calculate the address to forward the response
   pj_bzero(&res_addr, sizeof(res_addr));
-  res_addr.dst_host.type = PJSIP_TRANSPORT_UDP;
+  res_addr.dst_host.type = pjsip_transport_get_type_from_name(&hvia->transport);
   res_addr.dst_host.flag =
-    pjsip_transport_get_flag_from_type(PJSIP_TRANSPORT_UDP);
+    pjsip_transport_get_flag_from_type(res_addr.dst_host.type);
 
   // Destination address is Via's received param
   res_addr.dst_host.addr.host = hvia->recvd_param;

--- a/sprout/ut/stateful_proxy_test.cpp
+++ b/sprout/ut/stateful_proxy_test.cpp
@@ -714,7 +714,7 @@ void StatefulProxyTestBase::doTestHeaders(TransportFlow* tpA,  //< Alice's trans
   // OK goes back C<-X
   out = current_txdata()->msg;
   RespMatcher(200).matches(out);
-  //@@@DISABLED - see bug 132. tpA->expect_target(current_txdata(), true);
+  tpA->expect_target(current_txdata(), true);
   msg.set_route(out);
   msg._cseq++;
 


### PR DESCRIPTION
Matt

Can you review this please.  I've tested by reenabling the disabled UT Keith mentioned in https://github.com/Metaswitch/sprout/issues/140.

Mike
