### PR TITLE
Reviewer RKD: Add more conditionals to IFC processing

### DIFF
--- a/sprout/ifchandler.cpp
+++ b/sprout/ifchandler.cpp
@@ -341,7 +341,6 @@ bool Ifc::spt_matches(const SessionCase& session_case,  //< The session case
             {
               // We've found a matching line type, and don't have to match on content.
               ret = true;
-              goto success_label;
             }
             else
             {
@@ -366,6 +365,10 @@ bool Ifc::spt_matches(const SessionCase& session_case,  //< The session case
                   ret = true;
                 }
               }
+              else
+              {
+                LOG_WARNING("Found badly formatted SDP line: %s", sdp_line.c_str());
+              }
             }
           }
         }
@@ -378,7 +381,6 @@ bool Ifc::spt_matches(const SessionCase& session_case,  //< The session case
     ret = false;
   }
 
-success_label:
   LOG_DEBUG("SPT class %s: result %s", name, ret ? "true" : "false");
   return ret;
 }

--- a/sprout/ut/ifchandler_test.cpp
+++ b/sprout/ut/ifchandler_test.cpp
@@ -105,7 +105,7 @@ public:
                "Accept: baz\n"
                "Accept: quux, foo\n"
                "Content-Type: application/sdp\n"
-               "Content-Length: 230\n\n"
+               "Content-Length: 242\n\n"
                "o=jdoe 2890844526 2890842807 IN IP4 10.47.16.5\n"
                "s=SDP Seminar\n"
                "b=X-YZ:128\n"
@@ -116,6 +116,7 @@ public:
                "m=video 51372 RTP/AVP 99\n"
                "b=Z-YZ:126\n"
                "c=IN IP4 225.2.17.14\n"
+               "einvalidline\n"
                "a=rtpmap:99 h263-1998/90000\n");
     pjsip_rx_data* rdata = build_rxdata(str);
     parse_rxdata(rdata);
@@ -2110,6 +2111,25 @@ TEST_F(IfcHandlerTest, SDPOriginContentNoMatch)
          SessionCase::Originating,
          false);
 }
+
+TEST_F(IfcHandlerTest, SDPNoEqualsSign)
+{
+  doTest("",
+         "    <TriggerPoint>\n"
+         "    <ConditionTypeCNF>1</ConditionTypeCNF>\n"
+         "    <SPT>\n"
+         "      <ConditionNegated>0</ConditionNegated>\n"
+         "      <Group>0</Group>\n"
+         "      <SessionDescription><Line>e</Line><Content>invalidline</Content></SessionDescription>\n"
+         "      <Extension></Extension>\n"
+         "    </SPT>\n"
+         "  </TriggerPoint>\n",
+         true,
+         SessionCase::Originating,
+         false);
+  EXPECT_TRUE(_log.contains("Found badly formatted SDP line: einvalidline"));
+}
+
 
 // @@@ iFC XML parse error
 // @@@ lookup_ifcs gets no served user


### PR DESCRIPTION
Added new parameters for service point trigger matching in ifchandler.cpp - registration type, sdp and request uri. Also added full UT coverage for new code.

UPDATE: I've applied the original set of mark ups, which included restructuring the SDP code, which I think is now much cleaner. Rob, do you mind re reviewing given that I've made some quite substantial changes? Since my SDP code is now the same for all SDP line types, I think a lot of my UTs are now just repeating the same thing - should I get rid of them?
