### PR TITLE
[Reviewer: Mike] Get the trail ID before creating the ACR.

### DIFF
--- a/sprout/icscfproxy.cpp
+++ b/sprout/icscfproxy.cpp
@@ -173,6 +173,7 @@ ICSCFProxy::UASTsx::~UASTsx()
 pj_status_t ICSCFProxy::UASTsx::init(pjsip_rx_data* rdata)
 {
   // Create an ACR if ACR generation is enabled.
+  _trail = get_trail(rdata);
   _acr = create_acr(rdata);
 
   // Do the BasicProxy initialization first.


### PR DESCRIPTION
Mike,

Please can you review my fix to Metaswitch/ralf#88, which covered EVENT ACRs not being SAS-traced correctly?  The issue was that, because we create the ACR before calling into `BasicProxy::init`, we don't have the SAS trail set up correctly.  I looked at reordering the BasicProxy initialization, but because it can actually reject requests itself, the ACR creation (and hence trail setup) must happen first.

I've run the UTs, but not live-tested yet.

Matt
