### PR TITLE
[Reviewer Andy] Don't crash if ENUM not enabled

### DIFF
--- a/include/icscfsproutlet.h
+++ b/include/icscfsproutlet.h
@@ -99,7 +99,8 @@ private:
     return _user_phone;
   }
 
-  std::string enum_translate_tel_uri(pjsip_msg* req, SAS::TrailId trail);
+  /// Attempts to use ENUM to translate the specified Tel URI into a SIP URI.
+  std::string enum_translate_tel_uri(pjsip_tel_uri* uri, SAS::TrailId trail);
 
   /// Get an ACR instance from the factory.
   /// @param trail                SAS trail identifier to use for the ACR.

--- a/sprout/icscfsproutlet.cpp
+++ b/sprout/icscfsproutlet.cpp
@@ -109,14 +109,14 @@ ACR* ICSCFSproutlet::get_acr(SAS::TrailId trail)
 }
 
 /// Translates a Tel URI to a SIP URI (if ENUM is enabled).
-std::string ICSCFSproutlet::enum_translate_tel_uri(pjsip_msg* req, SAS::TrailId trail)
+std::string ICSCFSproutlet::enum_translate_tel_uri(pjsip_tel_uri* uri,
+                                                   SAS::TrailId trail)
 {
   std::string new_uri;
   if (_enum_service != NULL)
   {
     // ENUM is enabled, so extract the user name from the Request-URI.
-    std::string user =
-         PJUtils::pj_str_to_string(&((pjsip_tel_uri*)req->line.req.uri)->number);
+    std::string user = PJUtils::pj_str_to_string(&uri->number);
 
     // If we're enforcing global only lookups then check we have a global user.
     if ((!_global_only_lookups) ||
@@ -683,7 +683,8 @@ void ICSCFSproutletTsx::on_cancel(int status_code, pjsip_msg* cancel_req)
 bool ICSCFSproutletTsx::translate_tel_uri(pjsip_msg* req, pj_pool_t* pool)
 {
   bool found = false;
-  std::string new_uri = _icscf->enum_translate_tel_uri(req, trail());
+  std::string new_uri =
+    _icscf->enum_translate_tel_uri((pjsip_tel_uri*)req->line.req.uri, trail());
 
   if (!new_uri.empty())
   {


### PR DESCRIPTION
Andy

Can you review my fix to the I-CSCF crash when ENUM isn't enabled.  I refactored the code slightly to move a chunk of processing in to the ICSCFSproutlet (from the ICSCFSproutletTsx) to neaten it up a bit.

All the UTs pass, but I haven't added a specific test case as it would be a chunk of work in the infrastructure.

Mike
