### PR TITLE
Reviewer MattL Don't shutdown TCP connections on overload

### DIFF
--- a/sprout/basicproxy.cpp
+++ b/sprout/basicproxy.cpp
@@ -372,6 +372,16 @@ int BasicProxy::verify_request(pjsip_rx_data *rdata)
 
   // 6. Proxy-Authorization.  Not checked in the BasicProxy.
 
+  // Check that non-ACK request has not been received on a shutting down
+  // transport.  If it has then we won't be able to send a transaction
+  // response, so it is better to reject immediately.
+  if ((rdata->msg_info.msg->line.req.method.id != PJSIP_ACK_METHOD) &&
+      (rdata->tp_info.transport != NULL) &&
+      (rdata->tp_info.transport->is_shutdown))
+  {
+    return PJSIP_SC_SERVICE_UNAVAILABLE;
+  }
+
   return PJSIP_SC_OK;
 }
 

--- a/sprout/stack.cpp
+++ b/sprout/stack.cpp
@@ -370,11 +370,10 @@ static pj_bool_t on_rx_msg(pjsip_rx_data* rdata)
                                (pjsip_hdr*)retry_after,
                                NULL);
 
-    // If the sprout/bono is overloaded, then close the connection (if it's TCP).
-    if ((rdata->tp_info.transport->flag & PJSIP_TRANSPORT_DATAGRAM) == 0)
-    {
-      pjsip_transport_shutdown(rdata->tp_info.transport);
-    }
+    // We no longer terminate TCP connections on overload as the shutdown has
+    // to wait for existing transactions to end and therefore it takes too
+    // long to get feedback to the downstream node.  We expect downstream nodes
+    // to rebalance load if possible triggered by receipt of the 503 responses.
 
     overload_counter->increment();
     return PJ_TRUE;

--- a/sprout/stateful_proxy.cpp
+++ b/sprout/stateful_proxy.cpp
@@ -714,6 +714,16 @@ static int proxy_verify_request(pjsip_rx_data *rdata)
   // 6. Proxy-Authorization.
   // Nah, we don't require any authorization with this sample.
 
+  // Check that non-ACK request has not been received on a shutting down
+  // transport.  If it has then we won't be able to send a transaction
+  // response, so it is better to reject immediately.
+  if ((rdata->msg_info.msg->line.req.method.id != PJSIP_ACK_METHOD) &&
+      (rdata->tp_info.transport != NULL) &&
+      (rdata->tp_info.transport->is_shutdown))
+  {
+    return PJSIP_SC_SERVICE_UNAVAILABLE;
+  }
+
   return PJSIP_SC_OK;
 }
 

--- a/sprout/ut/basicproxy_test.cpp
+++ b/sprout/ut/basicproxy_test.cpp
@@ -2113,6 +2113,33 @@ TEST_F(BasicProxyTest, RequestErrors)
   msg2._method = "ACK";
   inject_msg(msg2.get_request(), tp);
 
+  // Inject an INVITE request on a transport which is shutting down.  It is safe
+  // to call pjsip_transport_shutdown on a TCP transport as the TransportFlow
+  // keeps a reference to the transport so it won't actually be destroyed until
+  // the TransportFlow is destroyed.
+  pjsip_transport_shutdown(tp->transport());
+
+  Message msg3;
+  msg3._method = "INVITE";
+  msg3._requri = "sip:bob@awaydomain";
+  msg3._from = "alice";
+  msg3._to = "bob";
+  msg3._todomain = "awaydomain";
+  msg3._via = tp->to_string(false);
+  msg3._route = "Route: <sip:proxy1.awaydomain;transport=TCP;lr>";
+  inject_msg(msg3.get_request(), tp);
+
+  // Check the 504 Service Unavailable response.
+  ASSERT_EQ(1, txdata_count());
+  tdata = current_txdata();
+  RespMatcher(503).matches(tdata->msg);
+  tp->expect_target(tdata);
+  free_txdata();
+
+  // Send an ACK to complete the UAS transaction.
+  msg3._method = "ACK";
+  inject_msg(msg3.get_request(), tp);
+
   delete tp;
 }
 


### PR DESCRIPTION
Matt

Can you review my fix to the problem with TCP connections being shutdown.  I've also added code to reject requests immediately if they are received on a transport which is shutting down.  I've added UTs for the latter fixes, but not for the first as it is simply a matter of removing some code and we don't have any UTs in this area of code at the moment.

Mike
