### PR TITLE
[Reviewer Andy] Sprout crashes is cluster_settings file is malformed

### DIFF
--- a/sprout/memcachedstore.cpp
+++ b/sprout/memcachedstore.cpp
@@ -275,7 +275,7 @@ void MemcachedStore::flush_all()
 AoR* MemcachedStore::get_aor_data(const std::string& aor_id)
                                   ///< the SIP URI
 {
-  memcached_return_t rc = MEMCACHED_SUCCESS;
+  memcached_return_t rc = MEMCACHED_ERROR;
   MemcachedAoR* aor_data = NULL;
   memcached_result_st result;
   std::vector<bool> read_repair(_replicas);
@@ -431,7 +431,7 @@ bool MemcachedStore::set_aor_data(const std::string& aor_id,
                                   AoR* data)
                                   ///< the data to store
 {
-  memcached_return_t rc = MEMCACHED_SUCCESS;
+  memcached_return_t rc = MEMCACHED_ERROR;
   MemcachedAoR* aor_data = (MemcachedAoR*)data;
 
   connection* conn = get_connection();


### PR DESCRIPTION
Andy

Can you review please.  As discussed, the issue is that when the cluster_settings file is malformed the memcached store ends up with no connections to the memcached cluster, so it does no iterations round the read or the write loops.  Unfortunately I initialised the return code variable to MEMCACHED_SUCCESS so in this case the function assumes it has a valid result from memcached and crashes trying to parse it.

I've tested by reproducing the problem with a hand edited cluster_settings file, watching sprout die horribly when I run the live tests against it, then applying the fixed build and watching sprout fail all the tests but survive and log nice error messages about failing to read registration data.

Mike
