### PR TITLE
[Reviewer: Mike] Don't reset the SAS trail when we associate a message with an ODI

### DIFF
--- a/sprout/stateful_proxy.cpp
+++ b/sprout/stateful_proxy.cpp
@@ -442,9 +442,6 @@ void process_tsx_request(pjsip_rx_data* rdata)
                    uri->user.slen, uri->user.ptr,
                    original_dialog.to_string().c_str());
           session_case = &original_dialog.session_case();
-
-          // This message forms part of the AsChain trail.
-          set_trail(rdata, original_dialog.trail());
         }
         else
         {


### PR DESCRIPTION
https://github.com/Metaswitch/sprout/issues/127 looked pretty easy to fix, so I just did it. I haven't tested this yet, but I'll run the AS live tests before merging and check that the traces are sensible.
