### PR TITLE
[Reviewer: Mike] Fix IPv6 when using transports from bono's connection pool to sprout

### DIFF
--- a/sprout/stateful_proxy.cpp
+++ b/sprout/stateful_proxy.cpp
@@ -3459,6 +3459,14 @@ void UACTransaction::set_target(const struct Target& target)
     tp_selector.u.transport = target.transport;
     pjsip_tx_data_set_transport(_tdata, &tp_selector);
 
+    _tdata->dest_info.addr.count = 1;
+    _tdata->dest_info.addr.entry[0].type = (pjsip_transport_type_e)target.transport->key.type;
+    pj_memcpy(&_tdata->dest_info.addr.entry[0].addr, &target.transport->key.rem_addr, sizeof(pj_sockaddr));
+    _tdata->dest_info.addr.entry[0].addr_len =
+         (_tdata->dest_info.addr.entry[0].addr.addr.sa_family == pj_AF_INET()) ?
+         sizeof(pj_sockaddr_in) : sizeof(pj_sockaddr_in6);
+    _tdata->dest_info.cur_addr = 0;
+
     // Remove the reference to the transport added when it was chosen.
     pjsip_transport_dec_ref(target.transport);
   }


### PR DESCRIPTION
Mike,

Please can you review this fix to IPv6 support?  When using a pre-selected transport, we need to fill in the `tdata->dest_info` structure to ensure that PJSIP doesn't do its own DNS resolution (which will fail, because it only seems to support IPv4).

I've live-tested and run UTs successfully.  I'm aware your DNS NAPTR/SRV fixes might supersede this - just reject the pull request if merging this will just unnecessarily complicate your merge.

Cheers,

Matt
