### PR TITLE
[Reviewer: Mike] Overload return codes

### DIFF
--- a/include/hssconnection.h
+++ b/include/hssconnection.h
@@ -63,10 +63,6 @@ public:
                 LastValueCache *stats_aggregator);
   ~HSSConnection();
 
-  HTTPCode get_digest_data(const std::string& private_user_id,
-                           const std::string& public_user_id,
-                           Json::Value*& object,
-                           SAS::TrailId trail);
   HTTPCode get_auth_vector(const std::string& private_user_id,
                            const std::string& public_user_id,
                            const std::string& auth_type,

--- a/sprout/handlers.cpp
+++ b/sprout/handlers.cpp
@@ -534,7 +534,7 @@ HTTPCode AuthTimeoutHandler::handle_response(std::string body)
 
   Json::Value* json = _cfg->_avstore->get_av(_impi, _nonce, trail());
   bool success = false;
-
+  HTTPCode hss_query = HTTP_OK;
 
   if (json == NULL)
   {
@@ -557,14 +557,15 @@ HTTPCode AuthTimeoutHandler::handle_response(std::string body)
     // If either of these operations fail, we return a 500 Internal
     // Server Error - this will trigger Chronos to try a different
     // Sprout, which may have better connectivity to Homestead or Memcached.
-    success = _cfg->_hss->update_registration_state(_impu, _impi, HSSConnection::AUTH_TIMEOUT, 0);
+    hss_query = _cfg->_hss->update_registration_state(_impu, _impi, HSSConnection::AUTH_TIMEOUT, 0);
 
-    if (success)
+    if (hss_query == HTTP_OK)
     {
       success = _cfg->_avstore->delete_av(_impi, _nonce, trail());
     }
 
     delete json;
   }
+
   return success ? HTTP_OK : HTTP_SERVER_ERROR;
 }

--- a/sprout/subscription.cpp
+++ b/sprout/subscription.cpp
@@ -398,10 +398,15 @@ void process_subscription_request(pjsip_rx_data* rdata)
     // We failed to get the list of associated URIs.  This indicates that the
     // HSS is unavailable, the public identity doesn't exist or the public
     // identity doesn't belong to the private identity.
-    st_code = PJSIP_SC_SERVICE_UNAVAILABLE;
 
-    // If the client shouldn't retry (when the subscriber isn't present in the HSS)
-    // reject with a 403, otherwise reject with a 503.
+    // The client shouldn't retry when the subscriber isn't present in the
+    // HSS; reject with a 403 in this case.
+    //
+    // The client should retry on timeout but no other Clearwater nodes should
+    // (as Sprout will already have retried on timeout). Reject with a 504
+    // (503 is used for overload).
+    st_code = PJSIP_SC_SERVER_TIMEOUT;
+
     if (http_code == HTTP_NOT_FOUND)
     {
       st_code = PJSIP_SC_FORBIDDEN;

--- a/sprout/ut/hssconnection_test.cpp
+++ b/sprout/ut/hssconnection_test.cpp
@@ -59,10 +59,6 @@ class HssConnectionTest : public BaseTest
     _hss("narcissus", NULL, NULL)
   {
     fakecurl_responses.clear();
-    fakecurl_responses["http://narcissus/impi/privid69/digest"] = "{\"digest\": \"myhashhere\"}";
-    fakecurl_responses["http://narcissus/impi/privid69/digest?public_id=pubid42"] = "{\"digest\": \"myhashhere\"}";
-    fakecurl_responses["http://narcissus/impi/privid_corrupt/digest?public_id=pubid42"] = "{\"digest\"; \"myhashhere\"}";
-    fakecurl_responses["http://narcissus/impi/privid69/digest?public_id=wrongpubid"] = CURLE_REMOTE_FILE_NOT_FOUND;
     fakecurl_responses_with_body[std::make_pair("http://narcissus/impu/pubid42/reg-data", "{\"reqtype\": \"reg\"}")] =
       "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
       "<ClearwaterRegData>"
@@ -137,6 +133,7 @@ class HssConnectionTest : public BaseTest
     fakecurl_responses_with_body[std::make_pair("http://narcissus/impu/pubid44/reg-data", "{\"reqtype\": \"reg\"}")] = CURLE_REMOTE_FILE_NOT_FOUND;
     fakecurl_responses["http://narcissus/impi/privid69/registration-status?impu=pubid44"] = "{\"result-code\": 2001, \"scscf\": \"server-name\"}";
     fakecurl_responses["http://narcissus/impi/privid69/registration-status?impu=pubid44&visited-network=domain&auth-type=REG"] = "{\"result-code\": 2001, \"mandatory-capabilities\": [1, 2, 3], \"optional-capabilities\": []}";
+    fakecurl_responses["http://narcissus/impi/privid_corrupt/registration-status?impu=pubid44"] = "{\"result-code\": 2001, \"scscf\"; \"server-name\"}";
     fakecurl_responses["http://narcissus/impu/pubid44/location"] = "{\"result-code\": 2001, \"scscf\": \"server-name\"}";
     fakecurl_responses["http://narcissus/impu/pubid44/location?auth-type=DEREG"] = "{\"result-code\": 2001, \"mandatory-capabilities\": [], \"optional-capabilities\": []}";
     fakecurl_responses["http://narcissus/impu/pubid44/location?originating=true&auth-type=CAPAB"] = "{\"result-code\": 2001, \"mandatory-capabilities\": [1, 2, 3], \"optional-capabilities\": []}";
@@ -179,24 +176,6 @@ class HssConnectionTest : public BaseTest
   {
   }
 };
-
-TEST_F(HssConnectionTest, SimpleDigest)
-{
-  Json::Value* actual;
-  _hss.get_digest_data("privid69", "pubid42", actual, 0);
-  ASSERT_TRUE(actual != NULL);
-  EXPECT_EQ("myhashhere", actual->get("digest", "").asString());
-  delete actual;
-}
-
-TEST_F(HssConnectionTest, CorruptDigest)
-{
-  Json::Value* actual;
-  _hss.get_digest_data("privid_corrupt", "pubid42", actual, 0);
-  ASSERT_TRUE(actual == NULL);
-  EXPECT_TRUE(_log.contains("Failed to parse Homestead response"));
-  delete actual;
-}
 
 TEST_F(HssConnectionTest, SimpleAssociatedUris)
 {
@@ -325,6 +304,15 @@ TEST_F(HssConnectionTest, FullUserAuth)
   _hss.get_user_auth_status("privid69", "pubid44", "domain", "REG", actual, 0);
   ASSERT_TRUE(actual != NULL);
   EXPECT_EQ("2001", actual->get("result-code", "").asString());
+  delete actual;
+}
+
+TEST_F(HssConnectionTest, CorruptAuth)
+{
+  Json::Value* actual;
+  _hss.get_user_auth_status("privid_corrupt", "pubid44", "", "", actual, 0);
+  ASSERT_TRUE(actual == NULL);
+  EXPECT_TRUE(_log.contains("Failed to parse Homestead response"));
   delete actual;
 }
 

--- a/sprout/ut/registrar_test.cpp
+++ b/sprout/ut/registrar_test.cpp
@@ -1198,8 +1198,8 @@ TEST_F(RegistrarTest, AssociatedUrisTimeOut)
   inject_msg(msg.get());
   ASSERT_EQ(1, txdata_count());
   pjsip_msg* out = current_txdata()->msg;
-  EXPECT_EQ(503, out->line.status.code);
-  EXPECT_EQ("Service Unavailable", str_pj(out->line.status.reason));
+  EXPECT_EQ(504, out->line.status.code);
+  EXPECT_EQ("Server Timeout", str_pj(out->line.status.reason));
 
   _hss_connection->delete_rc("/impu/sip%3A6505550232%40homedomain/reg-data");
 }

--- a/sprout/ut/subscription_test.cpp
+++ b/sprout/ut/subscription_test.cpp
@@ -435,8 +435,8 @@ TEST_F(SubscriptionTest, AssociatedUrisTimeOut)
   inject_msg(msg.get());
   ASSERT_EQ(1, txdata_count());
   pjsip_msg* out = current_txdata()->msg;
-  EXPECT_EQ(503, out->line.status.code);
-  EXPECT_EQ("Service Unavailable", str_pj(out->line.status.reason));
+  EXPECT_EQ(504, out->line.status.code);
+  EXPECT_EQ("Server Timeout", str_pj(out->line.status.reason));
   check_subscriptions("sip:6505550232@homedomain", 0u);
 
   _hss_connection->delete_rc("/impu/sip%3A6505550232%40homedomain/reg-data");


### PR DESCRIPTION
Mike, can you review this change to only return 503 when the current node is overloaded (or when a connection to the node times out). 504 is used when a downstream node is overloaded. 

I've also done some tidy up the hssconnection methods while testing this. 

This is part of the fix for #572 - cpp-common and homestead changes are needed too. 
