### PR TITLE
[Reviewer: Mike] Use find, not find_first_of

### DIFF
--- a/sprout/main.cpp
+++ b/sprout/main.cpp
@@ -1444,8 +1444,8 @@ int main(int argc, char *argv[])
       // Create a local I-CSCF URI by replacing the S-CSCF port number in the
       // S-CSCF URI with the I-CSCF port number.
       icscf_uri = scscf_uri;
-      size_t pos = icscf_uri.find_first_of(std::to_string(opt.scscf_port));
-      if (pos != std::string::npos) 
+      size_t pos = icscf_uri.find(std::to_string(opt.scscf_port));
+      if (pos != std::string::npos)
       {
         icscf_uri.replace(pos,
                           std::to_string(opt.scscf_port).length(),
@@ -1474,7 +1474,7 @@ int main(int argc, char *argv[])
                                          scscf_acr_factory,
                                          opt.enforce_user_phone,
                                          opt.enforce_global_only_lookups);
-    if (scscf_sproutlet == NULL) 
+    if (scscf_sproutlet == NULL)
     {
       LOG_ERROR("Failed to create S-CSCF Sproutlet");
       return 1;
@@ -1484,7 +1484,7 @@ int main(int argc, char *argv[])
     BGCFSproutlet* bgcf_sproutlet = new BGCFSproutlet(0,
                                                       bgcf_service,
                                                       bgcf_acr_factory);
-    if (bgcf_sproutlet == NULL) 
+    if (bgcf_sproutlet == NULL)
     {
       LOG_ERROR("Failed to create BGCF Sproutlet");
       return 1;
@@ -1497,7 +1497,7 @@ int main(int argc, char *argv[])
   {
     // Create the S-CSCF selector.
     scscf_selector = new SCSCFSelector();
-    if (scscf_selector == NULL) 
+    if (scscf_selector == NULL)
     {
       LOG_ERROR("Failed to create S-CSCF selector");
       return 1;
@@ -1549,7 +1549,7 @@ int main(int argc, char *argv[])
                                          PJSIP_MOD_PRIORITY_UA_PROXY_LAYER+3,
                                          std::string(stack_data.scscf_uri.ptr, stack_data.scscf_uri.slen),
                                          sproutlets);
-    if (sproutlet_proxy == NULL) 
+    if (sproutlet_proxy == NULL)
     {
       LOG_ERROR("Failed to create SproutletProxy");
       return 1;
@@ -1620,8 +1620,8 @@ int main(int argc, char *argv[])
   unregister_stack_modules();
 
   // Destroy the Sproutlet Proxy and any Sproutlets.
-  delete sproutlet_proxy; 
-  while (!sproutlets.empty()) 
+  delete sproutlet_proxy;
+  while (!sproutlets.empty())
   {
     delete sproutlets.front();
     sproutlets.pop_front();


### PR DESCRIPTION
Mike, can you review this fix to use find, not find_first_of. The icscf_uri code was finding the first instance of a single character in the string 5054 in the scscf_uri and replacing it with 5052, meaning the iscsf uri for my em4 deployment was turned into sip:sprout.em5052-ngv.com:5054;transport=TCP
