### PR TITLE
Reviewer Mike - Handle --target-latency-us in main.cpp and thus fix Bono load monitoring

### DIFF
--- a/debian/bono.init.d
+++ b/debian/bono.init.d
@@ -119,6 +119,7 @@ get_settings()
 
         [ -z "$ralf_hostname" ] || ralf_arg="--ralf $ralf_hostname"
         [ -z "$billing_cdf" ] || billing_cdf_arg="--billing-cdf $billing_cdf"
+        [ -z "$target_latency_us" ] || target_latency_us_arg="--target-latency-us=$target_latency_us"
         [ -z "$signaling_namespace" ] || namespace_prefix="ip netns exec $signaling_namespace"
 }
 
@@ -156,6 +157,7 @@ do_start()
                      -a $log_directory
                      -F $log_directory
                      -L $log_level
+                     $target_latency_us_arg
                      $ibcf_arg
                      $billing_cdf_arg"
 

--- a/sprout-base.root/etc/init.d/sprout
+++ b/sprout-base.root/etc/init.d/sprout
@@ -84,7 +84,6 @@ get_settings()
         sas_server=0.0.0.0
         sprout_rr_level="pcscf"
         scscf=5054
-        target_latency_us=100000
         alias_list=""
         default_session_expires=600
         signaling_dns_server=127.0.0.1
@@ -146,6 +145,8 @@ get_settings()
           alarms_enabled_arg="--alarms-enabled"
         fi
 
+        [ -z "$target_latency_us" ] || target_latency_us_arg="--target-latency-us=$target_latency_us"
+
         [ -z "$signaling_namespace" ] || namespace_prefix="ip netns exec $signaling_namespace"
 }
 
@@ -188,7 +189,7 @@ do_start()
                      --worker-threads=$num_worker_threads
                      --record-routing-model=$sprout_rr_level
                      --default-session-expires=$default_session_expires
-                     --target-latency-us=$target_latency_us
+                     $target_latency_us_arg
                      $authentication_arg
                      $user_phone_arg
                      $global_only_lookups_arg

--- a/sprout/main.cpp
+++ b/sprout/main.cpp
@@ -104,7 +104,8 @@ enum OptionTypes
   OPT_MEMENTO_THREADS,
   OPT_CALL_LIST_TTL,
   OPT_ALARMS_ENABLED,
-  OPT_DNS_SERVER
+  OPT_DNS_SERVER,
+  OPT_TARGET_LATENCY_US
 };
 
 
@@ -130,7 +131,7 @@ const static struct pj_getopt_option long_opt[] =
   { "hss",               required_argument, 0, 'H'},
   { "record-routing-model", required_argument, 0, 'C'},
   { "default-session-expires", required_argument, 0, OPT_DEFAULT_SESSION_EXPIRES},
-  { "target-latency-us", required_argument, 0, 'Y'},
+  { "target-latency-us", required_argument, 0, OPT_TARGET_LATENCY_US},
   { "xdms",              required_argument, 0, 'X'},
   { "chronos",           required_argument, 0, 'K'},
   { "ralf",              required_argument, 0, 'G'},
@@ -163,7 +164,7 @@ const static struct pj_getopt_option long_opt[] =
   { NULL,                0, 0, 0}
 };
 
-static std::string pj_options_description = "p:s:i:l:D:c:C:n:e:Y:I:A:R:M:S:H:T:o:q:X:E:x:f:u:g:r:P:w:a:F:L:K:G:B:dth";
+static std::string pj_options_description = "p:s:i:l:D:c:C:n:e:I:A:R:M:S:H:T:o:q:X:E:x:f:u:g:r:P:w:a:F:L:K:G:B:dth";
 
 static sem_t term_sem;
 
@@ -255,7 +256,7 @@ static void usage(void)
        "                            The maximum allowed subscription period (in seconds)\n"
        "     --default-session-expires <expiry>\n"
        "                            The session expiry period to request (in seconds)\n"
-       " -Y, --target-latency-us <usecs>\n"
+       "     --target-latency-us <usecs>\n"
        "                            Target latency above which throttling applies (default: 100000)\n"
        " -T  --http_address <server>\n"
        "                            Specify the HTTP bind address\n"
@@ -641,7 +642,7 @@ static pj_status_t init_options(int argc, char* argv[], struct options* options)
       }
       break;
 
-    case 'Y':
+    case OPT_TARGET_LATENCY_US:
       options->target_latency_us = atoi(pj_optarg);
       if (options->target_latency_us <= 0)
       {
@@ -1046,6 +1047,7 @@ int main(int argc, char* argv[])
   opt.memento_threads = 25;
   opt.call_list_ttl = 604800;
   opt.alarms_enabled = PJ_FALSE;
+  opt.target_latency_us = 100000;
   opt.log_to_file = PJ_FALSE;
   opt.log_level = 0;
   opt.daemon = PJ_FALSE;


### PR DESCRIPTION
#890 broke bono's load monitoring since the `init.d` script didn't pass the `--target-latency-us`.  This fixes that and moves the defaulting code into `main.cpp` to make it easier to run sprout/bono directly from the command line if desired.
