### PR TITLE
[No reviewer required] Pass binary parmeter through to MemcachedStore constructor

### DIFF
--- a/sprout/memcachedstore.cpp
+++ b/sprout/memcachedstore.cpp
@@ -69,7 +69,7 @@ RegData::Store* create_memcached_store(const std::list<std::string>& servers,
                                        bool binary)
                                        ///< use binary protocol?
 {
-  return new MemcachedStore(servers, connections);
+  return new MemcachedStore(servers, connections, binary);
 }
 
 /// Destroy a store object which used the memcached implementation.


### PR DESCRIPTION
Fixing a minor problem that got introduced while merging sto390 in to dev.  Won't have impact on sprout itself, because the MemcachedStore defaults to use the binary protocol anyway.
