### PR TITLE
[Reviewer Matt] Create default cluster_settings file if one does not exist

### DIFF
--- a/debian/sprout.init.d
+++ b/debian/sprout.init.d
@@ -84,6 +84,9 @@ get_settings()
         sas_server=0.0.0.0
         . /etc/clearwater/config
 
+        # Set up a default cluster_settings file if it does not exist.
+        [ -f /etc/clearwater/cluster_settings ] || echo "servers=$local_ip:11211" > /etc/clearwater/cluster_settings
+
         # Set up defaults for user settings then pull in any overrides.
         # Sprout uses blocking look-up services, so must run multi-threaded.
         num_pjsip_threads=1


### PR DESCRIPTION
Matt

Can you review this fix to issue 241 (to ensure that Sprout works after a manual install and in AIO nodes).  I've tested it by stopping sprout on a Chef installed node, deleting the cluster_settings file, then restarting Sprout - checking that the file is recreated as expected and the system passes live tests.

Mike
