### PR TITLE
[Reviewer Andy] Enable XPUB_VERBOSE mode in XPUB socket so that last value cache hears about all subscriptions

### DIFF
--- a/sprout/zmq_lvc.cpp
+++ b/sprout/zmq_lvc.cpp
@@ -134,6 +134,9 @@ void LastValueCache::run()
   }
 
   _publisher = zmq_socket(_context, ZMQ_XPUB);
+  int verbose = 1;
+  zmq_setsockopt(_publisher, ZMQ_XPUB_VERBOSE, &verbose, sizeof(verbose));
+  LOG_DEBUG("Enabled XPUB_VERBOSE mode");
   zmq_bind(_publisher, "tcp://*:6666");
 
   while (!_terminate)


### PR DESCRIPTION
Andy

Can you review and merge asap please - I've checked this fixes the problem live.

Mike
