### PR TITLE
[Reviewer Matt] Select a transport from connection pool for routing calls to sprout

### DIFF
--- a/sprout/stateful_proxy.cpp
+++ b/sprout/stateful_proxy.cpp
@@ -857,6 +857,9 @@ static void proxy_route_upstream(pjsip_rx_data* rdata,
     pj_list_insert_after(&upstream_uri->other_param, orig_param);
   }
 
+  // Select a transport for the request.
+  target_p->transport = upstream_conn_pool->get_connection();
+
   target_p->paths.push_back((pjsip_uri*)upstream_uri);
 }
 


### PR DESCRIPTION
Matt

Can you review this change - this is just reintroducing the call to assign a transport from the upstream connection pool when Bono is routing upstream to Sprout.  I've tested it by kicking over one of a three-node cluster of Sprouts and checking that only a small numbers of calls failed (without the fix it is utter carnage).

It wasn't good that this regression got past the unit tests, so I have taken an action to look at beefing up some of the checking.

Mike
