### PR TITLE
[Reviewer: Mike] Allow sprout BGCF config to specify a port. 

### DIFF
--- a/sprout/stateful_proxy.cpp
+++ b/sprout/stateful_proxy.cpp
@@ -1288,13 +1288,13 @@ void proxy_calculate_targets(pjsip_msg* msg,
       if (!bgcf_route.empty())
       {
         // Split the route into a host and (optional) port.
-        int port = 0
+        int port = 0;
         std::vector<std::string> bgcf_route_elems;
         Utils::split_string(bgcf_route, ':', bgcf_route_elems, 2, true);
 
-        if (bgcf_route_elems.length() > 1)
+        if (bgcf_route_elems.size() > 1)
         {
-          port = atoi(bgcf_route_elems[1].c_str())
+          port = atoi(bgcf_route_elems[1].c_str());
         }
 
         // BGCF configuration has a route to this destination, so translate to


### PR DESCRIPTION
Mike, this is a fix for the issue you, me and Matt discussed earlier. By allowing BGCF config to specify a port we can ensure a PSTN-bound request gets routed to port 5058 on bono.
