### PR TITLE
[Reviewer: Mike] Only allow call diversion to trigger once per invocation

### DIFF
--- a/include/mmtel.h
+++ b/include/mmtel.h
@@ -124,7 +124,7 @@ private:
   unsigned int _media_conditions;
   int _late_redirect_fork_id;
   TimerID _no_reply_timer;
-  std::unordered_set<std::string> _cdiv_targets;
+  bool _diverted;
 
   pjsip_status_code apply_ob_call_barring(pjsip_msg* req);
   pjsip_status_code apply_ib_call_barring(pjsip_msg* req);


### PR DESCRIPTION
Mike,

Please can you review my change to fix #879?  As discussed, I've changed the AS to only trigger once per invocation - in particular, if a call is diverted and then the no-answer timer pops, this is ignored (in fact, we cancel it at the point we forward).

I've manually live-tested.

Matt
