### PR TITLE
[Reviewer: Graeme] Ensure that monit doesn't monitor poll_restund.sh rather than restund

### DIFF
--- a/restund.root/usr/share/clearwater/infrastructure/scripts/restund
+++ b/restund.root/usr/share/clearwater/infrastructure/scripts/restund
@@ -81,8 +81,9 @@ set daemon 10
 check program poll_restund with path "/usr/share/clearwater/bin/poll_restund.sh"
   if status != 0 for 2 cycles then exec "/etc/init.d/restund abort"
 
-# Monitor the server's PID.
-check process restund matching restund
+# Monitor the server's PID.  Include a / in the "matching" expression to ensure
+# that this doesn't pick up poll_restund.sh by accident.
+check process restund matching /restund
   start program = "/etc/init.d/restund start"
   stop program = "/etc/init.d/restund stop"
 EOF


### PR DESCRIPTION
Graeme,

Please can you review this fix to the restund issue you saw?  The problem is that monit monitors restund by process name, not PID file, and the regular expression it used was just `restund` (which also matches `poll_restund.sh`).  When I was testing, `restund` always had a lower PID than `poll_restund.sh`, so monit picked `restund` in preference to `poll_restund.sh`.  In the instance you saw, `poll_restund.sh` had the lower PID, so monit decided that it was the true restund process and consequently decided that restund was broken.

Matt
