### PR TITLE
[Reviewer: Andy] Preserve quotes when parsing Accept/Reject-Contact headers, but strip th...

### DIFF
--- a/include/pjutils.h
+++ b/include/pjutils.h
@@ -79,6 +79,8 @@ pjsip_uri* uri_from_string(const std::string& uri_s,
 
 std::string pj_str_to_string(const pj_str_t* pjstr);
 
+std::string pj_str_to_unquoted_string(const pj_str_t* pjstr);
+
 std::string pj_status_to_string(const pj_status_t status);
 
 std::string aor_from_uri(const pjsip_sip_uri* uri);

--- a/sprout/contact_filtering.cpp
+++ b/sprout/contact_filtering.cpp
@@ -133,7 +133,7 @@ void filter_bindings_to_targets(const std::string& aor,
         deprioritized = true;
       }
     }
-    
+
     // Assuming we're still allowed to use this Contact, create a target from it.
     if (!rejected)
     {
@@ -157,7 +157,7 @@ void filter_bindings_to_targets(const std::string& aor,
   prune_targets(max_targets, targets);
 }
 
-// Convert a binding to its equivalent Target.  This can fail if (for example), 
+// Convert a binding to its equivalent Target.  This can fail if (for example),
 // the stored Path headers are not valid URIs.  In this case the function returns
 // false and the target parameter should not be used.
 bool binding_to_target(const std::string& aor,
@@ -221,7 +221,7 @@ void add_implicit_filters(const pjsip_msg* msg,
     pjsip_accept_contact_hdr* new_hdr = pjsip_accept_contact_hdr_create(pool);
     new_hdr->explicit_match = false;
     new_hdr->required_match = true;
-    
+
     // Create a method feature, specifying the requests's method.
     pjsip_param* method_feature = PJ_POOL_ALLOC_T(pool, pjsip_param);
     pj_strdup(pool, &method_feature->name, &STR_METHODS);
@@ -264,7 +264,8 @@ MatchResult match_feature_sets(const FeatureSet& contact_feature_set,
 
     // For boolean features the name may be prefixed with ! to indicate negation.
     std::string feature_name = PJUtils::pj_str_to_string(&feature_param->name);
-    std::string feature_value = PJUtils::pj_str_to_string(&feature_param->value);
+    std::string feature_value = PJUtils::pj_str_to_unquoted_string(&feature_param->value);
+
     Feature feature(feature_name, feature_value);
     std::string negated_feature_name;
     if (feature_name[0] == '!')
@@ -277,7 +278,7 @@ MatchResult match_feature_sets(const FeatureSet& contact_feature_set,
     }
 
     // Now find the Contact's version of this feature (using either name).
-    FeatureSet::const_iterator contact_feature; 
+    FeatureSet::const_iterator contact_feature;
     contact_feature = contact_feature_set.find(feature_name);
     if (contact_feature == contact_feature_set.end())
     {
@@ -354,11 +355,11 @@ MatchResult match_feature_sets(const FeatureSet& contact_feature_set,
        (feature_param != &reject->feature_set) && (rc == YES);
        feature_param = feature_param->next)
   {
-    // For boolean features the name may be prefixed with ! to indicate negation.
-    std::string feature_name = std::string(feature_param->name.ptr,
-                                           feature_param->name.slen);
-    std::string feature_value = std::string(feature_param->value.ptr,
-                                            feature_param->value.slen);
+    // For boolean features the name may be prefixed with ! to
+    // indicate negation.
+    std::string feature_name = PJUtils::pj_str_to_string(&feature_param->name);
+    std::string feature_value = PJUtils::pj_str_to_unquoted_string(&feature_param->value);
+
     Feature feature(feature_name, feature_value);
     std::string negated_feature_name;
     if (feature_name[0] == '!')
@@ -371,7 +372,7 @@ MatchResult match_feature_sets(const FeatureSet& contact_feature_set,
     }
 
     // Now find the Contact's version of this feature (using either name).
-    FeatureSet::const_iterator contact_feature; 
+    FeatureSet::const_iterator contact_feature;
     contact_feature = contact_feature_set.find(feature_name);
     if (contact_feature == contact_feature_set.end())
     {
@@ -469,7 +470,7 @@ MatchResult match_feature(const Feature& matcher,
   else
   {
     // Matcher is a token set...
-    if ((matchee.second[0] == '#') || 
+    if ((matchee.second[0] == '#') ||
         (matchee.second[0] == '<'))
     {
       // ...but the matchee is not
@@ -616,7 +617,7 @@ void prune_targets(int max_targets,
   // Sort the targets and truncate.
   std::sort(targets.begin(), targets.end(), compare_targets);
 
-  // Truncate down to max_targets by creating the shortened list and 
+  // Truncate down to max_targets by creating the shortened list and
   // swapping for the passed one.
   TargetList(targets.begin(), targets.begin() + max_targets).swap(targets);
 }

--- a/sprout/custom_headers.cpp
+++ b/sprout/custom_headers.cpp
@@ -923,8 +923,7 @@ pjsip_hdr* parse_hdr_reject_contact(pjsip_parse_ctx* ctx)
       pj_scan_get_char(scanner);
     }
 
-    pjsip_parse_param_imp(scanner, pool, &name, &value,
-                          PJSIP_PARSE_REMOVE_QUOTE);
+    pjsip_parse_param_imp(scanner, pool, &name, &value, 0);
     param = PJ_POOL_ALLOC_T(pool, pjsip_param);
     param->name = name;
     param->value = value;
@@ -1055,8 +1054,7 @@ pjsip_hdr* parse_hdr_accept_contact(pjsip_parse_ctx* ctx)
       pj_scan_get_char(scanner);
     }
 
-    pjsip_parse_param_imp(scanner, pool, &name, &value,
-                          PJSIP_PARSE_REMOVE_QUOTE);
+    pjsip_parse_param_imp(scanner, pool, &name, &value, 0);
     param = PJ_POOL_ALLOC_T(pool, pjsip_param);
     param->name = name;
     param->value = value;
@@ -1161,16 +1159,6 @@ int pjsip_accept_contact_hdr_print_on(void* void_hdr,
   copy_advance(buf, hdr->name);
   copy_advance(buf, pj_str(": *"));
 
-  if (hdr->required_match)
-  {
-    copy_advance(buf, pj_str(";require"));
-  }
-
-  if (hdr->explicit_match)
-  {
-    copy_advance(buf, pj_str(";explicit"));
-  }
-
   printed = pjsip_param_print_on(&hdr->feature_set, buf, endbuf-buf,
                                  &pc->pjsip_TOKEN_SPEC,
                                  &pc->pjsip_TOKEN_SPEC, ';');
@@ -1179,6 +1167,16 @@ int pjsip_accept_contact_hdr_print_on(void* void_hdr,
     return -1;
   }
   buf += printed;
+
+  if (hdr->explicit_match)
+  {
+    copy_advance(buf, pj_str(";explicit"));
+  }
+
+  if (hdr->required_match)
+  {
+    copy_advance(buf, pj_str(";require"));
+  }
 
   return buf-startbuf;
 }

--- a/sprout/pjutils.cpp
+++ b/sprout/pjutils.cpp
@@ -186,6 +186,18 @@ std::string PJUtils::pj_str_to_string(const pj_str_t* pjstr)
   return ((pjstr != NULL) && (pj_strlen(pjstr) > 0)) ? std::string(pj_strbuf(pjstr), pj_strlen(pjstr)) : std::string("");
 }
 
+std::string PJUtils::pj_str_to_unquoted_string(const pj_str_t* pjstr)
+{
+  std::string ret = pj_str_to_string(pjstr);
+
+  if ((ret.front() == '"') && (ret.back() == '"'))
+  {
+    ret = ret.substr(1, (ret.size() - 2));
+  }
+
+  return ret;
+}
+
 
 std::string PJUtils::pj_status_to_string(const pj_status_t status)
 {

--- a/sprout/ut/custom_headers_test.cpp
+++ b/sprout/ut/custom_headers_test.cpp
@@ -272,3 +272,116 @@ TEST_F(CustomHeadersTest, SessionExpires)
   EXPECT_EQ(written, 63);
   EXPECT_STREQ("Session-Expires: 600;refresher=uas;other-param=10;more-param=42", buf);
 }
+
+TEST_F(CustomHeadersTest, AcceptContact)
+{
+  pj_pool_t *main_pool = pjsip_endpt_create_pool(stack_data.endpt, "rtd%p",
+                                                 PJSIP_POOL_RDATA_LEN,
+                                                 PJSIP_POOL_RDATA_INC);
+  pj_pool_t *clone_pool = pjsip_endpt_create_pool(stack_data.endpt, "rtd%p",
+                                                  PJSIP_POOL_RDATA_LEN,
+                                                  PJSIP_POOL_RDATA_INC);
+
+  string str("INVITE sip:6505554321@homedomain SIP/2.0\n"
+             "Via: SIP/2.0/TCP 10.0.0.1:5060;rport;branch=z9hG4bKPjPtVFjqo;alias\n"
+             "Max-Forwards: 63\n"
+             "From: <sip:6505551234@homedomain>;tag=1234\n"
+             "To: <sip:6505554321@homedomain>\n"
+             "Contact: <sip:6505551234@10.0.0.1:5060;transport=TCP;ob>\n"
+             "Call-ID: 1-13919@10.151.20.48\n"
+             "CSeq: 1 INVITE\n"
+             "Accept-Contact: *;+sip.instance=\"<i:am:a:robot>\";explicit;require\n"
+             "Content-Length: 0\n\n");
+
+  pjsip_rx_data* rdata = build_rxdata(str, _tp_default, main_pool);
+  parse_rxdata(rdata);
+
+  pj_str_t header_name = pj_str("Accept-Contact");
+  pjsip_accept_contact_hdr* hdr =
+      (pjsip_accept_contact_hdr*)pjsip_msg_find_hdr_by_name(rdata->msg_info.msg,
+                                                            &header_name,
+                                                            NULL);
+  EXPECT_NE(hdr, (pjsip_accept_contact_hdr*)NULL);
+  EXPECT_EQ(true, hdr->required_match);
+  EXPECT_EQ(true, hdr->explicit_match);
+  EXPECT_EQ(1u, pj_list_size(&hdr->feature_set));
+
+  pjsip_accept_contact_hdr* clone = (pjsip_accept_contact_hdr*)hdr->vptr->clone(clone_pool, (void*)hdr);
+  EXPECT_EQ(true, clone->required_match);
+  EXPECT_EQ(true, clone->explicit_match);
+  EXPECT_EQ(1u, pj_list_size(&clone->feature_set));
+
+  pjsip_accept_contact_hdr* sclone = (pjsip_accept_contact_hdr*)hdr->vptr->shallow_clone(clone_pool, (void*)clone);
+  EXPECT_EQ(true, sclone->required_match);
+  EXPECT_EQ(true, sclone->explicit_match);
+  EXPECT_EQ(1u, pj_list_size(&sclone->feature_set));
+
+  pj_pool_release(main_pool);
+
+  char buf[1024];
+  memset(buf, 0, 1024);
+  pjsip_hdr* generic_hdr = (pjsip_hdr*)sclone;
+  int written = generic_hdr->vptr->print_on(sclone, buf, 0);
+  EXPECT_EQ(written, -1);
+  int i = 1;
+  while ((written == -1) && (i <= 1024)) {
+    written = generic_hdr->vptr->print_on(sclone, buf, i);
+    i++;
+  }
+  EXPECT_EQ(written, 65);
+  EXPECT_STREQ("Accept-Contact: *;+sip.instance=\"<i:am:a:robot>\";explicit;require", buf);
+  pj_pool_release(clone_pool);
+}
+
+TEST_F(CustomHeadersTest, RejectContact)
+{
+  pj_pool_t *main_pool = pjsip_endpt_create_pool(stack_data.endpt, "rtd%p",
+                                                 PJSIP_POOL_RDATA_LEN,
+                                                 PJSIP_POOL_RDATA_INC);
+  pj_pool_t *clone_pool = pjsip_endpt_create_pool(stack_data.endpt, "rtd%p",
+                                                  PJSIP_POOL_RDATA_LEN,
+                                                  PJSIP_POOL_RDATA_INC);
+
+  string str("INVITE sip:6505554321@homedomain SIP/2.0\n"
+             "Via: SIP/2.0/TCP 10.0.0.1:5060;rport;branch=z9hG4bKPjPtVFjqo;alias\n"
+             "Max-Forwards: 63\n"
+             "From: <sip:6505551234@homedomain>;tag=1234\n"
+             "To: <sip:6505554321@homedomain>\n"
+             "Contact: <sip:6505551234@10.0.0.1:5060;transport=TCP;ob>\n"
+             "Call-ID: 1-13919@10.151.20.48\n"
+             "CSeq: 1 INVITE\n"
+             "Reject-Contact: *;+sip.instance=\"<i:am:a:robot>\"\n"
+             "Content-Length: 0\n\n");
+
+  pjsip_rx_data* rdata = build_rxdata(str, _tp_default, main_pool);
+  parse_rxdata(rdata);
+
+  pj_str_t header_name = pj_str("Reject-Contact");
+  pjsip_reject_contact_hdr* hdr =
+      (pjsip_reject_contact_hdr*)pjsip_msg_find_hdr_by_name(rdata->msg_info.msg,
+                                                            &header_name,
+                                                            NULL);
+  EXPECT_NE(hdr, (pjsip_reject_contact_hdr*)NULL);
+  EXPECT_EQ(1u, pj_list_size(&hdr->feature_set));
+
+  pjsip_reject_contact_hdr* clone = (pjsip_reject_contact_hdr*)hdr->vptr->clone(clone_pool, (void*)hdr);
+  EXPECT_EQ(1u, pj_list_size(&clone->feature_set));
+
+  pjsip_reject_contact_hdr* sclone = (pjsip_reject_contact_hdr*)hdr->vptr->shallow_clone(clone_pool, (void*)clone);
+  EXPECT_EQ(1u, pj_list_size(&sclone->feature_set));
+
+  pj_pool_release(main_pool);
+
+  char buf[1024];
+  memset(buf, 0, 1024);
+  pjsip_hdr* generic_hdr = (pjsip_hdr*)sclone;
+  int written = generic_hdr->vptr->print_on(sclone, buf, 0);
+  EXPECT_EQ(written, -1);
+  int i = 1;
+  while ((written == -1) && (i <= 1024)) {
+    written = generic_hdr->vptr->print_on(sclone, buf, i);
+    i++;
+  }
+  EXPECT_STREQ("Reject-Contact: *;+sip.instance=\"<i:am:a:robot>\"", buf);
+  pj_pool_release(clone_pool);
+}


### PR DESCRIPTION
...em when doing comparisons

Also includes custom headers tests to check this, and make sure all the cloning is valid.

Fixes https://github.com/Metaswitch/pjsip-upstream/issues/26.
