### PR TITLE
{Reviewer Andy] Check URI returned in IFC

### DIFF
--- a/sprout/basicproxy.cpp
+++ b/sprout/basicproxy.cpp
@@ -1362,7 +1362,10 @@ void BasicProxy::UASTsx::dissociate(UACTsx* uac_tsx)
 {
   LOG_DEBUG("Dissociate UAC transaction %p for target %d", uac_tsx, uac_tsx->_index);
   uac_tsx->_uas_tsx = NULL;
-  _uac_tsx[uac_tsx->_index] = NULL;
+  if (_uac_tsx.size() > (size_t)uac_tsx->_index)
+  {
+    _uac_tsx[uac_tsx->_index] = NULL;
+  }
 }
 
 

--- a/sprout/scscfsproutlet.cpp
+++ b/sprout/scscfsproutlet.cpp
@@ -933,7 +933,8 @@ void SCSCFSproutletTsx::route_to_as(pjsip_msg* req, const std::string& server_na
   pjsip_sip_uri* as_uri = (pjsip_sip_uri*)
                         PJUtils::uri_from_string(server_name, get_pool(req));
 
-  if (as_uri != NULL)
+  if ((as_uri != NULL) &&
+      (PJSIP_URI_SCHEME_IS_SIP(as_uri)))
   {
     // AS URI is valid, so encode the AS hop and the return hop in Route headers.
     std::string odi_value = PJUtils::pj_str_to_string(&STR_ODI_PREFIX) +


### PR DESCRIPTION
Andy

Can you review my fix to issue 472, to check the URI in the ServerName parameter in IFC.  This is also covered by issue 723.

I also hit and fixed a separate problem while testing this.  I put in what I though was a bad URI but turned out to be a valid Tel: URI, this then crashed later on because we failed to set up the PJSIP UAC transaction (it won't let you use a Tel URI in a route header) and hit a problem while clearing up the UACTsx object.  That is the fix in BasicProxy.

Mike
