### PR TITLE
Reviewer Matt - Add chronos-dbg dependency to sprout-dbg

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -32,7 +32,7 @@ Architecture: any
 Section: debug
 Priority: extra
 Depends: sprout (= ${binary:Version})
-Recommends: gdb, sprout-libs-dbg
+Recommends: gdb, sprout-libs-dbg, chronos-dbg
 Description: Debugging symbols for sprout, the SIP Router
 
 Package: bono


### PR DESCRIPTION
If we're running with debug symbols we should probably run with all of them, not just some. Without this, we are getting issues raised in Chronos without proper backtraces/core cracks.

Similar change for Ralf coming imminently.
