### PR TITLE
[Reviewer Andy] Remove extra Via header when attempting to send to a unresolvable URI

### DIFF
--- a/include/pjutils.h
+++ b/include/pjutils.h
@@ -218,6 +218,8 @@ void clone_header(const pj_str_t* hdr_name, pjsip_msg* old_msg, pjsip_msg* new_m
 
 void add_top_via(pjsip_tx_data* tdata);
 
+void remove_top_via(pjsip_tx_data* tdata);
+
 void add_reason(pjsip_tx_data* tdata, int reason_code);
 
 bool compare_pj_sockaddr(const pj_sockaddr& lhs, const pj_sockaddr& rhs);

--- a/sprout/pjutils.cpp
+++ b/sprout/pjutils.cpp
@@ -1524,6 +1524,16 @@ void PJUtils::add_top_via(pjsip_tx_data* tdata)
   generate_new_branch_id(tdata);
 }
 
+void PJUtils::remove_top_via(pjsip_tx_data* tdata)
+{
+  // Removes the top Via header.
+  pjsip_via_hdr *hvia = (pjsip_via_hdr*)pjsip_msg_find_hdr(tdata->msg, PJSIP_H_VIA, NULL);
+  if (hvia != NULL)
+  {
+    pj_list_erase(hvia);
+  }
+}
+
 void PJUtils::add_reason(pjsip_tx_data* tdata, int reason_code)
 {
   char reason_val_str[100];

--- a/sprout/sproutletproxy.cpp
+++ b/sprout/sproutletproxy.cpp
@@ -762,7 +762,6 @@ void SproutletProxy::UASTsx::schedule_requests()
       // No local Sproutlet, proxy the request.
       LOG_DEBUG("No local sproutlet matches request");
       size_t index;
-      PJUtils::add_top_via(req.req);
 
       pj_status_t status = allocate_uac(req.req, index);
 

--- a/sprout/ut/sproutletproxy_test.cpp
+++ b/sprout/ut/sproutletproxy_test.cpp
@@ -1305,6 +1305,7 @@ TEST_F(SproutletProxyTest, SproutletDelayRedirect)
   delete tp;
 }
 
+
 TEST_F(SproutletProxyTest, SproutletErrors)
 {
   // Tests error handling in SproutletProxy.
@@ -1342,7 +1343,7 @@ TEST_F(SproutletProxyTest, SproutletErrors)
 
 TEST_F(SproutletProxyTest, UnrecognisedSproutlet)
 {
-  // Tests error handling in SproutletProxy.
+  // Tests SproutletProxy handling of requests to an unrecognised sproutlet.
   pjsip_tx_data* tdata;
 
   // Create a TCP connection to the listening port.
@@ -1492,7 +1493,5 @@ TEST_F(SproutletProxyTest, UASError)
   req.clear();
   ASSERT_EQ(0, txdata_count());
 }
-
-
 
 


### PR DESCRIPTION
Andy

Can you review my fix to #794.  The issue explains the exact scenario.  I decided the cleanest fix was to make the UACTsx responsible for removing the extra Via header from the request before reporting errors upstream.  This isn't perfect, but I think it is the best we can do without introducing another clone of the request.

The SproutletProxy.UnrecognisedSproutlet test case already exercised this case, but the response matcher utility in siptest isn't clever enough to spot it, so I've verified the fix by checking trace output.  I've also run all the UTs and the live tests to make sure nothing else has broken.

I also cleaned up when the Via header is added - at the moment it was being done in a couple of places before the UACTsx was created, so I moved it in to the UACTsx::init() routine to make it cleaner.

Mike
