### PR TITLE
Fix grp_lock crash due to error path clean-up.

### DIFF
--- a/sprout/basicproxy.cpp
+++ b/sprout/basicproxy.cpp
@@ -803,6 +803,7 @@ pj_status_t BasicProxy::UASTsx::create_pjsip_transaction(pjsip_rx_data* rdata)
     // LCOV_EXCL_START
     pj_grp_lock_release(_lock);
     pj_grp_lock_dec_ref(_lock);
+    _lock = NULL;
     return status;
     // LCOV_EXCL_STOP
   }


### PR DESCRIPTION
During load testing, the call to `pjsip_tsx_create_uas2()` from `create_pjsip_transaction()` will sometimes fail. This results in the `_lock` cleanup code following the call to be executed. This code invokes `pj_grp_lock_dec_ref()` which at this point will take the reference count to 0. `grp_lock_dec_ref()` will call `grp_lock_destroy()` in this case which will clean-up the lock and release its' resources. At some later point when the UASTsx destructor runs it will invoke `pj_grp_lock_release()` on `_lock` since it is not NULL. This causes a crash since the resources have already been released due to the previous 0 reference count clean-up. Since there are a number of safety checks for `(_lock != NULL)` already, it seems like this should be a reasonable fix for the error path. 
