### PR TITLE
[No reviewer] Make Reg check lowercase

### DIFF
--- a/sprout/subscription.cpp
+++ b/sprout/subscription.cpp
@@ -433,11 +433,11 @@ pj_bool_t subscription_on_rx_request(pjsip_rx_data *rdata)
     // whether it should be processed by this module or passed up to an AS. 
     pjsip_msg *msg = rdata->msg_info.msg;
 
-    // A valid subscription must have the Event header set to "Reg"
+    // A valid subscription must have the Event header set to "reg". This is case-sensitive
     pj_str_t event_name = pj_str("Event");
     pjsip_event_hdr* event = (pjsip_event_hdr*)pjsip_msg_find_hdr_by_name(msg, &event_name, NULL);
 
-    if (!event || (PJUtils::pj_str_to_string(&event->event_type) != "Reg"))
+    if (!event || (PJUtils::pj_str_to_string(&event->event_type) != "reg"))
     {
       // The Event header is missing or doesn't match "Reg"
       LOG_DEBUG("Rejecting subscription request with invalid event header");

--- a/sprout/ut/subscription_test.cpp
+++ b/sprout/ut/subscription_test.cpp
@@ -153,7 +153,7 @@ public:
     _user("6505550231"),
     _domain("homedomain"),
     _contact("sip:f5cc3de4334589d89c661a7acf228ed7@10.114.61.213:5061;transport=tcp;ob"),
-    _event("Event: Reg"),
+    _event("Event: reg"),
     _accepts("Accept: application/reginfo+xml"),
     _expires(""),
     _route(""),
@@ -278,7 +278,7 @@ TEST_F(SubscriptionTest, MissingEventHeader)
 }
 
 // Test the Event Header
-// Event that isn't Reg should be rejected
+// Event that isn't reg should be rejected
 TEST_F(SubscriptionTest, IncorrectEventHeader)
 {
   check_subscriptions("sip:6505550231@homedomain", 0u);
@@ -286,6 +286,12 @@ TEST_F(SubscriptionTest, IncorrectEventHeader)
   SubscribeMessage msg;
   msg._event = "Event: Not Reg";
   pj_bool_t ret = inject_msg_direct(msg.get());
+  EXPECT_EQ(PJ_FALSE, ret);
+  check_subscriptions("sip:6505550231@homedomain", 0u);
+
+  SubscribeMessage msg2;
+  msg2._event = "Event: Reg";
+  ret = inject_msg_direct(msg2.get());
   EXPECT_EQ(PJ_FALSE, ret);
   check_subscriptions("sip:6505550231@homedomain", 0u);
 }


### PR DESCRIPTION
This checks that the event header in a subscription is reg, not Reg. This deals with the first simple part of #413
