### PR TITLE
[Reviewer: Mike] Move cwtest_reset_time() into BaseTest to avoid a gap between HttpConnec...

### DIFF
--- a/sprout/ut/basetest.cpp
+++ b/sprout/ut/basetest.cpp
@@ -46,6 +46,7 @@
 #include "fakelogger.hpp"
 
 #include "basetest.hpp"
+#include "test_interposer.hpp"
 
 using namespace std;
 
@@ -59,7 +60,12 @@ BaseTest::BaseTest()
 
 BaseTest::~BaseTest()
 {
+  // Destroy the LVC before calling cw_reset_time, otherwise ZeroMQ
+  // checks the wrong time against its timeout and the poll loop
+  // continues for several minutes.
   delete stack_data.stats_aggregator;
   stack_data.stats_aggregator = NULL;
+
+  cwtest_reset_time();
 }
 

--- a/sprout/ut/httpconnection_test.cpp
+++ b/sprout/ut/httpconnection_test.cpp
@@ -89,13 +89,6 @@ class HttpConnectionTest : public BaseTest
   {
     fakecurl_responses.clear();
     fakecurl_requests.clear();
-
-    // Destroy the LVC before calling cw_reset_time, otherwise ZeroMQ
-    // checks the wrong time against its timeout and the poll loop
-    // continues for several minutes.
-    delete stack_data.stats_aggregator;
-    stack_data.stats_aggregator = NULL;
-    cwtest_reset_time();
   }
 };
 
@@ -143,7 +136,8 @@ TEST_F(HttpConnectionTest, ConnectionRecycle)
   long ret = _http.get("/blah/blah/blah", output, "gandalf", 0);
   EXPECT_EQ(200, ret);
 
-  // Wait a very short time.
+  // Wait a very short time. Note that this is reverted by the
+  // BaseTest destructor, which calls cwtest_reset_time().
   cwtest_advance_time_ms(10L);
 
   // Next request should be on same connection (it's possible but very


### PR DESCRIPTION
...tionTest deleting the LVC and something else still using it

I had a think about the Valgrind invalid read error - I think it could be due to the fact that we're now deleting the LVC slightly earlier (in the HttpConnectionTest destructor rather than the BaseTest destructor). This is to avoid an ordering issue between destroying that and calling cwtest_reset_time() to move time backwards (if you move time backwards first, ZeroMQ might pause for ages waiting for a timeout).

This speculative fix does things in the opposite order - it moves cwtest_reset_time() into ~BaseTest, so that the ordering is still correct and we're still deleting the LVC at the same time.
