### PR TITLE
[Reviewer: Mike] Don't add 2 references to statelessly sent requests

### DIFF
--- a/sprout/pjutils.cpp
+++ b/sprout/pjutils.cpp
@@ -1067,9 +1067,12 @@ static void stateless_send_cb(pjsip_send_state *st,
       // but just in case ...
       PJUtils::generate_new_branch_id(tdata);
 
+      // Add a reference to the tdata to stop PJSIP releasing it when we
+      // return the callback.
+      pjsip_tx_data_add_ref(tdata);
+
       // Set up destination info for the new server and resend the request.
       PJUtils::set_dest_info(tdata, sss->servers[sss->current_server]);
-      pjsip_tx_data_add_ref(tdata);
       status = pjsip_endpt_send_request_stateless(stack_data.endpt,
                                                   tdata,
                                                   (void*)sss,
@@ -1077,9 +1080,6 @@ static void stateless_send_cb(pjsip_send_state *st,
 
       if (status == PJ_SUCCESS)
       {
-        // Add a reference to the tdata to stop PJSIP releasing it when we
-        // return the callback.
-        pjsip_tx_data_add_ref(tdata);
         retrying = true;
       }
       else


### PR DESCRIPTION
Mike,

I think the previous fix (https://github.com/Metaswitch/sprout/commit/5ed33cbb80e658a71a16e0ab081d50ade71d7680) was just wrong - it added code to add an additional reference but didn't remove the old one.  My fix is not to add the second reference.  As well as avoiding a spurious reference, it also fixes #555, which covers the original problem - that `tdata` can already have been destroyed by the time we hit the success branch.

I've run the UT but not added any new test cases - I don't think we can easily UT this.

Matt
