### PR TITLE
[Reviewer Matt] Use local_host domain name in ODI route headers on ISC interface

### DIFF
--- a/include/scscfsproutlet.h
+++ b/include/scscfsproutlet.h
@@ -71,7 +71,8 @@ class SCSCFSproutletTsx;
 class SCSCFSproutlet : public Sproutlet
 {
 public:
-  SCSCFSproutlet(const std::string& scscf_uri,
+  SCSCFSproutlet(const std::string& scscf_cluster_uri,
+                 const std::string& scscf_node_uri,
                  const std::string& icscf_uri,
                  const std::string& bgcf_uri,
                  int port,
@@ -96,8 +97,11 @@ private:
   /// Returns the AS chain table for this system.
   AsChainTable* as_chain_table() const;
 
-  /// Returns the configured S-CSCF URI for this system.
-  const pjsip_uri* scscf_uri() const;
+  /// Returns the configured S-CSCF cluster URI for this system.
+  const pjsip_uri* scscf_cluster_uri() const;
+
+  /// Returns the configured S-CSCF node URI for this system.
+  const pjsip_uri* scscf_node_uri() const;
 
   /// Returns the configured I-CSCF URI for this system.
   const pjsip_uri* icscf_uri() const;
@@ -133,8 +137,18 @@ private:
 
   friend class SCSCFSproutletTsx;
 
-  pjsip_uri* _scscf_uri;
+  /// A URI which routes to the S-CSCF cluster.
+  pjsip_uri* _scscf_cluster_uri;
+
+  /// A URI which routes to this particular S-CSCF node.  This must be
+  /// constructed using an IP address or a domain name which resolves to this
+  /// Sprout node only.
+  pjsip_uri* _scscf_node_uri;
+
+  /// A URI which routes to the URI cluster.
   pjsip_uri* _icscf_uri;
+
+  /// A URI which routes to the BGCF.
   pjsip_uri* _bgcf_uri;
 
   RegStore* _store;

--- a/sprout/scscfplugin.cpp
+++ b/sprout/scscfplugin.cpp
@@ -79,15 +79,19 @@ std::list<Sproutlet*> SCSCFPlugin::load(struct options& opt)
   if (opt.scscf_enabled)
   {
     // Determine the S-CSCF, BGCF and I-CSCF URIs.
-    std::string scscf_uri = std::string(stack_data.scscf_uri.ptr,
-                                        stack_data.scscf_uri.slen);
-    std::string bgcf_uri = "sip:bgcf." + scscf_uri.substr(4);
+    std::string scscf_cluster_uri = std::string(stack_data.scscf_uri.ptr,
+                                                stack_data.scscf_uri.slen);
+    std::string scscf_node_uri = "sip:" +
+                                 std::string(stack_data.local_host.ptr,
+                                             stack_data.local_host.slen) +
+                                 ":" + std::to_string(opt.scscf_port);
+    std::string bgcf_uri = "sip:bgcf." + scscf_cluster_uri.substr(4);
     std::string icscf_uri;
     if (opt.icscf_enabled)
     {
       // Create a local I-CSCF URI by replacing the S-CSCF port number in the
       // S-CSCF URI with the I-CSCF port number.
-      icscf_uri = scscf_uri;
+      icscf_uri = scscf_cluster_uri;
       size_t pos = icscf_uri.find(std::to_string(opt.scscf_port));
 
       if (pos != std::string::npos)
@@ -99,7 +103,7 @@ std::list<Sproutlet*> SCSCFPlugin::load(struct options& opt)
       else
       {
         // No port number, so best we can do is strap icscf. on the front.
-        icscf_uri = "sip:icscf." + scscf_uri.substr(4);
+        icscf_uri = "sip:icscf." + scscf_cluster_uri.substr(4);
       }
     }
     else
@@ -107,7 +111,8 @@ std::list<Sproutlet*> SCSCFPlugin::load(struct options& opt)
       icscf_uri = opt.external_icscf_uri;
     }
 
-    _scscf_sproutlet = new SCSCFSproutlet(scscf_uri,
+    _scscf_sproutlet = new SCSCFSproutlet(scscf_cluster_uri,
+                                          scscf_node_uri,
                                           icscf_uri,
                                           bgcf_uri,
                                           opt.scscf_port,


### PR DESCRIPTION
Matt

Can your review my fix to switch back to using node specific URIs for ODI Route headers (issue #825).  I've tested by
-  fixing up the UTs to test that the headers are set correctly (I had incorrectly changed the UTs when refactoring the code - I think because I was hitting problems with requests getting routed to the S-CSCF Sproutlet because this pre-dated Andy's changes to have a list of alias hosts)
-  running the live tests over the fix and manually verifying the ODI Route headers in traces.

Mike
