### PR TITLE
[Reviewer: Mike] Don't reject off-net calls just because caller doesn't have E164 number

### DIFF
--- a/sprout/stateful_proxy.cpp
+++ b/sprout/stateful_proxy.cpp
@@ -2180,29 +2180,6 @@ bool UASTransaction::move_to_terminating_chain()
 // is now `Complete`. Never returns `Next`.
 AsChainLink::Disposition UASTransaction::handle_terminating(Target** target) // OUT: target, if disposition is Skip
 {
-  if (!PJUtils::is_home_domain(_req->msg->line.req.uri))
-  {
-    // This is an off-net domain.  Find the calling party, either in the
-    // P-Asserted-Identity (which really should be present) or the From (if
-    // not).
-    pjsip_routing_hdr* asserted_id_hdr = (pjsip_routing_hdr*)
-                             pjsip_msg_find_hdr_by_name(_req->msg, &STR_P_ASSERTED_IDENTITY, NULL);
-    pjsip_uri* id_uri = (pjsip_uri*)((asserted_id_hdr != NULL) ?
-                                pjsip_uri_get_uri(&asserted_id_hdr->name_addr) :
-                                pjsip_uri_get_uri(PJSIP_MSG_FROM_HDR(_req->msg)->uri));
-
-    if (!PJUtils::is_e164(id_uri))
-    {
-      // The URI has been translated to an off-net domain, but the user does
-      // not have a valid E.164 number that can be used to make off-net calls.
-      // Reject the call with a not found response code, which is about the
-      // most suitable for this case.
-      LOG_INFO("Rejecting off-net call from user without E.164 address");
-      send_response(PJSIP_SC_NOT_FOUND, &SIP_REASON_OFFNET_DISALLOWED);
-      return AsChainLink::Disposition::Stop;
-    }
-  }
-
   // If the newly translated ReqURI indicates that we're the host of the
   // target user, include ourselves as the terminating operator for
   // billing.

--- a/sprout/ut/stateful_proxy_test.cpp
+++ b/sprout/ut/stateful_proxy_test.cpp
@@ -1077,14 +1077,14 @@ TEST_F(StatefulProxyTest, TestEnumExternalSuccessFromFromHeader)
   doSuccessfulFlow(msg, testing::MatchesRegex(".*+15108580271@ut.cw-ngv.com.*"), hdrs);
 }
 
-TEST_F(StatefulProxyTest, TestEnumExternalOffNetDialingNotAllowed)
+TEST_F(StatefulProxyTest, TestEnumExternalOffNetDialingAllowed)
 {
   SCOPED_TRACE("");
   Message msg;
   msg._to = "+15108580271";
   cwtest_add_host_mapping("ut.cw-ngv.com", "10.9.8.7");
   list<HeaderMatcher> hdrs;
-  doSlowFailureFlow(msg, 404);
+  doSuccessfulFlow(msg, testing::MatchesRegex(".*+15108580271@ut.cw-ngv.com.*"), hdrs);
 }
 
 /// Test a forked flow - setup phase.


### PR DESCRIPTION
Mike,

Please can you review my fix to not reject off-net calls just because the caller doesn't have an E164 number.  This was historical, but is no longer relevant (and not backed up by IMS specs).  The fix is trivial and there's a corresponding UT fix (which passes).  I'll also send you a live test fix in a moment.

Matt

fixes #247
