### PR TITLE
[Reviewer Andy] Disable dependency checking of extra test build objects

### DIFF
--- a/mk/platform.mk
+++ b/mk/platform.mk
@@ -85,8 +85,11 @@ TARGET_OBJS := $(patsubst %.cpp, ${OBJ_DIR}/%.o, ${TARGET_SOURCES} ${TARGET_SOUR
 TARGET_OBJS_TEST := $(patsubst %.cpp, ${OBJ_DIR_TEST}/%.o, ${TARGET_SOURCES} ${TARGET_SOURCES_TEST}) \
                     $(patsubst %,     ${OBJ_DIR_TEST}/%, $(TARGET_EXTRA_OBJS_TEST))
 
+#	We only want to do dependencies for standard test objects, not for the extra ones.
+TARGET_OBJS_DEPS := $(patsubst %.cpp, ${OBJ_DIR_TEST}/%.o, ${TARGET_SOURCES} ${TARGET_SOURCES_TEST})
+
 # The dependencies
-DEPS := $(patsubst %.o, %.depends, $(patsubst %.so, %.depends, ${TARGET_OBJS} ${TARGET_OBJS_TEST}))
+DEPS := $(patsubst %.o, %.depends, $(patsubst %.so, %.depends, ${TARGET_OBJS} ${TARGET_OBJS_DEPS}))
 
 # Build the production binary.
 .PHONY: build


### PR DESCRIPTION
Andy

Can you review my fix to the build issue we were looking at.  I've tested this by do a clean build and a clean test build, both of which worked fine.

Mike
