### PR TITLE
[Reviewer: Rob] Add sprout-libs-dbg package, containing debug symbols for sprout-libs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ MODULE_DIR := ${ROOT}/modules
 
 DEB_COMPONENT := sprout
 DEB_MAJOR_VERSION := 1.0
-DEB_NAMES := sprout-libs sprout sprout-dbg bono bono-dbg restund clearwater-sip-stress clearwater-sip-stress-dbg clearwater-sip-stress-stats
+DEB_NAMES := sprout-libs sprout-libs-dbg sprout sprout-dbg bono bono-dbg restund clearwater-sip-stress clearwater-sip-stress-dbg clearwater-sip-stress-stats
 
 INCLUDE_DIR := ${INSTALL_DIR}/include
 LIB_DIR := ${INSTALL_DIR}/lib

--- a/debian/.gitignore
+++ b/debian/.gitignore
@@ -10,5 +10,6 @@
 /clearwater-sip-stress-stats/
 /restund/
 /sprout-dbg/
+/sprout-libs-dbg/
 /sprout-libs/
 /sprout/

--- a/debian/control
+++ b/debian/control
@@ -13,6 +13,14 @@ Package: sprout-libs
 Architecture: any
 Description: Libraries for sprout, bono and restund
 
+Package: sprout-libs-dbg
+Architecture: any
+Section: debug
+Priority: extra
+Depends: sprout-libs (= ${binary:Version})
+Recommends: gdb,
+Description: Debugging symbols for sprout-libs
+
 Package: sprout
 Architecture: any
 Depends: clearwater-infrastructure, clearwater-tcp-scalability, clearwater-log-cleanup, sprout-libs, clearwater-memcached, monit, libboost-regex1.46.1, libboost-system1.46.1, libboost-thread1.46.1, libzmq3, libevent-pthreads-2.0-5, chronos
@@ -24,7 +32,7 @@ Architecture: any
 Section: debug
 Priority: extra
 Depends: sprout (= ${binary:Version})
-Recommends: gdb
+Recommends: gdb, sprout-libs-dbg
 Description: Debugging symbols for sprout, the SIP Router
 
 Package: bono

--- a/debian/rules
+++ b/debian/rules
@@ -35,6 +35,7 @@ override_dh_installinit:
 
 override_dh_shlibdeps:
 override_dh_strip:
+	dh_strip -psprout-libs --dbg-package=sprout-libs-dbg
 	dh_strip -psprout --dbg-package=sprout-dbg
 	dh_strip -pbono --dbg-package=bono-dbg
 	dh_strip -pclearwater-sip-stress --dbg-package=clearwater-sip-stress-dbg


### PR DESCRIPTION
Rob,

Please can you review this enhancement to add a sprout-libs-dbg.  This mirrors the existing sprout-dbg and homestead-libs-dbg packages.

Matt
