### PR TITLE
[Reviewer: Andy] Change to monotonic

### DIFF
--- a/include/eventq.h
+++ b/include/eventq.h
@@ -233,7 +233,7 @@ public:
       struct timespec attime;
       if (timeout != -1)
       {
-        clock_gettime(CLOCK_REALTIME, &attime);
+        clock_gettime(CLOCK_MONOTONIC, &attime);
         attime.tv_sec += timeout / 1000;
         attime.tv_nsec += ((timeout % 1000) * 1000000);
         if (attime.tv_nsec >= 1000000000)


### PR DESCRIPTION
Andy, as just discussed, can you please review this change to use clock_monotonic rather than clock_realtime when using a pthread_cond_timedwait
