### PR TITLE
[Reviewer Matt] Remove special case handling of 1xx responses on forked transactions

### DIFF
--- a/sprout/stateful_proxy.cpp
+++ b/sprout/stateful_proxy.cpp
@@ -1410,7 +1410,7 @@ bool UASTransaction::get_data_from_hss(std::string public_id, HSSCallInformation
 // Look up the associated URIs for the given public ID, using the cache if possible (and caching them and the iFC otherwise).
 // The uris parameter is only filled in correctly if this function
 // returns true,
-bool UASTransaction::get_associated_uris(std::string public_id, std::vector<std::string>& uris, SAS::TrailId trail) 
+bool UASTransaction::get_associated_uris(std::string public_id, std::vector<std::string>& uris, SAS::TrailId trail)
 {
   HSSCallInformation data;
   bool success = get_data_from_hss(public_id, data, trail);
@@ -1421,12 +1421,12 @@ bool UASTransaction::get_associated_uris(std::string public_id, std::vector<std:
   return success;
 }
 
-// Look up the Ifcs for the given public ID, using the cache if possible (and caching them and the associated URIs otherwise).  
+// Look up the Ifcs for the given public ID, using the cache if possible (and caching them and the associated URIs otherwise).
 // The ifcs parameter is only filled in correctly if this function
 // returns true,
-bool UASTransaction::lookup_ifcs(std::string public_id, Ifcs& ifcs, SAS::TrailId trail) 
+bool UASTransaction::lookup_ifcs(std::string public_id, Ifcs& ifcs, SAS::TrailId trail)
 {
-  HSSCallInformation data; 
+  HSSCallInformation data;
   bool success = get_data_from_hss(public_id, data, trail);
   if (success)
   {
@@ -1483,7 +1483,7 @@ void UASTransaction::proxy_calculate_targets(pjsip_msg* msg,
       if (!bgcf_route.empty())
       {
         for (std::vector<std::string>::const_iterator ii = bgcf_route.begin(); ii != bgcf_route.end(); ++ii)
-        { 
+        {
           // Split the route into a host and (optional) port.
           int port = 0;
           std::vector<std::string> bgcf_route_elems;
@@ -2325,51 +2325,11 @@ void UASTransaction::on_new_client_response(UACTransaction* uac_data, pjsip_rx_d
 
     if (_num_targets > 1)
     {
-      // Do special response filtering for forked transactions.
-      if ((method() == PJSIP_INVITE_METHOD) &&
-          (status_code == 180) &&
-          (!_ringing))
+      if ((status_code > 100) &&
+          (status_code < 199))
       {
-        LOG_DEBUG("%s - 180/INVITE Ringing response", uac_data->name());
-        // We special case the first ringing response to an INVITE,
-        // sending a ringing response to the originating UAC, but
-        // pretending the response is from a UAS co-resident with the
-        // proxy.
-        pjsip_fromto_hdr *to;
-
-        _ringing = PJ_TRUE;
-
-        // Change the tag in the To header.
-        to = (pjsip_fromto_hdr* )pjsip_msg_find_hdr(tdata->msg,
-                                                    PJSIP_H_TO, NULL);
-        if (to == NULL)
-        {
-          LOG_ERROR("No To header in INVITE response", 0);
-          exit_context();
-          return;
-        }
-
-        to->tag = pj_str("xyz");
-
-        // Contact header???
-
-        // Forward response with the UAS transaction
-        pjsip_tsx_send_msg(_tsx, tdata);
-      }
-      else if ((method() == PJSIP_INVITE_METHOD) &&
-               (status_code > 100) &&
-               (status_code < 199))
-      {
-        // Discard all other provisional responses to INVITE
-        // transactions.
-        LOG_DEBUG("%s - Discard 1xx/INVITE response", uac_data->name());
-        pjsip_tx_data_dec_ref(tdata);
-      }
-      else if ((status_code > 100) &&
-               (status_code < 199))
-      {
-        // Forward all provisional responses to non-INVITE transactions.
-        LOG_DEBUG("%s - Forward 1xx/non-INVITE response", uac_data->name());
+        // Forward all provisional responses.
+        LOG_DEBUG("%s - Forward 1xx response", uac_data->name());
 
         // Forward response with the UAS transaction
         pjsip_tsx_send_msg(_tsx, tdata);

--- a/sprout/ut/stateful_proxy_test.cpp
+++ b/sprout/ut/stateful_proxy_test.cpp
@@ -1168,8 +1168,11 @@ TEST_F(StatefulProxyTest, TestForkedFlow)
   // Send 183 back from one of them
   inject_msg(respond_to_txdata(_tdata[_uris[0]], 183, "early"));
 
-  // Nothing happens yet!
-  ASSERT_EQ(0, txdata_count());
+  // 183 goes back
+  ASSERT_EQ(1, txdata_count());
+  out = current_txdata()->msg;
+  RespMatcher(183, "early").matches(out);
+  free_txdata();
 
   // Send 200 OK from another of them
   inject_msg(respond_to_txdata(_tdata[_uris[1]], 200, "bbb"));
@@ -1232,8 +1235,12 @@ TEST_F(StatefulProxyTest, TestForkedFlow2)
 
   // Send 183 back from one of them
   inject_msg(respond_to_txdata(_tdata[_uris[0]], 183));
-  // Nothing happens yet!
-  ASSERT_EQ(0, txdata_count());
+
+  // 183 goes back
+  ASSERT_EQ(1, txdata_count());
+  out = current_txdata()->msg;
+  RespMatcher(183).matches(out);
+  free_txdata();
 
   // Send final error from another of them
   inject_msg(respond_to_txdata(_tdata[_uris[1]], 404));
@@ -1286,9 +1293,11 @@ TEST_F(StatefulProxyTest, TestForkedFlow3)
 
   // Send 183 back from one of them
   inject_msg(respond_to_txdata(_tdata[_uris[0]], 183));
-  // Nothing happens yet!
-  poll();
-  ASSERT_EQ(0, txdata_count());
+  // 183 goes back
+  ASSERT_EQ(1, txdata_count());
+  out = current_txdata()->msg;
+  RespMatcher(183).matches(out);
+  free_txdata();
 
   // Send final error from another of them
   inject_msg(respond_to_txdata(_tdata[_uris[1]], 404));


### PR DESCRIPTION
Matt

A fix for the issue with odd handling of 1xx responses on forked transactions.  There's some spurious white-space differences in the diff, which are probably down to my editor settings - sorry).  The fix basically involves removing some special case code we added right at the beginning of Clearwater development (before it was called Clearwater) to get around some issues with clients that didn't seem to like being downstream of a forking proxy.  This isn't relevant any more, so it should be safe to remove this code.

I've tested by fixing up the unit tests that were checking for this.  They aren't 100% perfect as they don't check that the To: tags are propagated properly, but I couldn't see how to easily do this check and wanted to get the fix out today.

Mike
