### PR TITLE
[Reviewer: Ellie] Add SAS log on transport failure

### DIFF
--- a/include/sproutsasevent.h
+++ b/include/sproutsasevent.h
@@ -116,6 +116,7 @@ namespace SASEvent
   const int IFC_MATCHED = SPROUT_BASE + 0x0000C3;
 
   const int TRANSPORT_FAILURE = SPROUT_BASE + 0x0000D0;
+  const int TIMEOUT_FAILURE = SPROUT_BASE + 0x0000D1;
 
 } //namespace SASEvent
 

--- a/sprout/basicproxy.cpp
+++ b/sprout/basicproxy.cpp
@@ -1783,14 +1783,21 @@ void BasicProxy::UACTsx::on_tsx_state(pjsip_event* event)
         // transaction.
         LOG_DEBUG("%s - UAC tsx terminated while still connected to UAS tsx",
                   _tsx->obj_name);
-        if ((event->body.tsx_state.type == PJSIP_EVENT_TIMER) ||
-            (event->body.tsx_state.type == PJSIP_EVENT_TRANSPORT_ERROR))
+        if (event->body.tsx_state.type == PJSIP_EVENT_TRANSPORT_ERROR)
         {
           LOG_DEBUG("Timeout or transport error");
           SAS::Event sas_event(trail(), SASEvent::TRANSPORT_FAILURE, 0);
           SAS::report_event(sas_event);
           _uas_tsx->on_client_not_responding(this);
         }
+        else if (event->body.tsx_state.type == PJSIP_EVENT_TIMER)
+        {
+          LOG_DEBUG("Timeout error");
+          SAS::Event sas_event(trail(), SASEvent::TIMEOUT_FAILURE, 0);
+          SAS::report_event(sas_event);
+          _uas_tsx->on_client_not_responding(this);
+        }
+
       }
     }
   }

--- a/sprout/stateful_proxy.cpp
+++ b/sprout/stateful_proxy.cpp
@@ -4329,11 +4329,17 @@ void UACTransaction::on_tsx_state(pjsip_event* event)
         // transaction.
         LOG_DEBUG("%s - UAC tsx terminated while still connected to UAS tsx",
                   _tsx->obj_name);
-        if ((event->body.tsx_state.type == PJSIP_EVENT_TIMER) ||
-            (event->body.tsx_state.type == PJSIP_EVENT_TRANSPORT_ERROR))
+        if (event->body.tsx_state.type == PJSIP_EVENT_TRANSPORT_ERROR)
         {
           LOG_DEBUG("Timeout or transport error");
           SAS::Event sas_event(trail(), SASEvent::TRANSPORT_FAILURE, 0);
+          SAS::report_event(sas_event);
+          _uas_data->on_client_not_responding(this);
+        }
+        else if (event->body.tsx_state.type == PJSIP_EVENT_TIMER)
+        {
+          LOG_DEBUG("Timeout error");
+          SAS::Event sas_event(trail(), SASEvent::TIMEOUT_FAILURE, 0);
           SAS::report_event(sas_event);
           _uas_data->on_client_not_responding(this);
         }


### PR DESCRIPTION
In https://github.com/Metaswitch/sprout/issues/538 you flagged that there's no SAS log on transport failure. This probably fixes that - unfortunately, I don't see an easy way to test it in the case that originally caused the problem (a P-CSCF tearing down connections due to overload).

https://github.com/Metaswitch/clearwater-sas-resources/commit/5e8ff2d39ebef0a7b781f4f9ce3d177c56aa36be is the corresponding resource bundle change.
