### PR TITLE
Make poll_restund only tight-loop for 1s, not forever

### DIFF
--- a/restund.root/usr/share/clearwater/bin/poll_restund.sh
+++ b/restund.root/usr/share/clearwater/bin/poll_restund.sh
@@ -45,6 +45,9 @@ sleep 5
 
 # Send the STUN message.  The nc line also includes checking the first line of the response starts
 # "\x01\x01" - a positive response.
+# The -q option forces netcat to quit after 1 second. This works
+# around a netcat bug where it tight-loops forever if the UDP port
+# it's trying to contact is closed.
 printf '\x00\x01\x00\x00\x21\x12\xa4\x42MonitPollXid' |
 nc -v -C -u -w 2 -q 1 $local_ip 3478 2> /tmp/poll_restund.sh.nc.stderr.$$ | tee /tmp/poll_restund.sh.nc.stdout.$$ | head -1 | grep -U -P -q '^\x01\x01'
 rc=$?


### PR DESCRIPTION
Fixes https://github.com/Metaswitch/sprout/issues/629. (Arguably tight-looping for 1s isn't a "fix", but it substantially improves the situation.)
