### PR TITLE
[Reviewer: Mike] Invalidate cached message info whenever we manually change the response code

### DIFF
--- a/sprout/authentication.cpp
+++ b/sprout/authentication.cpp
@@ -415,6 +415,7 @@ void create_challenge(pjsip_authorization_hdr* auth_hdr,
 
     tdata->msg->line.status.code = PJSIP_SC_FORBIDDEN;
     tdata->msg->line.status.reason = *pjsip_get_status_text(PJSIP_SC_FORBIDDEN);
+    pjsip_tx_data_invalidate_msg(tdata);
   }
 }
 

--- a/sprout/basicproxy.cpp
+++ b/sprout/basicproxy.cpp
@@ -1155,6 +1155,7 @@ void BasicProxy::UASTsx::send_response(int st_code, const pj_str_t* st_text)
     prov_rsp->msg->line.status.code = st_code;
     prov_rsp->msg->line.status.reason =
                 (st_text != NULL) ? *st_text : *pjsip_get_status_text(st_code);
+    pjsip_tx_data_invalidate_msg(prov_rsp);
     set_trail(prov_rsp, trail());
     on_tx_response(prov_rsp);
     pjsip_tsx_send_msg(_tsx, prov_rsp);
@@ -1168,6 +1169,7 @@ void BasicProxy::UASTsx::send_response(int st_code, const pj_str_t* st_text)
     best_rsp->msg->line.status.code = st_code;
     best_rsp->msg->line.status.reason =
                 (st_text != NULL) ? *st_text : *pjsip_get_status_text(st_code);
+    pjsip_tx_data_invalidate_msg(best_rsp);
     set_trail(best_rsp, trail());
     on_tx_response(best_rsp);
     pjsip_tsx_send_msg(_tsx, best_rsp);

--- a/sprout/icscfproxy.cpp
+++ b/sprout/icscfproxy.cpp
@@ -514,6 +514,7 @@ bool ICSCFProxy::UASTsx::retry_to_alternate_scscf(int rsp_status)
           _best_rsp->msg->line.status.reason =
                        *pjsip_get_status_text(_best_rsp->msg->line.status.code);
         }
+        pjsip_tx_data_invalidate_msg(_best_rsp);
       }
     }
   }

--- a/sprout/registrar.cpp
+++ b/sprout/registrar.cpp
@@ -779,6 +779,7 @@ void process_register_request(pjsip_rx_data* rdata)
     SAS::report_event(event);
 
     tdata->msg->line.status.code = PJSIP_SC_INTERNAL_SERVER_ERROR;
+    pjsip_tx_data_invalidate_msg(tdata);
     status = pjsip_endpt_send_response2(stack_data.endpt, rdata, tdata, NULL, NULL);
     delete acr;
     delete aor_data;

--- a/sprout/stateful_proxy.cpp
+++ b/sprout/stateful_proxy.cpp
@@ -2373,6 +2373,7 @@ void UASTransaction::handle_non_cancel(const ServingState& serving_state, Target
         // Pass the error response to the I-CSCF ACR and send the ACR.
         _best_rsp->msg->line.status.code = status_code;
         _best_rsp->msg->line.status.reason = *pjsip_get_status_text(status_code);
+        pjsip_tx_data_invalidate_msg(_best_rsp);
         _icscf_acr->tx_response(_best_rsp->msg);
         _icscf_acr->send_message();
         delete _icscf_acr;
@@ -3122,6 +3123,7 @@ pj_status_t UASTransaction::handle_final_response()
 
       // Reset the best response to a 408 response to use if none of the targets responds.
       _best_rsp->msg->line.status.code = PJSIP_SC_REQUEST_TIMEOUT;
+      pjsip_tx_data_invalidate_msg(_best_rsp);
 
       // Redirect the dialog to the next AS in the chain.
       ServingState serving_state(&_as_chain_link.session_case(),
@@ -3194,6 +3196,7 @@ pj_status_t UASTransaction::send_response(int st_code, const pj_str_t* st_text)
     pjsip_tx_data* prov_rsp = PJUtils::clone_tdata(_best_rsp);
     prov_rsp->msg->line.status.code = st_code;
     prov_rsp->msg->line.status.reason = (st_text != NULL) ? *st_text : *pjsip_get_status_text(st_code);
+    pjsip_tx_data_invalidate_msg(prov_rsp);
     set_trail(prov_rsp, trail());
     _upstream_acr->tx_response(prov_rsp->msg);
     return pjsip_tsx_send_msg(_tsx, prov_rsp);
@@ -3202,6 +3205,7 @@ pj_status_t UASTransaction::send_response(int st_code, const pj_str_t* st_text)
   {
     _best_rsp->msg->line.status.code = st_code;
     _best_rsp->msg->line.status.reason = (st_text != NULL) ? *st_text : *pjsip_get_status_text(st_code);
+    pjsip_tx_data_invalidate_msg(_best_rsp);
     return handle_final_response();
   }
 }


### PR DESCRIPTION
Mike,

Please can you review this simple fix to invalidate cached message information whenever we manually change the response code of the message.  This fixes #456, where we log out-of-date information.

Note that pjsip_tx_data_invalidate_msg invalidates both the cached message summary (which we need to be invalidated) and the actual constructed message (which we don't need to be invalidated, but doesn't hurt because the constructed message is either empty already or will be invalidated by PJSIP before it is sent).

I've run UTs and live tests.

Matt
