### PR TITLE
Reviewer Matt - Move sprout-libs to /usr/share/clearwater/sprout/lib and restund libs to...

### DIFF
--- a/debian/bono.init.d
+++ b/debian/bono.init.d
@@ -133,7 +133,7 @@ do_start()
                 || return 1
 
         # daemon is not running, so attempt to start it.
-        export LD_LIBRARY_PATH=/usr/share/clearwater/lib
+        export LD_LIBRARY_PATH=/usr/share/clearwater/sprout/lib
         ulimit -Hn 1000000
         ulimit -Sn 1000000
         ulimit -c unlimited

--- a/debian/restund.init.d
+++ b/debian/restund.init.d
@@ -85,7 +85,7 @@ do_start()
                 || return 1
 
         # daemon is not running, so attempt to start it.
-        export LD_LIBRARY_PATH=/usr/share/clearwater/lib
+        export LD_LIBRARY_PATH=/usr/share/clearwater/restund/lib
         ulimit -Hn 10000
         ulimit -Sn 10000
         ulimit -c unlimited

--- a/debian/restund.install
+++ b/debian/restund.install
@@ -1,3 +1,3 @@
 usr/sbin/restund usr/share/clearwater/bin
-usr/lib/restund/modules/* usr/share/clearwater/lib
+usr/lib/restund/modules/* usr/share/clearwater/restund/lib
 restund.root/* /

--- a/debian/sprout-libs.install
+++ b/debian/sprout-libs.install
@@ -1,2 +1,2 @@
-usr/lib/*.so usr/share/clearwater/lib
-usr/lib/*.so.* usr/share/clearwater/lib
+usr/lib/*.so usr/share/clearwater/sprout/lib
+usr/lib/*.so.* usr/share/clearwater/sprout/lib

--- a/debian/sprout.init.d
+++ b/debian/sprout.init.d
@@ -152,7 +152,7 @@ do_start()
                 || return 1
 
         # daemon is not running, so attempt to start it.
-        export LD_LIBRARY_PATH=/usr/share/clearwater/lib
+        export LD_LIBRARY_PATH=/usr/share/clearwater/sprout/lib
         ulimit -Hn 1000000
         ulimit -Sn 1000000
         ulimit -c unlimited

--- a/restund.root/usr/share/clearwater/infrastructure/scripts/restund
+++ b/restund.root/usr/share/clearwater/infrastructure/scripts/restund
@@ -37,7 +37,7 @@ udp_listen              $bracketed_ip:3478
 udp_sockbuf_size        524288
 tcp_listen              $bracketed_ip:3478
 # modules
-module_path             /usr/share/clearwater/lib
+module_path             /usr/share/clearwater/restund/lib
 module                  stat.so
 module                  httpdb.so
 module                  binding.so


### PR DESCRIPTION
... /usr/share/clearwater/restund/lib

This is the complementary change to https://github.com/Metaswitch/ralf/pull/79/files.
