### PR TITLE
[Reviewer Andy] Don't hairpin outgoing requests

### DIFF
--- a/sprout/stateful_proxy.cpp
+++ b/sprout/stateful_proxy.cpp
@@ -619,6 +619,52 @@ void process_tsx_request(pjsip_rx_data* rdata)
       downstream_acr->tx_request(tdata->msg);
     }
 
+    if (target != NULL) 
+    {
+      // Target has already been selected for the request, so set it up on the
+      // request.
+      tdata->msg->line.req.uri = target->uri;
+
+      // If the target is routing to the upstream device (we're acting as an access
+      // proxy), strip any extra loose routes on the message to prevent accidental
+      // double routing.
+      if (target->upstream_route)
+      {
+        LOG_DEBUG("Stripping loose routes from proxied message");
+
+        // Tight loop to strip all route headers.
+        while (pjsip_msg_find_remove_hdr(tdata->msg,
+                                         PJSIP_H_ROUTE,
+                                         NULL) != NULL)
+        {
+          // Tight loop.
+        };
+      }
+
+      if (target->transport != NULL)
+      {
+        // The target includes a selected transport, so set it here.
+        pjsip_tpselector tp_selector;
+        tp_selector.type = PJSIP_TPSELECTOR_TRANSPORT;
+        tp_selector.u.transport = target->transport;
+        pjsip_tx_data_set_transport(tdata, &tp_selector);
+
+        tdata->dest_info.addr.count = 1;
+        tdata->dest_info.addr.entry[0].type =
+                           (pjsip_transport_type_e)target->transport->key.type;
+        pj_memcpy(&tdata->dest_info.addr.entry[0].addr,
+                  &target->transport->key.rem_addr,
+                  sizeof(pj_sockaddr));
+        tdata->dest_info.addr.entry[0].addr_len =
+             (tdata->dest_info.addr.entry[0].addr.addr.sa_family == pj_AF_INET()) ?
+             sizeof(pj_sockaddr_in) : sizeof(pj_sockaddr_in6);
+        tdata->dest_info.cur_addr = 0;
+
+        // Remove the reference to the transport added when it was chosen.
+        pjsip_transport_dec_ref(target->transport);
+      }
+    }
+
     status = PJUtils::send_request_stateless(tdata);
 
     if (status != PJ_SUCCESS)
@@ -1410,18 +1456,10 @@ int proxy_process_access_routing(pjsip_rx_data *rdata,
         // This must be a request for a client, so make sure it is routed
         // over the appropriate flow.
         LOG_DEBUG("Inbound request for client with flow identifier in Route header");
-        pjsip_tpselector tp_selector;
-        tp_selector.type = PJSIP_TPSELECTOR_TRANSPORT;
-        tp_selector.u.transport = tgt_flow->transport();
-        pjsip_tx_data_set_transport(tdata, &tp_selector);
-
-        tdata->dest_info.addr.count = 1;
-        tdata->dest_info.addr.entry[0].type = (pjsip_transport_type_e)tgt_flow->transport()->key.type;
-        pj_memcpy(&tdata->dest_info.addr.entry[0].addr, tgt_flow->remote_addr(), sizeof(pj_sockaddr));
-        tdata->dest_info.addr.entry[0].addr_len =
-             (tdata->dest_info.addr.entry[0].addr.addr.sa_family == pj_AF_INET()) ?
-             sizeof(pj_sockaddr_in) : sizeof(pj_sockaddr_in6);
-        tdata->dest_info.cur_addr = 0;
+        *target = new Target();
+        (*target)->uri = (pjsip_uri*)pjsip_uri_clone(tdata->pool, tdata->msg->line.req.uri);
+        (*target)->transport = tgt_flow->transport();
+        pjsip_transport_add_ref((*target)->transport);
 
         *trust = &TrustBoundary::OUTBOUND_EDGE_CLIENT;
 
@@ -1445,45 +1483,49 @@ int proxy_process_access_routing(pjsip_rx_data *rdata,
     // remove the top route header if it corresponds to this node.
     proxy_process_routing(tdata);
 
-    // Check if we have any Route headers.  If so, we'll follow them.  If not,
-    // we get to choose where to route to, so route upstream to sprout.
-    void* top_route = pjsip_msg_find_hdr(tdata->msg, PJSIP_H_ROUTE, NULL);
-    if (top_route)
+    // If we haven't already decided where to route the request, do so now.
+    if (*target == NULL) 
     {
-      // We already have Route headers, so just build a target that mirrors
-      // the current request URI.
-      *target = new Target();
-      (*target)->uri = (pjsip_uri*)pjsip_uri_clone(tdata->pool, tdata->msg->line.req.uri);
-    }
-    else if (PJUtils::is_home_domain(tdata->msg->line.req.uri) ||
-             PJUtils::is_uri_local(tdata->msg->line.req.uri))
-    {
-      // Route the request upstream to Sprout.
-      proxy_route_upstream(rdata, tdata, trust, target);
-    }
-
-    // Work out the next hop target for the message.  This will either be the
-    // URI in the top route header, or the request URI.
-    pjsip_uri* next_hop = PJUtils::next_hop(tdata->msg);
-
-    if ((ibcf) &&
-        (tgt_flow == NULL) &&
-        (PJSIP_URI_SCHEME_IS_SIP(next_hop)))
-    {
-      // Check if the message is destined for a SIP trunk
-      LOG_DEBUG("Check whether destination %.*s is a SIP trunk",
-                ((pjsip_sip_uri*)next_hop)->host.slen, ((pjsip_sip_uri*)next_hop)->host.ptr);
-      pj_sockaddr dest;
-      if (pj_sockaddr_parse(pj_AF_UNSPEC(), 0, &((pjsip_sip_uri*)next_hop)->host, &dest) == PJ_SUCCESS)
+      // Check if we have any Route headers.  If so, we'll follow them.  If not,
+      // we get to choose where to route to, so route upstream to sprout.
+      void* top_route = pjsip_msg_find_hdr(tdata->msg, PJSIP_H_ROUTE, NULL);
+      if (top_route)
       {
-        // Target host name is an IP address, so check against the IBCF trusted
-        // peers.
-        LOG_DEBUG("Parsed destination as an IP address, so check against trusted peers list");
-        if (ibcf_trusted_peer(dest))
+        // We already have Route headers, so just build a target that mirrors
+        // the current request URI.
+        *target = new Target();
+        (*target)->uri = (pjsip_uri*)pjsip_uri_clone(tdata->pool, tdata->msg->line.req.uri);
+      }
+      else if ((PJUtils::is_home_domain(tdata->msg->line.req.uri)) ||
+               (PJUtils::is_uri_local(tdata->msg->line.req.uri)))
+      {
+        // We've not already decided to route the request Route the request upstream to Sprout.
+        proxy_route_upstream(rdata, tdata, trust, target);
+      }
+
+      // Work out the next hop target for the message.  This will either be the
+      // URI in the top route header, or the request URI.
+      pjsip_uri* next_hop = PJUtils::next_hop(tdata->msg);
+
+      if ((ibcf) &&
+          (tgt_flow == NULL) &&
+          (PJSIP_URI_SCHEME_IS_SIP(next_hop)))
+      {
+        // Check if the message is destined for a SIP trunk
+        LOG_DEBUG("Check whether destination %.*s is a SIP trunk",
+                  ((pjsip_sip_uri*)next_hop)->host.slen, ((pjsip_sip_uri*)next_hop)->host.ptr);
+        pj_sockaddr dest;
+        if (pj_sockaddr_parse(pj_AF_UNSPEC(), 0, &((pjsip_sip_uri*)next_hop)->host, &dest) == PJ_SUCCESS)
         {
-          LOG_DEBUG("Destination is a SIP trunk");
-          *trust = &TrustBoundary::OUTBOUND_TRUNK;
-          pjsip_msg_find_remove_hdr(tdata->msg, PJSIP_H_AUTHORIZATION, NULL);
+          // Target host name is an IP address, so check against the IBCF trusted
+          // peers.
+          LOG_DEBUG("Parsed destination as an IP address, so check against trusted peers list");
+          if (ibcf_trusted_peer(dest))
+          {
+            LOG_DEBUG("Destination is a SIP trunk");
+            *trust = &TrustBoundary::OUTBOUND_TRUNK;
+            pjsip_msg_find_remove_hdr(tdata->msg, PJSIP_H_AUTHORIZATION, NULL);
+          }
         }
       }
     }


### PR DESCRIPTION
Andy

Can you review this fix to issue #704. I was hitting this Bono problem when testing Sproutlet function so needed to fix it in a hurry.  The fix is to handle routing to clients using flow tokens by setting up a target - which required some extra code in the ACK handling case as well.

Mike
