### PR TITLE
Reviewer RKD: [DO NOT MERGE] Escape necessary fields in reg-event XML

### DIFF
--- a/include/regstore.h
+++ b/include/regstore.h
@@ -114,7 +114,7 @@ public:
       bool _emergency_registration;
 
       pjsip_sip_uri* pub_gruu(pj_pool_t* pool) const;
-      pj_str_t pub_gruu_pj_str(pj_pool_t* pool) const;
+      std::string pub_gruu_str(pj_pool_t* pool) const;
       std::string pub_gruu_quoted_string(pj_pool_t* pool) const;
     };
 

--- a/sprout/regstore.cpp
+++ b/sprout/regstore.cpp
@@ -687,34 +687,23 @@ pjsip_sip_uri* RegStore::AoR::Binding::pub_gruu(pj_pool_t* pool) const
 
 // Utility method to return the public GRUU as a string.
 // Returns "" if this binding has no GRUU.
-pj_str_t RegStore::AoR::Binding::pub_gruu_pj_str(pj_pool_t* pool) const
+std::string RegStore::AoR::Binding::pub_gruu_str(pj_pool_t* pool) const
 {
   pjsip_sip_uri* pub_gruu_uri = pub_gruu(pool);
 
   if (pub_gruu_uri == NULL)
   {
-    return pj_str("");
+    return "";
   }
 
-  return PJUtils::uri_to_pj_str(PJSIP_URI_IN_REQ_URI, (pjsip_uri*)pub_gruu_uri, pool);
+  return PJUtils::uri_to_string(PJSIP_URI_IN_REQ_URI, (pjsip_uri*)pub_gruu_uri);
 }
 
 // Utility method to return the public GRUU surrounded by quotes.
 // Returns "" if this binding has no GRUU.
 std::string RegStore::AoR::Binding::pub_gruu_quoted_string(pj_pool_t* pool) const
 {
-  pj_str_t unquoted_pub_gruu = pub_gruu_pj_str(pool);
-
-  if (unquoted_pub_gruu.slen == 0)
-  {
-    return "";
-  }
-
-  std::string ret;
-  ret.reserve(unquoted_pub_gruu.slen + 2);
-  ret.append("\"");
-  ret.append(unquoted_pub_gruu.ptr, unquoted_pub_gruu.slen);
-  ret.append("\"");
+  std::string ret = "\"" + pub_gruu_str(pool) + "\"";
   return ret;
 }
 

--- a/sprout/regstore.cpp
+++ b/sprout/regstore.cpp
@@ -703,7 +703,14 @@ std::string RegStore::AoR::Binding::pub_gruu_str(pj_pool_t* pool) const
 // Returns "" if this binding has no GRUU.
 std::string RegStore::AoR::Binding::pub_gruu_quoted_string(pj_pool_t* pool) const
 {
-  std::string ret = "\"" + pub_gruu_str(pool) + "\"";
+  std::string unquoted_pub_gruu = pub_gruu_str(pool);
+
+  if (unquoted_pub_gruu.length() == 0)
+  {
+    return "";
+  }
+
+  std::string ret = "\"" + unquoted_pub_gruu + "\"";
   return ret;
 }
 

--- a/sprout/ut/subscription_test.cpp
+++ b/sprout/ut/subscription_test.cpp
@@ -508,7 +508,7 @@ TEST_F(SubscriptionTest, NoNotificationsForEmergencyRegistrations)
   char buf[16384];
   int n = out->body->print_body(out->body, buf, sizeof(buf));
   string body(buf, n);
-  EXPECT_THAT(body, HasSubstr("<sip:6505550231@192.91.191.29:59934;transport=tcp;ob>"));
+  EXPECT_THAT(body, HasSubstr("&lt;sip:6505550231@192.91.191.29:59934;transport=tcp;ob&gt;"));
   EXPECT_THAT(body, Not(HasSubstr("sos")));
   inject_msg(respond_to_current_txdata(200));
 


### PR DESCRIPTION
Hi Rob,

Please can you review my changes to escape characters correctly in our XML that we build for the NOTIFY reg-event package? This fixes https://github.com/Metaswitch/sprout/issues/749.

I've also changed the pub_gruu_pj_str method to be pub_gruu_str method since it only seemed to be return a pj_str for the purpose of building this xml, and I now want it in std::string form first. I hope this will become clear when you look at the code, and I hope this is sensible.

I think I'm escaping all the necessary fields, and no unnecessary fields. I've been using the following website to help - http://www.in2eps.com/fo-abnf/tk-fo-abnf-siprules.html.

Testing wise, all I've done is run the existing UTs. I had to fix up one UT that was expecting unescaped '<' and '>'. Otherwise, the xml_escape method has its own UTs so I deemed that sufficient.

I won't merge until after the release has been cut now.

Thanks,
Graeme