### PR TITLE
[Reviewer: Alex] Check that an element exists after <Method>REGISTER</Method> in IFCs (fixes #356)

### DIFF
--- a/sprout/ifchandler.cpp
+++ b/sprout/ifchandler.cpp
@@ -157,39 +157,41 @@ bool Ifc::spt_matches(const SessionCase& session_case,  //< The session case
     {
       ret = true;
       node = node->next_sibling();
-      name = node->name();
-
-      if (strcmp(name, "Extension") == 0)
+      if (node)
       {
-        xml_node<>* reg_type_node = node->first_node("RegistrationType");
-
-        if (reg_type_node)
+        name = node->name();
+        if (strcmp(name, "Extension") == 0)
         {
-          name = reg_type_node->name();
-          int reg_type = parse_integer(reg_type_node, "registration type", 0, 2);
+          xml_node<>* reg_type_node = node->first_node("RegistrationType");
 
-          // Find expiry value from SIP message if it is present to determine
-          // whether we have a de-registration.  Set an arbitrary default value of
-          // an hour.
-          int expiry = PJUtils::max_expires(msg, 3600);
-
-          switch (reg_type)
+          if (reg_type_node)
           {
-          case INITIAL_REGISTRATION:
-            ret = (is_initial_registration && (expiry > 0));
-            break;
-          case REREGISTRATION:
-            ret = (!is_initial_registration && (expiry > 0));
-            break;
-          case DEREGISTRATION:
-            ret = (expiry == 0);
-            break;
-          default:
-          // LCOV_EXCL_START Unreachable
-            LOG_WARNING("Impossible case %d", reg_type);
-            ret = false;
-            break;
-          // LCOV_EXCL_STOP
+            name = reg_type_node->name();
+            int reg_type = parse_integer(reg_type_node, "registration type", 0, 2);
+
+            // Find expiry value from SIP message if it is present to determine
+            // whether we have a de-registration.  Set an arbitrary default value of
+            // an hour.
+            int expiry = PJUtils::max_expires(msg, 3600);
+
+            switch (reg_type)
+            {
+            case INITIAL_REGISTRATION:
+              ret = (is_initial_registration && (expiry > 0));
+              break;
+            case REREGISTRATION:
+              ret = (!is_initial_registration && (expiry > 0));
+              break;
+            case DEREGISTRATION:
+              ret = (expiry == 0);
+              break;
+            default:
+            // LCOV_EXCL_START Unreachable
+              LOG_WARNING("Impossible case %d", reg_type);
+              ret = false;
+              break;
+            // LCOV_EXCL_STOP
+            }
           }
         }
       }

--- a/sprout/ut/registrar_test.cpp
+++ b/sprout/ut/registrar_test.cpp
@@ -914,3 +914,60 @@ TEST_F(RegistrarTest, NonPrimaryAssociatedUri)
   EXPECT_EQ(0u, aor_data->_bindings.size());
   delete aor_data; aor_data = NULL;
 }
+
+/// Test for issue 356
+TEST_F(RegistrarTest, AppServersWithNoExtension)
+{
+  _hss_connection->set_result("/impu/sip%3A6505550231%40homedomain",
+                              "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                              "<IMSSubscription><ServiceProfile>\n"
+                              "  <PublicIdentity><Identity>sip:6505550231@homedomain</Identity></PublicIdentity>\n"
+                              "  <InitialFilterCriteria>\n"
+                              "    <Priority>1</Priority>\n"
+                              "    <TriggerPoint>\n"
+                              "      <ConditionTypeCNF>0</ConditionTypeCNF>\n"
+                              "      <SPT>\n"
+                              "        <ConditionNegated>0</ConditionNegated>\n"
+                              "        <Group>0</Group>\n"
+                              "        <Method>REGISTER</Method>\n"
+                              "      </SPT>\n"
+                              "    </TriggerPoint>\n"
+                              "    <ApplicationServer>\n"
+                              "      <ServerName>sip:1.2.3.4:56789;transport=UDP</ServerName>\n"
+                              "      <DefaultHandling>0</DefaultHandling>\n"
+                              "    </ApplicationServer>\n"
+                              "  </InitialFilterCriteria>\n"
+                              "</ServiceProfile></IMSSubscription>");
+
+  TransportFlow tpAS(TransportFlow::Protocol::UDP, stack_data.scscf_port, "1.2.3.4", 56789);
+
+  SCOPED_TRACE("REGISTER (1)");
+  Message msg;
+  msg._expires = "Expires: 800";
+  msg._contact_params = ";+sip.ice;reg-id=1";
+  SCOPED_TRACE("REGISTER (about to inject)");
+  inject_msg(msg.get());
+  SCOPED_TRACE("REGISTER (injected)");
+  ASSERT_EQ(2, txdata_count());
+  SCOPED_TRACE("REGISTER (200 OK)");
+  pjsip_msg* out = current_txdata()->msg;
+  EXPECT_EQ(200, out->line.status.code);
+  EXPECT_EQ("OK", str_pj(out->line.status.reason));
+  EXPECT_EQ("Supported: outbound", get_headers(out, "Supported"));
+  EXPECT_EQ("Contact: sip:f5cc3de4334589d89c661a7acf228ed7@10.114.61.213:5061;transport=tcp;ob;expires=300;+sip.ice;reg-id=1;+sip.instance=\"<urn:uuid:00000000-0000-0000-0000-b665231f1213>\"",
+            get_headers(out, "Contact"));  // that's a bit odd; we glom together the params
+  EXPECT_EQ("Require: outbound", get_headers(out, "Require")); // because we have path
+  EXPECT_EQ(msg._path, get_headers(out, "Path"));
+  free_txdata();
+
+  SCOPED_TRACE("REGISTER (forwarded)");
+  // REGISTER passed on to AS
+  out = current_txdata()->msg;
+  ReqMatcher r1("REGISTER");
+  ASSERT_NO_FATAL_FAILURE(r1.matches(out));
+  EXPECT_EQ(NULL, out->body);
+
+  tpAS.expect_target(current_txdata(), false);
+
+  free_txdata();
+}


### PR DESCRIPTION
Alex,

Please can you review my fix to check that we have a node after `<Method>REGISTER</Method>` before checking that it is an `<Extension>`, when parsing IFCs?  I've repro-ed this in UT (see below) and it fixes the issue.  A quick turn-around would be appreciated - I'd like to build a patch tonight.

Matt
