### PR TITLE
[Reviewer: Andy] Don't try to parse SDP body when processing IFCs if there is no body

### DIFF
--- a/sprout/ifchandler.cpp
+++ b/sprout/ifchandler.cpp
@@ -312,8 +312,6 @@ bool Ifc::spt_matches(const SessionCase& session_case,  //< The session case
     boost::regex line_regex;
     boost::regex content_regex;
     char newline = '\n';
-    std::stringstream sdp((char *)msg->body->data);
-    std::string sdp_line;
 
     if (!spt_line)
     {
@@ -334,6 +332,8 @@ bool Ifc::spt_matches(const SessionCase& session_case,  //< The session case
       if (msg->body->data != NULL)
       {
         // Split the message body into each SDP line.
+        std::stringstream sdp((char *)msg->body->data);
+        std::string sdp_line;
         while((std::getline(sdp, sdp_line, newline)) && (ret == false))
         {
           // Match the line regex on the first character of the SDP line.


### PR DESCRIPTION
Andy,

Please can you review my fix to the issue we discussed?  We were accessing the SDP body before checking that it existed - REGISTERs in particular won't often have bodies.  As you can see, I've added UT - I haven't tested this live.

Thanks,

Matt

(fixes #358)
