### PR TITLE
[Reviewer Matt] Remove extra REGISTER at start-of-day, and shorten reREGISTER period to 290 seconds to avoid expiries

### DIFF
--- a/tests/load/call_load2.xml
+++ b/tests/load/call_load2.xml
@@ -140,7 +140,7 @@
     ]]>
   </send>
 
-  <recv response="200" rtd="register" chance="0.161" next="2">
+  <recv response="200" chance="0.161" next="2">
     <action>
       <add assign_to="reg_repeat" value="1" />
     </action>


### PR DESCRIPTION
Matt

Can you review these updates to the call_load2.xml script.  I've tested them live against a Clearwater system.

Mike
