### PR TITLE
[Reviewer: Matt] Add a check for any memory errors 

### DIFF
--- a/sprout/Makefile
+++ b/sprout/Makefile
@@ -263,10 +263,10 @@ vg: build_test | $(TEST_OUT_DIR)
 # if there are no errors. 
 .PHONY: vg-check
 vg-check: vg
-	@xmllint --xpath '//error/kind' $(VG_XML) 2>&1 \
-		| sed -e 's#<kind>##g' \
-		| sed -e 's#</kind>#\n#g' \
-		| sort > $(VG_LIST)
+	@xmllint --xpath '//error/kind' $(VG_XML) 2>&1 | \
+		sed -e 's#<kind>##g' | \
+		sed -e 's#</kind>#\n#g' | \
+		sort > $(VG_LIST)
 	@if grep -q -v "XPath set is empty" $(VG_LIST) ; then \
 		echo "Error: some memory errors have been detected" ; \
 		cat $(VG_LIST) ; \


### PR DESCRIPTION
Matt, can you please review this change to the makefile to output to screen when there are valgrind errors when running the UTs

The output will look like:

Error: some memory errors have been detected
Leak_DefinitelyLost
See /home/em/sprout/build/testout/vg_sprout_test.memcheck for further details.

Fixes #264 
