### PR TITLE
Reviewer Andy: Read Session-Expires header from transmitted as well as received INVITEs

### DIFF
--- a/sprout/acr.cpp
+++ b/sprout/acr.cpp
@@ -442,6 +442,21 @@ void RalfACR::tx_request(pjsip_msg* req, pj_time_val timestamp)
     _route_hdr_transmitted = hdr_contents((pjsip_hdr*)route_hdr);
   }
 
+  // If the request is an INVITE, save the delta_seconds value from the
+  // Session-Expires header if present.
+  if (req->line.req.method.id == PJSIP_INVITE_METHOD)
+  {
+    pjsip_session_expires_hdr* sess_expires = (pjsip_session_expires_hdr*)
+                             pjsip_msg_find_hdr_by_names(req,
+                                                         &STR_SESSION_EXPIRES,
+                                                         &STR_X,
+                                                         NULL);
+    if (sess_expires != NULL)
+    {
+      _interim_interval = sess_expires->expires;
+    }
+  }
+
   if ((_method != "REGISTER") &&
       (_node_role == NODE_ROLE_ORIGINATING))
   {


### PR DESCRIPTION
Andy

Can you review this fix.  Should be relatively self-explanatory.  I did think about moving the code to a function to commonalize it, but ended up thinking it wasn't worth it (I probably wouldn't want to move the surrounding "if INVITE" test into a common function anyway) - shout if you disagree with this.

Mike
