### PR TITLE
[No reviewer] Use correct error code when terminating user isn't registered

### DIFF
--- a/sprout/stateful_proxy.cpp
+++ b/sprout/stateful_proxy.cpp
@@ -2502,7 +2502,7 @@ void UASTransaction::handle_outgoing_non_cancel(Target* target)
   if (targets.size() == 0)
   {
     // No targets found, so reject with a 480 error.
-    // There will only be no targets when the terminatiing user isn't
+    // There will only be no targets when the terminating user isn't
     // registered or has no valid bindings.
     LOG_INFO("Reject request with 480");
     send_response(PJSIP_SC_TEMPORARILY_UNAVAILABLE);


### PR DESCRIPTION
Simple change to use the correct error code when a terminating user isn't registered (meaning that there are no targets to route to).

Fixes #443 
