### PR TITLE
[No reviewer required] Delete master vbucket maps when memcached store is destroyed

### DIFF
--- a/sprout/memcachedstore.cpp
+++ b/sprout/memcachedstore.cpp
@@ -125,6 +125,11 @@ MemcachedStore::~MemcachedStore()
   }
 
   pthread_rwlock_destroy(&_view_lock);
+
+  for (int ii = 0; ii < _replicas; ++ii)
+  {
+    delete _vbucket_map[ii];
+  }
 }
 
 


### PR DESCRIPTION
Just fixing a leak flagged by valgrind on Jenkins.
