### PR TITLE
[Reviewer: Mike] Check that reg_max_expires is valid before using it 

### DIFF
--- a/sprout/main.cpp
+++ b/sprout/main.cpp
@@ -201,6 +201,7 @@ static pj_status_t init_options(int argc, char *argv[], struct options *options)
   };
   int c;
   int opt_ind;
+  int reg_max_expires;
 
   pj_optind = 0;
   while((c=pj_getopt_long(argc, argv, "s:t:u:l:e:I:A:R:M:S:H:X:E:x:f:r:p:w:a:F:L:dih", long_opt, &opt_ind))!=-1) {
@@ -319,7 +320,7 @@ static pj_status_t init_options(int argc, char *argv[], struct options *options)
       break;
 
     case 'r':
-      int reg_max_expires = atoi(pj_optarg);
+      reg_max_expires = atoi(pj_optarg);
 
       if (reg_max_expires > 0)
       {


### PR DESCRIPTION
In applying markups to the code for sto438 I implicitly removed the code that only uses the command line parameter if it's actually valid. This pull request adds some checking back in. 
