### PR TITLE
[Reviewer Rob]Fixes issue 349.  Set correct reason on 403 response when AV lookup fails

### DIFF
--- a/sprout/authentication.cpp
+++ b/sprout/authentication.cpp
@@ -358,6 +358,7 @@ void create_challenge(pjsip_authorization_hdr* auth_hdr,
   {
     LOG_DEBUG("Failed to get Authentication vector");
     tdata->msg->line.status.code = PJSIP_SC_FORBIDDEN;
+    tdata->msg->line.status.reason = *pjsip_get_status_text(PJSIP_SC_FORBIDDEN);
   }
 }
 

--- a/sprout/ut/custom_headers_test.cpp
+++ b/sprout/ut/custom_headers_test.cpp
@@ -93,7 +93,7 @@ TEST_F(CustomHeadersTest, PChargingVector)
   EXPECT_PJEQ(pcv->orig_ioi, "homedomain");
   EXPECT_PJEQ(pcv->term_ioi, "remotedomain");
   EXPECT_PJEQ(pcv->icid_gen_addr, "edge.proxy.net");
-  EXPECT_EQ(1, pj_list_size(&pcv->other_param));
+  EXPECT_EQ(1u, pj_list_size(&pcv->other_param));
 
   // Test the VPTR functions (clone, shallow clone and print on).
   pjsip_p_c_v_hdr* pcv_clone = (pjsip_p_c_v_hdr*)hdr->vptr->clone(stack_data.pool, (void*)hdr);
@@ -102,7 +102,7 @@ TEST_F(CustomHeadersTest, PChargingVector)
   EXPECT_PJEQ(pcv_clone->orig_ioi, "homedomain");
   EXPECT_PJEQ(pcv_clone->term_ioi, "remotedomain");
   EXPECT_PJEQ(pcv_clone->icid_gen_addr, "edge.proxy.net");
-  EXPECT_EQ(1, pj_list_size(&pcv_clone->other_param));
+  EXPECT_EQ(1u, pj_list_size(&pcv_clone->other_param));
 
   pjsip_p_c_v_hdr* pcv_sclone = (pjsip_p_c_v_hdr*)hdr->vptr->shallow_clone(stack_data.pool, (void*)hdr);
 
@@ -110,7 +110,7 @@ TEST_F(CustomHeadersTest, PChargingVector)
   EXPECT_PJEQ(pcv_sclone->orig_ioi, "homedomain");
   EXPECT_PJEQ(pcv_sclone->term_ioi, "remotedomain");
   EXPECT_PJEQ(pcv_sclone->icid_gen_addr, "edge.proxy.net");
-  EXPECT_EQ(1, pj_list_size(&pcv_sclone->other_param));
+  EXPECT_EQ(1u, pj_list_size(&pcv_sclone->other_param));
 
   char buf[1024];
   hdr = (pjsip_hdr*)pcv_clone;
@@ -150,22 +150,22 @@ TEST_F(CustomHeadersTest, PChargingFunctionAddresses)
   // We have a P-CFA header, check it was filled out correctly.
   pjsip_p_c_f_a_hdr* pcfa = (pjsip_p_c_f_a_hdr*)hdr;
 
-  EXPECT_EQ(2, pj_list_size(&pcfa->ccf));
-  EXPECT_EQ(2, pj_list_size(&pcfa->ecf));
-  EXPECT_EQ(1, pj_list_size(&pcfa->other_param));
+  EXPECT_EQ(2u, pj_list_size(&pcfa->ccf));
+  EXPECT_EQ(2u, pj_list_size(&pcfa->ecf));
+  EXPECT_EQ(1u, pj_list_size(&pcfa->other_param));
 
   // Test the VPTR functions (clone, shallow clone and print on).
   pjsip_p_c_f_a_hdr* pcfa_clone = (pjsip_p_c_f_a_hdr*)hdr->vptr->clone(stack_data.pool, (void*)hdr);
 
-  EXPECT_EQ(2, pj_list_size(&pcfa_clone->ccf));
-  EXPECT_EQ(2, pj_list_size(&pcfa_clone->ecf));
-  EXPECT_EQ(1, pj_list_size(&pcfa_clone->other_param));
+  EXPECT_EQ(2u, pj_list_size(&pcfa_clone->ccf));
+  EXPECT_EQ(2u, pj_list_size(&pcfa_clone->ecf));
+  EXPECT_EQ(1u, pj_list_size(&pcfa_clone->other_param));
 
   pjsip_p_c_f_a_hdr* pcfa_sclone = (pjsip_p_c_f_a_hdr*)hdr->vptr->shallow_clone(stack_data.pool, (void*)hdr);
 
-  EXPECT_EQ(2, pj_list_size(&pcfa_sclone->ccf));
-  EXPECT_EQ(2, pj_list_size(&pcfa_sclone->ecf));
-  EXPECT_EQ(1, pj_list_size(&pcfa_sclone->other_param));
+  EXPECT_EQ(2u, pj_list_size(&pcfa_sclone->ccf));
+  EXPECT_EQ(2u, pj_list_size(&pcfa_sclone->ecf));
+  EXPECT_EQ(1u, pj_list_size(&pcfa_sclone->other_param));
 
   char buf[1024];
   hdr = (pjsip_hdr*)pcfa_clone;

--- a/sprout/ut/siptest.cpp
+++ b/sprout/ut/siptest.cpp
@@ -727,7 +727,7 @@ std::ostream& operator<<(std::ostream& os, const PjMsg& msg)
 
 void MsgMatcher::matches(pjsip_msg* msg)
 {
-  if (_match_body)
+  if (_expected_body != "")
   {
     char buf[16384];
     int n = msg->body->print_body(msg->body, buf, sizeof(buf));
@@ -748,5 +748,8 @@ void RespMatcher::matches(pjsip_msg* msg)
 {
   ASSERT_EQ(PJSIP_RESPONSE_MSG, msg->type);
   EXPECT_EQ(_status, msg->line.status.code);
+  std::string reason(msg->line.status.reason.ptr, msg->line.status.reason.slen);
+  EXPECT_EQ(_reason, reason);
+
   MsgMatcher::matches(msg);
 }

--- a/sprout/ut/siptest.hpp
+++ b/sprout/ut/siptest.hpp
@@ -265,13 +265,7 @@ private:
 class MsgMatcher
 {
 public:
-  MsgMatcher() :
-    _match_body(false)
-  {
-  }
-
-  MsgMatcher(string expected_body) :
-    _match_body(true),
+  MsgMatcher(string expected_body="") :
     _expected_body(expected_body)
   {
   }
@@ -279,7 +273,6 @@ public:
   void matches(pjsip_msg* msg);
 
 private:
-  bool _match_body;
   string _expected_body;
 };
 
@@ -316,23 +309,24 @@ private:
 
 class RespMatcher : public MsgMatcher
 {
-  RespMatcher(int status) :
-    MsgMatcher(),
-    _status(status)
-  {
-  }
-
-  RespMatcher(int status,
-              string body) :
+  RespMatcher(int status, string body="", string reason="") :
     MsgMatcher(body),
-    _status(status)
+    _status(status),
+    _reason(reason)
   {
+    if (_reason == "")
+    {
+      // No reason specified, so use the default from PJSIP.
+      const pj_str_t* reason = pjsip_get_status_text(status);
+      _reason.assign(reason->ptr, reason->slen);
+    }
   }
 
   void matches(pjsip_msg* msg);
 
 private:
   int _status;
+  std::string _reason;
 };
 
 /// Convert a PJ string to a C++ string.

--- a/sprout/ut/stateful_proxy_test.cpp
+++ b/sprout/ut/stateful_proxy_test.cpp
@@ -2615,7 +2615,7 @@ TEST_F(StatefulEdgeProxyTest, TestEdgeCorruptToken)
     ASSERT_EQ(1, txdata_count());
 
     // Is the right kind and method.
-    RespMatcher r2(430);
+    RespMatcher r2(430, "", "Flow failed");
     r2.matches(current_txdata()->msg);
 
     // Goes to the right place: to sprout, not the client.
@@ -2634,7 +2634,7 @@ TEST_F(StatefulEdgeProxyTest, TestEdgeCorruptToken)
   ASSERT_EQ(1, txdata_count());
 
   // Is the right kind and method.
-  RespMatcher r2(430);
+  RespMatcher r2(430, "", "Flow failed");
   r2.matches(current_txdata()->msg);
 
   // Goes to the right place: to sprout, not the client.


### PR DESCRIPTION
Rob

Can you review my fix to the issue you flagged with Sprout setting the wrong reason on some 403 responses.  The fix is fairly self-explanatory.  I tested by updating the UT RespMatcher to check the reason text, verified that this reproduced the problem, then ran the tests again with the fix.  I also fixed a build warning in the custom_headers_test UTs as it was bugging me.

Mike
