### PR TITLE
[Reviewer Mike] I-CSCF sproutlet

### DIFF
--- a/include/icscfsproutlet.h
+++ b/include/icscfsproutlet.h
@@ -71,7 +71,7 @@ public:
                  ACRFactory* acr_factory,
                  SCSCFSelector* scscf_selector);
 
-  ~ICSCFSproutlet();
+  virtual ~ICSCFSproutlet();
 
   SproutletTsx* get_tsx(SproutletTsxHelper* helper, pjsip_msg* req);
 

--- a/sprout/Makefile
+++ b/sprout/Makefile
@@ -332,7 +332,7 @@ vg-check: vg
 
 .PHONY: vg_raw
 vg_raw: build_test | $(TEST_OUT_DIR)
-	-valgrind --gen-suppressions=all $(VGFLAGS) \
+	-valgrind --gen-suppressions=all --show-reachable=yes $(VGFLAGS) \
 	  $(TARGET_BIN_TEST) --gtest_filter='-*DeathTest*' $(EXTRA_TEST_ARGS)
 
 .PHONY: distclean

--- a/sprout/icscfsproutlet.cpp
+++ b/sprout/icscfsproutlet.cpp
@@ -113,6 +113,7 @@ ICSCFSproutletRegTsx::ICSCFSproutletRegTsx(SproutletTsxHelper* helper,
 ICSCFSproutletRegTsx::~ICSCFSproutletRegTsx()
 {
   delete _acr;
+  delete _router;
 }
 
 
@@ -213,6 +214,7 @@ void ICSCFSproutletRegTsx::on_rx_initial_request(pjsip_msg* req)
     pjsip_msg* rsp = create_response(req, status_code);
     send_response(rsp);
     free_msg(req);
+    free_msg(_cloned_req);
   }
 }
 
@@ -356,6 +358,7 @@ ICSCFSproutletTsx::ICSCFSproutletTsx(SproutletTsxHelper* helper,
 ICSCFSproutletTsx::~ICSCFSproutletTsx()
 {
   delete _acr;
+  delete _router;
 }
 
 
@@ -434,9 +437,11 @@ void ICSCFSproutletTsx::on_rx_initial_request(pjsip_msg* req)
   }
   else
   {
+    // Failed to find an S-CSCF, the is the final response.
     pjsip_msg* rsp = create_response(req, status_code);
     send_response(rsp);
     free_msg(req);
+    free_msg(_cloned_req);
   }
 }
 

--- a/sprout/sproutletproxy.cpp
+++ b/sprout/sproutletproxy.cpp
@@ -139,13 +139,15 @@ void SproutletProxy::add_record_route(pjsip_tx_data* tdata,
 
 SproutletProxy::UASTsx::UASTsx(BasicProxy* proxy) :
   BasicProxy::UASTsx(proxy),
-  _in_dialog(false)
+  _in_dialog(false),
+  _helper(NULL)
 {
 }
 
 
 SproutletProxy::UASTsx::~UASTsx()
 {
+  delete _helper; _helper = NULL;
 }
 
 
@@ -360,6 +362,7 @@ SproutletProxyTsxHelper::~SproutletProxyTsxHelper()
   assert(_packets.empty());
   assert(_send_requests.empty());
   assert(_send_responses.empty());
+  delete _sproutlet; _sproutlet = NULL;
 }
 
 //

--- a/sprout/ut/icscfsproutlet_test.cpp
+++ b/sprout/ut/icscfsproutlet_test.cpp
@@ -79,7 +79,7 @@ public:
     std::list<Sproutlet*> sproutlets;
     sproutlets.push_back(_icscf_sproutlet);
 
-    SproutletProxy* _icscf_proxy =
+    _icscf_proxy =
       new SproutletProxy(stack_data.endpt,
                          PJSIP_MOD_PRIORITY_UA_PROXY_LAYER,
                          PJUtils::pj_str_to_string(&stack_data.scscf_uri),


### PR DESCRIPTION
I-CSCF sproutlet code.  I've ported the I-CSCF Proxy UTs to use the I-CSCF Sproutlet and the `SproutletProxy`.  After fixing the bugs in my code, the unit tests all ran exactly as they used to (apart from the `WrongPort` test which is no longer valid).

There's a memory leak here, none of the `UASTsx`s from BasicProxy are being deleted correctly.  I've not spent any time looking into that yet, that's my plan for tomorrow.
