### PR TITLE
[Reviewer: Mike] Let OPTIONS requests hit ASs

### DIFF
--- a/sprout/options.cpp
+++ b/sprout/options.cpp
@@ -72,8 +72,7 @@ pj_bool_t on_rx_request(pjsip_rx_data* rdata)
 {
   if (rdata->msg_info.msg->line.req.method.id == PJSIP_OPTIONS_METHOD)
   {
-    if ((PJUtils::is_uri_local(rdata->msg_info.msg->line.req.uri)) ||
-        (PJUtils::is_home_domain(rdata->msg_info.msg->line.req.uri)))
+    if (PJUtils::is_uri_local(rdata->msg_info.msg->line.req.uri))
     {
       // OPTIONS targetted at this node or at the home domain, so respond
       // statelessly.

--- a/sprout/ut/options_test.cpp
+++ b/sprout/ut/options_test.cpp
@@ -89,7 +89,7 @@ public:
   Message() :
     _method("OPTIONS"),
     _user("6505550231"),
-    _domain("homedomain")
+    _domain("testnode")
   {
   }
 
@@ -140,6 +140,14 @@ TEST_F(OptionsTest, NotOurs)
 {
   Message msg;
   msg._domain = "not-us.example.org";
+  pj_bool_t ret = inject_msg_direct(msg.get());
+  EXPECT_EQ(PJ_FALSE, ret);
+}
+
+TEST_F(OptionsTest, HomeDomain)
+{
+  Message msg;
+  msg._domain = "homedomain";
   pj_bool_t ret = inject_msg_direct(msg.get());
   EXPECT_EQ(PJ_FALSE, ret);
 }


### PR DESCRIPTION
Mike,

Please can you review my fix to let OPTIONS requests get routed to the ASs?  As discussed, the options module no longer processes requests targeted at the home domain.  I've added UT both for this function and also that stateful_proxy routes OPTIONS to ASs.  This fixes #253.

Matt
