### PR TITLE
[Reviewer: Mike] Check Sec-WebSocket-Protocol header and echo it back if valid (fixes #252)

### DIFF
--- a/sprout/websockets.cpp
+++ b/sprout/websockets.cpp
@@ -396,7 +396,8 @@ static pj_status_t ws_destroy_transport(pjsip_transport *transport)
 class sip_server_handler : public server::handler {
   public:
 
-    void validate(connection_ptr con) {
+    void validate(connection_ptr con)
+    {
       // The key validation step we need to do is on the subprotocols the
       // client requested.  This should include "sip", in which case we'll
       // select "sip" too.  If "sip" was not offered, we offer nothing and the


### PR DESCRIPTION
Mike,

Please can you review my fix to issue #252, which covered WebSockets support being broken?  The fix was simply to check the Sec-WebSocket-Protocol header and echo it back if it contains "sip".  There are no UTs for WebSockets (although I've run the UTs to make sure I haven't accidentally broken anything else in the meantime).  I have tested live in Google Chrome and successfully registered with both sipML5 and JsSIP.

Matt
