### PR TITLE
[Reviewer: Alex] Fix AsChain scribbler

### DIFF
--- a/include/aschain.h
+++ b/include/aschain.h
@@ -205,11 +205,12 @@ public:
   }
 
   /// Caller has finished using this link.
-  void release() const
+  void release()
   {
     if (_as_chain != NULL)
     {
       _as_chain->dec_ref();
+      _as_chain = NULL;
     }
   }
 


### PR DESCRIPTION
Alex,

Please can you review my fix to NULL out the reference to the AsChain when we release it.  Without this fix, we can
-   initialize the AsChainLink with an AsChain when we start originating processing
-   release the AsChainLink (decrementing the AsChain's reference count) when we complete originating processing and start terminating processing
-   **not** overwrite the AsChainLink if this is an outgoing call - normally, it would be overwritten by the terminating AsChain
-   release the AsChainLink a second time in the UASTransaction destructor
-   scribble because this decrements the AsChain's reference count a second time, but the AsChain has already been destroyed.

I've run the UT and confirmed that this fixes the failing live test.

Matt
