### PR TITLE
Store dialog_id from route hdr on in dialog requests

### DIFF
--- a/include/constants.h
+++ b/include/constants.h
@@ -112,6 +112,7 @@ const pj_str_t STR_XML_PUB_GRUU = pj_str((char*)"gr:pub-gruu");
 const pj_str_t STR_ISUB = pj_str((char*)"isub");
 const pj_str_t STR_EXT = pj_str((char*)"ext");
 const pj_str_t STR_USER_PHONE = pj_str((char*)"phone");
+const pj_str_t STR_DIALOG_ID = pj_str((char*)"dialog_id");
 
 /// Prefix of ODI tokens we generate.
 const pj_str_t STR_ODI_PREFIX = pj_str((char*)"odi_");

--- a/include/sproutletappserver.h
+++ b/include/sproutletappserver.h
@@ -68,6 +68,9 @@ public:
   /// transaction.
   void store_onward_route(pjsip_msg* req);
 
+  /// Stores the dialog_id from the top Route header, if it is present.
+  void store_dialog_id(pjsip_msg* req);
+
   /// Returns a mutable clone of the original request.  This can be modified
   /// and sent by the application using the send_request call.
   ///


### PR DESCRIPTION
Hi Andy,

Please can you review this fix to store off the dialog_id from the top route header on in dialog requests in the SproutletAppServerShimTsx?

This fixes https://github.com/Metaswitch/sprout/issues/813.

There don't appear to be any UTs for this file at the moment - do you know why? Either way, I've live tested by running some calls with memento.

Thanks,
Graeme
