### PR TITLE
[Reviewer: Mike] Make ConnectionPool loop more tightly in UTs to speed them up

### DIFF
--- a/sprout/connection_pool.cpp
+++ b/sprout/connection_pool.cpp
@@ -426,7 +426,12 @@ void ConnectionPool::recycle_connections()
 
   while (!_terminated)
   {
+#ifdef UNIT_TEST
+    // A smaller pause here is much faster
+    sleep(0.1);
+#else
     sleep(1);
+#endif
 
     int now = time(NULL);
 


### PR DESCRIPTION
This shaves about 4 seconds off the Sprout UTs.
