### PR TITLE
[Reviewer: Alex] Prevent pauses when running tests without an accessible DNS server

### DIFF
--- a/sprout/ut/siptest.cpp
+++ b/sprout/ut/siptest.cpp
@@ -346,6 +346,7 @@ void SipTest::add_host_mapping(const string& hostname, const string& addresses)
   std::vector<DnsRRecord*> records;
   while (!address_list.empty())
   {
+    cwtest_add_host_mapping(hostname, address_list.front());
     struct in_addr addr;
     inet_pton(AF_INET, address_list.front().c_str(), &addr);
     records.push_back((DnsRRecord*)new DnsARecord(hostname, 36000000, addr));


### PR DESCRIPTION
Turns out a five-hour plane journey spent working on FakeLogger really concentrates the mind on https://github.com/Metaswitch/sprout/issues/588. (I think DNS caching might have been misleading me before.)

The problem was just that some of the trusted peer processing doesn't go through DnsResolver but goes through pj_sockaddr_parse instead, so SipTest::add_host_mapping wasn't actually mocking the DNS lookup out. I'll talk to Mike about whether using pj_sockaddr_parse is right, but for now, I've added cwtest_add_host_mapping (back?) in to avoid this and potential future issues.

I do still see a brief pause after some of the emergency registration tests - the logs suggest this is because SipResolver is doing some work - but the IBCF-related pauses were far longer and more annoying.
