### PR TITLE
{Reviewer: Andy} Revert "Update Sprout's default setting for memcached hosts to match the...

### DIFF
--- a/debian/sprout.init.d
+++ b/debian/sprout.init.d
@@ -86,7 +86,7 @@ get_settings()
         . /etc/clearwater/config
 
         # Pull in the current cluster configuration (creating a default if it does not exist).
-        [ -f /etc/clearwater/cluster_settings ] || echo "memcached_servers=$local_ip:11211" > /etc/clearwater/cluster_settings
+        [ -f /etc/clearwater/cluster_settings ] || echo "memcached_servers=$public_hostname:11211" > /etc/clearwater/cluster_settings
         . /etc/clearwater/cluster_settings
 
         # Set up defaults for user settings then pull in any overrides.


### PR DESCRIPTION
... Chef default (local IP rather than hostname)."

This reverts commit 44fa5068fea7bfe5f7fb3c1cd38701a9fc67663d.
