### PR TITLE
Add configuration support for target latency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "build-infra"]
 	path = build-infra
-	url = git@github.com:Metaswitch/clearwater-build-infra.git
+	url = git@github.com:ClearwaterCore/clearwater-build-infra.git
 [submodule "modules/c-ares"]
 	path = modules/c-ares
 	url = git@github.com:bagder/c-ares.git
@@ -9,40 +9,40 @@
 	url = git@github.com:bagder/curl.git
 [submodule "modules/gmock"]
 	path = modules/gmock
-	url = git@github.com:Metaswitch/gmock-upstream.git
+	url = git@github.com:ClearwaterCore/gmock-upstream.git
 [submodule "modules/jsoncpp"]
 	path = modules/jsoncpp
-	url = git@github.com:Metaswitch/jsoncpp-upstream.git
+	url = git@github.com:ClearwaterCore/jsoncpp-upstream.git
 [submodule "modules/libmemcached"]
 	path = modules/libmemcached
-	url = git@github.com:Metaswitch/libmemcached-upstream.git
+	url = git@github.com:ClearwaterCore/libmemcached-upstream.git
 [submodule "modules/libre"]
 	path = modules/libre
-	url = git@github.com:Metaswitch/libre-upstream.git
+	url = git@github.com:ClearwaterCore/libre-upstream.git
 [submodule "modules/openssl"]
 	path = modules/openssl
 	url = git@github.com:openssl/openssl.git
 [submodule "modules/pjsip"]
 	path = modules/pjsip
-	url = git@github.com:Metaswitch/pjsip-upstream.git
+	url = git@github.com:ClearwaterCore/pjsip-upstream.git
 [submodule "modules/restund"]
 	path = modules/restund
-	url = git@github.com:Metaswitch/restund.git
+	url = git@github.com:ClearwaterCore/restund.git
 [submodule "modules/sipp"]
 	path = modules/sipp
-	url = git@github.com:Metaswitch/sipp.git
+	url = git@github.com:ClearwaterCore/sipp.git
 [submodule "modules/websocketpp"]
 	path = modules/websocketpp
 	url = git@github.com:zaphoyd/websocketpp.git
 [submodule "modules/sas-client"]
 	path = modules/sas-client
-	url = git@github.com:Metaswitch/sas-client.git
+	url = git@github.com:ClearwaterCore/sas-client.git
 [submodule "modules/cpp-common"]
 	path = modules/cpp-common
-	url = git@github.com:Metaswitch/cpp-common.git
+	url = git@github.com:ClearwaterCore/cpp-common.git
 [submodule "modules/libevhtp"]
 	path = modules/libevhtp
-	url = git@github.com:Metaswitch/libevhtp.git
+	url = git@github.com:ClearwaterCore/libevhtp.git
 [submodule "modules/gcovr"]
 	path = modules/gcovr
 	url = git@github.com:gcovr/gcovr.git

--- a/debian/sprout.init.d
+++ b/debian/sprout.init.d
@@ -84,6 +84,7 @@ get_settings()
         sas_server=0.0.0.0
         sprout_rr_level="pcscf"
         scscf=5054
+        target_latency_us=100000
         alias_list=""
         default_session_expires=600
         . /etc/clearwater/config
@@ -177,6 +178,7 @@ do_start()
                      --worker-threads $num_worker_threads
                      --record-routing-model $sprout_rr_level
                      --default-session-expires $default_session_expires
+                     --target-latency-us $target_latency_us
                      $authentication_arg
                      $user_phone_arg
                      $global_only_lookups_arg

--- a/include/avstore.h
+++ b/include/avstore.h
@@ -66,6 +66,7 @@ public:
   bool set_av(const std::string& impi,
               const std::string& nonce,
               const Json::Value* av,
+              uint64_t cas,
               SAS::TrailId trail);
 
   /// Retrieves the Authentication Vector for the specified private user identity
@@ -77,11 +78,8 @@ public:
   /// @param nonce     A reference to the nonce.
   Json::Value* get_av(const std::string& impi,
                       const std::string& nonce,
+                      uint64_t& cas,
                       SAS::TrailId trail);
-
-  bool delete_av(const std::string& impi,
-                 const std::string& nonce,
-                 SAS::TrailId trail);
 
 private:
   /// A pointer to the underlying data store.
@@ -93,5 +91,9 @@ private:
   /// should pop before it expires.
   static const int AV_EXPIRY = 40;
 };
+
+// Utility function - retrieves the "branch" field from the given AV
+// and raises a correlating transaction marker in the given trail.
+void correlate_branch_from_av(Json::Value* av, SAS::TrailId trail);
 
 #endif

--- a/include/pjutils.h
+++ b/include/pjutils.h
@@ -167,7 +167,8 @@ void generate_new_branch_id(pjsip_tx_data* tdata);
 pj_status_t send_request(pjsip_tx_data* tdata,
                          int retries=0,
                          void* token=NULL,
-                         pjsip_endpt_send_callback cb=NULL);
+                         pjsip_endpt_send_callback cb=NULL,
+                         bool log_sas_branch = false);
 
 pj_status_t send_request_stateless(pjsip_tx_data* tdata,
                                    int retries=0);
@@ -208,7 +209,7 @@ bool check_route_headers(pjsip_rx_data* rdata);
 
 void put_unary_param(pjsip_param* params_list,
                      const pj_str_t* name,
-                     pj_pool_t* pool); 
+                     pj_pool_t* pool);
 
 } // namespace PJUtils
 

--- a/include/regstore.h
+++ b/include/regstore.h
@@ -254,10 +254,10 @@ public:
   bool set_aor_data(const std::string& aor_id, AoR* data, bool update_timers, SAS::TrailId trail, bool& all_bindings_expired);
 
   // Send a SIP NOTIFY
-  void send_notify(AoR::Subscription* s, int cseq, AoR::Binding* b, std::string b_id);
+  void send_notify(AoR::Subscription* s, int cseq, AoR::Binding* b, std::string b_id, SAS::TrailId trail);
 
 private:
-  int expire_bindings(AoR* aor_data, int now);
+  int expire_bindings(AoR* aor_data, int now, SAS::TrailId trail);
   void expire_subscriptions(AoR* aor_data, int now);
 
   ChronosConnection* _chronos;

--- a/sprout/avstore.cpp
+++ b/sprout/avstore.cpp
@@ -57,13 +57,14 @@ AvStore::~AvStore()
 bool AvStore::set_av(const std::string& impi,
                      const std::string& nonce,
                      const Json::Value* av,
+                     uint64_t cas,
                      SAS::TrailId trail)
 {
   std::string key = impi + '\\' + nonce;
   Json::FastWriter writer;
   std::string data = writer.write(*av);
   LOG_DEBUG("Set AV for %s\n%s", key.c_str(), data.c_str());
-  Store::Status status = _data_store->set_data("av", key, data, 0, AV_EXPIRY, trail);
+  Store::Status status = _data_store->set_data("av", key, data, cas, AV_EXPIRY, trail);
   std::string operation = "SET";
   if (status != Store::Status::OK)
   {
@@ -88,46 +89,14 @@ bool AvStore::set_av(const std::string& impi,
   return true;
 }
 
-bool AvStore::delete_av(const std::string& impi,
-                        const std::string& nonce,
-                        SAS::TrailId trail)
-{
-  std::string key = impi + '\\' + nonce;
-  LOG_DEBUG("Delete AV for %s", key.c_str());
-  Store::Status status = _data_store->delete_data("av", key, trail);
-  std::string operation = "DELETE";
-  if (status != Store::Status::OK)
-  {
-    // LCOV_EXCL_START
-    std::string error_msg = "Failed to delete Authentication Vector for private_id " + impi;
-    LOG_ERROR(error_msg.c_str());
-
-    SAS::Event event(trail, SASEvent::AVSTORE_FAILURE, 0);
-    event.add_var_param(operation);
-    event.add_var_param(error_msg);
-    SAS::report_event(event);
-
-    return false;
-    // LCOV_EXCL_STOP
-  }
-
-  SAS::Event event(trail, SASEvent::AVSTORE_SUCCESS, 0);
-  event.add_var_param(operation);
-  event.add_var_param(impi);
-  SAS::report_event(event);
-
-  return true;
-}
-
-
 Json::Value* AvStore::get_av(const std::string& impi,
                              const std::string& nonce,
+                             uint64_t& cas,
                              SAS::TrailId trail)
 {
   Json::Value* av = NULL;
   std::string key = impi + '\\' + nonce;
   std::string data;
-  uint64_t cas;
   Store::Status status = _data_store->get_data("av", key, data, cas, trail);
   std::string operation = "GET";
 
@@ -162,3 +131,26 @@ Json::Value* AvStore::get_av(const std::string& impi,
   return av;
 }
 
+void correlate_branch_from_av(Json::Value* av, SAS::TrailId trail)
+{
+  Json::Value null_json;
+  Json::Value branch = av->get("branch", null_json);
+  if (branch.isNull())
+  {
+    LOG_WARNING("Could not raise branch correlation marker because the stored authentication vector is missing 'branch' field");
+  }
+  else if (!branch.isString())
+  {
+    LOG_WARNING("Could not raise branch correlation marker because the stored authentication vector has a non-string 'branch' field");
+  }
+  else if (branch.asString().empty())
+  {
+    LOG_WARNING("Could not raise branch correlation marker because the stored authentication vector has an empty 'branch' field");
+  }
+  else
+  {
+    SAS::Marker via_marker(trail, MARKER_ID_VIA_BRANCH_PARAM, 1u);
+    via_marker.add_var_param(branch.asString());
+    SAS::report_marker(via_marker, SAS::Marker::Scope::Trace);
+  }
+}

--- a/sprout/basicproxy.cpp
+++ b/sprout/basicproxy.cpp
@@ -45,6 +45,7 @@ extern "C" {
 #include <pjlib-util.h>
 #include <pjlib.h>
 #include <stdint.h>
+#include "pjsip-simple/evsub.h"
 }
 
 #include <vector>
@@ -1212,7 +1213,18 @@ void BasicProxy::UASTsx::on_tsx_start(const pjsip_rx_data* rdata)
     SAS::report_marker(called_dn);
   }
 
-  PJUtils::mark_sas_call_branch_ids(trail(), rdata->msg_info.cid, rdata->msg_info.msg);
+  if ((rdata->msg_info.msg->line.req.method.id == PJSIP_REGISTER_METHOD) ||
+      ((pjsip_method_cmp(&rdata->msg_info.msg->line.req.method, pjsip_get_subscribe_method())) == 0) ||
+      ((pjsip_method_cmp(&rdata->msg_info.msg->line.req.method, pjsip_get_notify_method())) == 0))
+  {
+    // Omit the Call-ID for these requests, as the same Call-ID can be
+    // reused over a long period of time and produce huge SAS trails.
+    PJUtils::mark_sas_call_branch_ids(trail(), NULL, rdata->msg_info.msg);
+  }
+  else
+  {
+    PJUtils::mark_sas_call_branch_ids(trail(), rdata->msg_info.cid, rdata->msg_info.msg);
+  }
 }
 
 

--- a/sprout/handlers.cpp
+++ b/sprout/handlers.cpp
@@ -454,7 +454,7 @@ RegStore::AoR* DeregistrationHandler::set_aor_data(RegStore* current_store,
                ++j)
           {
             // LCOV_EXCL_START
-            current_store->send_notify(j->second, aor_data->_notify_cseq, b, b_id);
+            current_store->send_notify(j->second, aor_data->_notify_cseq, b, b_id, trail());
             // LCOV_EXCL_STOP
           }
         }
@@ -532,44 +532,47 @@ HTTPCode AuthTimeoutHandler::handle_response(std::string body)
     return HTTP_BAD_RESULT;
   }
 
-  Json::Value* json = _cfg->_avstore->get_av(_impi, _nonce, trail());
   bool success = false;
-  HTTPCode hss_query = HTTP_OK;
-
-  if (json == NULL)
+  uint64_t cas;
+  Json::Value* av = _cfg->_avstore->get_av(_impi, _nonce, cas, trail());
+  if (av != NULL)
   {
-    // Mainline case - our AV has already been deleted because the
-    // user has tried to authenticate. No need to notify the HSS in
-    // this case (as they'll either have successfully authenticated
-    // and triggered a REGISTRATION SAR, or failed and triggered an
-    // AUTHENTICATION_FAILURE SAR).
-    success = true;
+    // If authentication completed, we'll have written a marker to
+    // indicate that. Look for it.
+    if (!av->isMember("tombstone"))
+    {
+      LOG_DEBUG("AV for %s:%s has timed out", _impi.c_str(), _nonce.c_str());
+
+      // Retrieve the original authentication vector, so we have the
+      // original REGISTER's branch parameter for SAS correlation
+
+      correlate_branch_from_av(av, trail());
+
+      // The AUTHENTICATION_TIMEOUT SAR is idempotent, so there's no
+      // problem if Chronos' timer pops twice (e.g. if we have high
+      // latency and these operations take more than 2 seconds).
+
+      // If either of these operations fail, we return a 500 Internal
+      // Server Error - this will trigger Chronos to try a different
+      // Sprout, which may have better connectivity to Homestead or Memcached.
+      HTTPCode hss_query = _cfg->_hss->update_registration_state(_impu, _impi, HSSConnection::AUTH_TIMEOUT, trail());
+
+      if (hss_query == HTTP_OK)
+      {
+        success = true;
+      }
+    }
+    else
+    {
+      LOG_DEBUG("Tombstone record indicates Authentication Vector has been used successfully - ignoring timer pop");
+      success = true;
+    }
   }
   else
   {
-    LOG_DEBUG("AV for %s:%s has timed out", _impi.c_str(), _nonce.c_str());
-
-    // Note that both AV deletion and the AUTHENTICATION_TIMEOUT SAR
-    // are idempotent, so there's no problem if Chronos' timer pops
-    // twice (e.g. if we have high latency and these operations take
-    // more than 2 seconds).
-
-    // If either of these operations fail, we return a 500 Internal
-    // Server Error - this will trigger Chronos to try a different
-    // Sprout, which may have better connectivity to Homestead or Memcached.
-    hss_query = _cfg->_hss->update_registration_state(_impu, _impi, HSSConnection::AUTH_TIMEOUT, 0);
-
-    if (hss_query == HTTP_OK)
-    {
-      success = _cfg->_avstore->delete_av(_impi, _nonce, trail());
-      if (!success) {
-        LOG_ERROR("Tried to delete AV for %s/%s based on a Chronos timer pop, but failed", _impi.c_str(), _nonce.c_str()); // LCOV_EXCL_LINE
-      }
-
-    }
-
-    delete json;
+    LOG_WARNING("Could not find AV for %s:%s when checking authentication timeout", _impi.c_str(), _nonce.c_str()); // LCOV_EXCL_LINE
   }
+  delete av;
 
   return success ? HTTP_OK : HTTP_SERVER_ERROR;
 }

--- a/sprout/main.cpp
+++ b/sprout/main.cpp
@@ -113,6 +113,7 @@ struct options
   std::string            external_icscf_uri;
   int                    record_routing_model;
   int                    default_session_expires;
+  int                    target_latency_us;
   std::string            local_host;
   std::string            public_host;
   std::string            home_domain;
@@ -175,6 +176,7 @@ struct options
     { "hss",               required_argument, 0, 'H'},
     { "record-routing-model", required_argument, 0, 'C'},
     { "default-session-expires", required_argument, 0, OPT_DEFAULT_SESSION_EXPIRES},
+    { "target-latency-us", required_argument, 0, 'Y'},
     { "xdms",              required_argument, 0, 'X'},
     { "chronos",           required_argument, 0, 'K'},
     { "ralf",              required_argument, 0, 'G'},
@@ -201,7 +203,7 @@ struct options
     { NULL,                0, 0, 0}
   };
 
-static std::string pj_options_description = "p:s:i:l:D:c:C:n:e:I:A:R:M:S:H:T:o:q:X:E:x:f:u:g:r:P:w:a:F:L:K:G:B:dth";
+static std::string pj_options_description = "p:s:i:l:D:c:C:n:e:Y:I:A:R:M:S:H:T:o:q:X:E:x:f:u:g:r:P:w:a:F:L:K:G:B:dth";
 
 static sem_t term_sem;
 
@@ -290,6 +292,8 @@ static void usage(void)
        "                            The maximum allowed registration period (in seconds)\n"
        "     --default-session-expires <expiry>\n"
        "                            The session expiry period to request (in seconds)\n"
+       " -Y, --target-latency-us <usecs>\n"
+       "                            Target latency above which throttling applies (default: 100000)\n"
        " -T  --http_address <server>\n"
        "                            Specify the HTTP bind address\n"
        " -o  --http_port <port>     Specify the HTTP bind port\n"
@@ -645,6 +649,15 @@ static pj_status_t init_options(int argc, char *argv[], struct options *options)
         LOG_WARNING("Invalid value for reg_max_expires: '%s'. "
                     "The default value of %d will be used.",
                     pj_optarg, options->reg_max_expires);
+      }
+      break;
+
+    case 'Y':
+      options->target_latency_us = atoi(pj_optarg);
+      if (options->target_latency_us <= 0)
+      {
+        LOG_ERROR("Invalid --target-latency-us option %s", pj_optarg);
+        return -1;
       }
       break;
 
@@ -1158,7 +1171,10 @@ int main(int argc, char *argv[])
   srand(seed);
 
   // Start the load monitor
-  load_monitor = new LoadMonitor(TARGET_LATENCY, MAX_TOKENS, INITIAL_TOKEN_RATE, MIN_TOKEN_RATE);
+  load_monitor = new LoadMonitor(opt.target_latency_us, // Initial target latency (us).
+                                 MAX_TOKENS,            // Maximum token bucket size.
+                                 INITIAL_TOKEN_RATE,    // Initial token fill rate (per sec).
+                                 MIN_TOKEN_RATE);       // Minimum token fill rate (per sec).
 
   // Create a DNS resolver and a SIP specific resolver.
   dns_resolver = new DnsCachedResolver("127.0.0.1");

--- a/sprout/pjutils.cpp
+++ b/sprout/pjutils.cpp
@@ -939,7 +939,8 @@ static void on_tsx_state(pjsip_transaction* tsx, pjsip_event* event)
 pj_status_t PJUtils::send_request(pjsip_tx_data* tdata,
                                   int retries,
                                   void* token,
-                                  pjsip_endpt_send_callback cb)
+                                  pjsip_endpt_send_callback cb,
+                                  bool log_sas_branch)
 {
   pjsip_transaction* tsx;
   pj_status_t status = PJ_SUCCESS;
@@ -980,7 +981,10 @@ pj_status_t PJUtils::send_request(pjsip_tx_data* tdata,
     {
       // Set the trail ID in the transaction from the message.
       set_trail(tsx, get_trail(tdata));
-
+      if (log_sas_branch)
+      {
+        PJUtils::mark_sas_call_branch_ids(get_trail(tdata), NULL, tdata->msg);
+      }
       // Set up the module data for the new transaction to reference
       // the state information.
       tsx->mod_data[mod_sprout_util.id] = sss;
@@ -1357,6 +1361,7 @@ void PJUtils::mark_sas_call_branch_ids(const SAS::TrailId trail, pjsip_cid_hdr* 
   // If we have a call ID, log it.
   if (cid_hdr != NULL)
   {
+    LOG_DEBUG("Logging SAS Call-ID marker, Call-ID %.*s", cid_hdr->id.slen, cid_hdr->id.ptr);
     SAS::Marker cid_marker(trail, MARKER_ID_SIP_CALL_ID, 1u);
     cid_marker.add_var_param(cid_hdr->id.slen, cid_hdr->id.ptr);
     SAS::report_marker(cid_marker, SAS::Marker::Scope::Trace);
@@ -1379,7 +1384,7 @@ void PJUtils::mark_sas_call_branch_ids(const SAS::TrailId trail, pjsip_cid_hdr* 
 
       // Now see if we can find the next Via header and log it if so.  This will have been added by
       // the previous server.  This means we'll be able to correlate with its trail.
-      pjsip_via_hdr* second_via = (pjsip_via_hdr*)pjsip_msg_find_hdr(msg, PJSIP_H_VIA, top_via);
+      pjsip_via_hdr* second_via = (pjsip_via_hdr*)pjsip_msg_find_hdr(msg, PJSIP_H_VIA, top_via->next);
       if (second_via != NULL)
       {
         SAS::Marker via_marker(trail, MARKER_ID_VIA_BRANCH_PARAM, 2u);

--- a/sprout/registrar.cpp
+++ b/sprout/registrar.cpp
@@ -448,14 +448,15 @@ RegStore::AoR* write_to_store(RegStore* primary_store,       ///<store to write 
 
         pj_status_t status = NotifyUtils::create_notify(&tdata_notify, subscription, aor,
                                                         aor_data->_notify_cseq, bindings_for_notify,
-                                                        NotifyUtils::DocState::PARTIAL, 
+                                                        NotifyUtils::DocState::PARTIAL,
                                                         NotifyUtils::RegistrationState::ACTIVE,
                                                         NotifyUtils::ContactState::ACTIVE, contact_event,
-                                                        NotifyUtils::SubscriptionState::ACTIVE, 
+                                                        NotifyUtils::SubscriptionState::ACTIVE,
                                                         (subscription->_expires - now));
         if (status == PJ_SUCCESS)
         {
-          status = PJUtils::send_request(tdata_notify);
+          set_trail(tdata_notify, trail);
+          status = PJUtils::send_request(tdata_notify, 0, NULL, NULL, true);
         }
       }
     }
@@ -531,7 +532,7 @@ void process_register_request(pjsip_rx_data* rdata)
   calling_dn.add_var_param(calling_uri->user.slen, calling_uri->user.ptr);
   SAS::report_marker(calling_dn);
 
-  PJUtils::mark_sas_call_branch_ids(trail, rdata->msg_info.cid, rdata->msg_info.msg);
+  PJUtils::mark_sas_call_branch_ids(trail, NULL, rdata->msg_info.msg);
 
   // Query the HSS for the associated URIs.
   std::vector<std::string> uris;

--- a/sprout/regstore.cpp
+++ b/sprout/regstore.cpp
@@ -90,7 +90,7 @@ RegStore::AoR* RegStore::get_aor_data(const std::string& aor_id, SAS::TrailId tr
   if (aor_data != NULL)
   {
     int now = time(NULL);
-    expire_bindings(aor_data, now);
+    expire_bindings(aor_data, now, trail);
     expire_subscriptions(aor_data, now);
   }
 
@@ -180,7 +180,7 @@ bool RegStore::set_aor_data(const std::string& aor_id,
   // This prevents a window condition where Chronos can return a binding to
   // expire, but memcached has already deleted the aor data (meaning that
   // no NOTIFYs could be sent)
-  int orig_max_expires = expire_bindings(aor_data, now);
+  int orig_max_expires = expire_bindings(aor_data, now, trail);
   int max_expires = orig_max_expires + 10;
 
   // expire_bindings returns "now" if there are no remaining bindings,
@@ -288,7 +288,8 @@ bool RegStore::Connector::set_aor_data(const std::string& aor_id,
 /// @param aor_data      The registration data record.
 /// @param now           The current time in seconds since the epoch.
 int RegStore::expire_bindings(AoR* aor_data,
-                              int now)
+                              int now,
+                              SAS::TrailId trail)
 {
   int max_expires = now;
   for (AoR::Bindings::iterator i = aor_data->_bindings.begin();
@@ -311,7 +312,7 @@ int RegStore::expire_bindings(AoR* aor_data,
         // Don't send a notification when an emergency registration expires
         if (!b->_emergency_registration)
         {
-          send_notify(j->second, aor_data->_notify_cseq, b, b_id);
+          send_notify(j->second, aor_data->_notify_cseq, b, b_id, trail);
         }
       }
 
@@ -319,7 +320,7 @@ int RegStore::expire_bindings(AoR* aor_data,
       // previous post/put failed) then don't.
       if (b->_timer_id != "")
       {
-        _chronos->send_delete(b->_timer_id, 0);
+        _chronos->send_delete(b->_timer_id, trail);
       }
 
       delete i->second;
@@ -699,22 +700,24 @@ void RegStore::AoR::remove_subscription(const std::string& to_tag)
 }
 
 void RegStore::send_notify(AoR::Subscription* s, int cseq,
-                           AoR::Binding* b, std::string b_id)
+                           AoR::Binding* b, std::string b_id,
+                           SAS::TrailId trail)
 {
   pjsip_tx_data* tdata_notify = NULL;
   std::map<std::string, AoR::Binding> bindings;
   bindings.insert(std::pair<std::string, RegStore::AoR::Binding>(b_id, *b));
   pj_status_t status = NotifyUtils::create_notify(&tdata_notify, s, "aor", cseq, bindings,
-                                  NotifyUtils::DocState::PARTIAL, 
+                                  NotifyUtils::DocState::PARTIAL,
                                   NotifyUtils::RegistrationState::ACTIVE,
-                                  NotifyUtils::ContactState::TERMINATED, 
+                                  NotifyUtils::ContactState::TERMINATED,
                                   NotifyUtils::ContactEvent::EXPIRED,
                                   NotifyUtils::SubscriptionState::ACTIVE,
                                   (s->_expires - time(NULL)));
 
   if (status == PJ_SUCCESS)
   {
-    status = PJUtils::send_request(tdata_notify);
+    set_trail(tdata_notify, trail);
+    status = PJUtils::send_request(tdata_notify, 0, NULL, NULL, true);
   }
 }
 

--- a/sprout/stateful_proxy.cpp
+++ b/sprout/stateful_proxy.cpp
@@ -1815,12 +1815,15 @@ void UASTransaction::proxy_calculate_targets(pjsip_msg* msg,
         _bgcf_acr = bgcf_acr_factory->get_acr(trail,
                                               CALLING_PARTY,
                                               ACR::requested_node_role(msg));
-        if (_downstream_acr != _upstream_acr)
+         
+        if ((_downstream_acr != _upstream_acr) &&
+            (!_as_chain_links.empty()))
         {
           // We've already set up a different downstream ACR to the upstream ACR
-          // so free it off.
+          // and the ASChain hasn't taken ownership of the acr so free it off.
           delete _downstream_acr;
         }
+
         _downstream_acr = _bgcf_acr;
 
         // Pass the request to the downstream ACR as if it is being received.

--- a/sprout/subscription.cpp
+++ b/sprout/subscription.cpp
@@ -266,12 +266,12 @@ pj_status_t write_subscriptions_to_store(RegStore* primary_store,      ///<store
           state = NotifyUtils::SubscriptionState::TERMINATED;
         }
 
-        status = NotifyUtils::create_notify(tdata_notify, subscription, aor, 
+        status = NotifyUtils::create_notify(tdata_notify, subscription, aor,
                                             (*aor_data)->_notify_cseq, bindings,
-                                            NotifyUtils::DocState::FULL, 
+                                            NotifyUtils::DocState::FULL,
                                             NotifyUtils::RegistrationState::ACTIVE,
-                                            NotifyUtils::ContactState::ACTIVE, 
-                                            NotifyUtils::ContactEvent::REGISTERED, 
+                                            NotifyUtils::ContactState::ACTIVE,
+                                            NotifyUtils::ContactEvent::REGISTERED,
                                             state, expiry);
       }
 
@@ -399,7 +399,7 @@ void process_subscription_request(pjsip_rx_data* rdata)
   calling_dn.add_var_param(calling_uri->user.slen, calling_uri->user.ptr);
   SAS::report_marker(calling_dn);
 
-  PJUtils::mark_sas_call_branch_ids(trail, rdata->msg_info.cid, rdata->msg_info.msg);
+  PJUtils::mark_sas_call_branch_ids(trail, NULL, rdata->msg_info.msg);
 
   // Query the HSS for the associated URIs.
   std::vector<std::string> uris;
@@ -536,7 +536,7 @@ void process_subscription_request(pjsip_rx_data* rdata)
   if (tdata_notify != NULL && notify_status == PJ_SUCCESS)
   {
     set_trail(tdata_notify, trail);
-    status = PJUtils::send_request(tdata_notify);
+    status = PJUtils::send_request(tdata_notify, 0, NULL, NULL, true);
 
     if (status != PJ_SUCCESS)
     {

--- a/sprout/ut/fakehssconnection.cpp
+++ b/sprout/ut/fakehssconnection.cpp
@@ -39,7 +39,6 @@
 #include <json/reader.h>
 #include "gtest/gtest.h"
 
-
 FakeHSSConnection::FakeHSSConnection() : HSSConnection("localhost", NULL, NULL, NULL)
 {
 }
@@ -54,6 +53,7 @@ FakeHSSConnection::~FakeHSSConnection()
 void FakeHSSConnection::flush_all()
 {
   _results.clear();
+  _calls.clear();
 }
 
 void FakeHSSConnection::set_result(const std::string& url,
@@ -118,6 +118,7 @@ long FakeHSSConnection::get_json_object(const std::string& path,
                                         Json::Value*& object,
                                         SAS::TrailId trail)
 {
+  _calls.insert(UrlBody(path, ""));
   HTTPCode http_code = HTTP_NOT_FOUND;
 
   std::map<UrlBody, std::string>::const_iterator i = _results.find(UrlBody(path, ""));
@@ -169,6 +170,7 @@ long FakeHSSConnection::get_xml_object(const std::string& path,
                                        rapidxml::xml_document<>*& root,
                                        SAS::TrailId trail)
 {
+  _calls.insert(UrlBody(path, body));
   HTTPCode http_code = HTTP_NOT_FOUND;
 
   std::map<UrlBody, std::string>::const_iterator i = _results.find(UrlBody(path, body));
@@ -210,3 +212,7 @@ long FakeHSSConnection::get_xml_object(const std::string& path,
   return http_code;
 }
 
+bool FakeHSSConnection::url_was_requested(const std::string& url, const std::string& body)
+{
+  return (_calls.find(UrlBody(url, body)) != _calls.end());
+}

--- a/sprout/ut/fakehssconnection.hpp
+++ b/sprout/ut/fakehssconnection.hpp
@@ -36,6 +36,7 @@
 
 #pragma once
 
+#include <set>
 #include <string>
 #include "log.h"
 #include "sas.h"
@@ -55,6 +56,7 @@ public:
   void delete_result(const std::string& url);
   void set_rc(const std::string& url, long rc);
   void delete_rc(const std::string& url);
+  bool url_was_requested(const std::string& url, const std::string& body);
 
 private:
   long get_json_object(const std::string& path, Json::Value*& object, SAS::TrailId trail);
@@ -66,4 +68,5 @@ private:
   typedef std::pair<std::string, std::string> UrlBody;
   std::map<UrlBody, std::string> _results;
   std::map<std::string, long> _rcs;
+  std::set<UrlBody> _calls;
 };


### PR DESCRIPTION
Configuration support for target latency (by specifying override "target_latency_us=<override target latency in usecs>" in /etc/clearwater/config.  Default is 100000, i.e. 100ms).

Tested live, using new logs to verify that values are being passed through to LoadMonitor.

Tested error path on Sprout (and confirmed that error log is made if invalid override value used)