### PR TITLE
[Reviewer: Mike] Make Sprout less aggressive about stripping Route headers

### DIFF
--- a/sprout/stateful_proxy.cpp
+++ b/sprout/stateful_proxy.cpp
@@ -1385,8 +1385,9 @@ static pj_status_t proxy_process_routing(pjsip_tx_data *tdata)
   // If the first value in the Route header field indicates this proxy or
   // home domain, the proxy MUST remove that value from the request.
   // We remove consecutive Route headers that point to us so we don't spiral.'
-  while (PJUtils::is_top_route_local(tdata->msg, &hroute))
+  if (PJUtils::is_top_route_local(tdata->msg, &hroute))
   {
+    LOG_DEBUG("Top Route header is local - erasing");
     pj_list_erase(hroute);
   }
 

--- a/sprout/ut/stateful_proxy_test.cpp
+++ b/sprout/ut/stateful_proxy_test.cpp
@@ -1424,11 +1424,12 @@ TEST_F(StatefulProxyTest, TestMultipleRouteHeaders)
   SCOPED_TRACE("");
   register_uri(_store, _hss_connection, "6505551234", "homedomain", "sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob");
   Message msg;
-  msg._extra = "Route: <sip:all.the.sprouts;transport=tcp>\r\nRoute: <sip:homedomain>";
+  msg._extra = "Route: <sip:local_ip:5054;transport=tcp;lr>\r\nRoute: <sip:local_ip:5058;lr>";
   list<HeaderMatcher> hdrs;
-  // Expect no Route headers out, as they all point to us
+  // Expect only the top Route header to be stripped, as is necessary
+  // for Sprout and Bono to be colocated
 
-  hdrs.push_back(HeaderMatcher("Route"));
+  hdrs.push_back(HeaderMatcher("Route", "Route: <sip:local_ip:5058;lr>"));
   doSuccessfulFlow(msg, testing::MatchesRegex(".*"), hdrs);
 }
 


### PR DESCRIPTION
Mike,

This fix should fix the problem of ACKs disappearing on all-in-one nodes. I've rewritten a UT to test this specifically, but not tested live.
