### PR TITLE
[Reviewer: Ellie] Exception handling: health-checker code

### DIFF
--- a/include/common_sip_processing.h
+++ b/include/common_sip_processing.h
@@ -52,11 +52,13 @@ extern "C" {
 
 #include "load_monitor.h"
 #include "counter.h"
+#include "health_checker.h"
 
 pj_status_t
 init_common_sip_processing(LoadMonitor* load_monitor_arg,
                            Counter* requests_counter_arg,
-                           Counter* overload_counter_arg);
+                           Counter* overload_counter_arg,
+                           HealthChecker* health_checker_arg);
 
 void unregister_common_processing_module(void);
 

--- a/sprout/common_sip_processing.cpp
+++ b/sprout/common_sip_processing.cpp
@@ -373,8 +373,8 @@ static pj_status_t process_on_tx_msg(pjsip_tx_data* tdata)
 
 pj_status_t
 init_common_sip_processing(LoadMonitor* load_monitor_arg,
-			   Counter* requests_counter_arg,
-			   Counter* overload_counter_arg,
+                           Counter* requests_counter_arg,
+                           Counter* overload_counter_arg,
                            HealthChecker* health_checker_arg)
 {
   // Register the stack modules.

--- a/sprout/main.cpp
+++ b/sprout/main.cpp
@@ -1718,9 +1718,10 @@ int main(int argc, char* argv[])
                            stack_data.stats_aggregator);
   HealthChecker* health_checker = new HealthChecker();
   pthread_t health_check_thread;
-  pthread_attr_t health_check_attr;
-  pthread_attr_init(&health_check_attr);
-  pthread_create(&health_check_thread, &health_check_attr, &HealthChecker::static_main_thread_function, (void*)health_checker);
+  pthread_create(&health_check_thread,
+                 NULL,
+                 &HealthChecker::static_main_thread_function,
+                 (void*)health_checker);
 
   
   init_common_sip_processing(load_monitor,

--- a/sprout/main.cpp
+++ b/sprout/main.cpp
@@ -1716,11 +1716,17 @@ int main(int argc, char* argv[])
   Counter* overload_counter =
       new StatisticCounter("rejected_overload",
                            stack_data.stats_aggregator);
+  HealthChecker* health_checker = new HealthChecker();
+  pthread_t health_check_thread;
+  pthread_attr_t health_check_attr;
+  pthread_attr_init(&health_check_attr);
+  pthread_create(&health_check_thread, &health_check_attr, &HealthChecker::main_thread_function, (void*)health_checker);
 
-
+  
   init_common_sip_processing(load_monitor,
                              requests_counter,
-                             overload_counter);
+                             overload_counter,
+                             health_checker);
   init_thread_dispatcher(opt.worker_threads,
                          latency_accumulator,
                          queue_size_accumulator,
@@ -1883,6 +1889,7 @@ int main(int argc, char* argv[])
   delete queue_size_accumulator;
   delete requests_counter;
   delete overload_counter;
+  delete health_checker;
   
   // Unregister the handlers that use semaphores (so we can safely destroy
   // them).

--- a/sprout/main.cpp
+++ b/sprout/main.cpp
@@ -1720,7 +1720,7 @@ int main(int argc, char* argv[])
   pthread_t health_check_thread;
   pthread_attr_t health_check_attr;
   pthread_attr_init(&health_check_attr);
-  pthread_create(&health_check_thread, &health_check_attr, &HealthChecker::main_thread_function, (void*)health_checker);
+  pthread_create(&health_check_thread, &health_check_attr, &HealthChecker::static_main_thread_function, (void*)health_checker);
 
   
   init_common_sip_processing(load_monitor,
@@ -1889,6 +1889,10 @@ int main(int argc, char* argv[])
   delete queue_size_accumulator;
   delete requests_counter;
   delete overload_counter;
+  health_checker->terminate();
+
+  pthread_join(health_check_thread, NULL);
+
   delete health_checker;
   
   // Unregister the handlers that use semaphores (so we can safely destroy

--- a/sprout/sprout_base.mk
+++ b/sprout/sprout_base.mk
@@ -58,7 +58,8 @@ TARGET_SOURCES := logger.cpp \
                   counter.cpp \
                   basicproxy.cpp \
                   acr.cpp \
-                  signalhandler.cpp	\
+                  signalhandler.cpp \
+		  health_checker.cpp \
                   subscription.cpp \
                   notify_utils.cpp \
                   unique.cpp \

--- a/sprout/sprout_base.mk
+++ b/sprout/sprout_base.mk
@@ -59,7 +59,7 @@ TARGET_SOURCES := logger.cpp \
                   basicproxy.cpp \
                   acr.cpp \
                   signalhandler.cpp \
-		  health_checker.cpp \
+                  health_checker.cpp \
                   subscription.cpp \
                   notify_utils.cpp \
                   unique.cpp \

--- a/sprout/sprout_test.mk
+++ b/sprout/sprout_test.mk
@@ -63,6 +63,7 @@ TARGET_SOURCES := logger.cpp \
                   scscfselector.cpp \
                   acr.cpp \
                   signalhandler.cpp \
+                  health_checker.cpp \
                   subscription.cpp \
                   notify_utils.cpp \
                   unique.cpp \

--- a/sprout/ut/common_sip_processing_test.cpp
+++ b/sprout/ut/common_sip_processing_test.cpp
@@ -450,6 +450,7 @@ TEST_F(CommonProcessingTest, BadResponseDropped)
 // then Sprout should be aborted.
 TEST_F(CommonProcessingTest, DeathTest_MissingResponseFailsHealthCheck)
 {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   _health_checker->hit_exception();
 
   // Inject a message.
@@ -510,6 +511,7 @@ TEST_F(CommonProcessingTest, Invite200PassesHealthCheck)
 // then Sprout should be aborted.
 TEST_F(CommonProcessingTest, DeathTest_Invite400FailsHealthCheck)
 {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   _health_checker->hit_exception();
 
   pjsip_endpt_register_module(stack_data.endpt, &mod_reject);
@@ -532,6 +534,7 @@ TEST_F(CommonProcessingTest, DeathTest_Invite400FailsHealthCheck)
 // then Sprout should be aborted.
 TEST_F(CommonProcessingTest, DeathTest_Message200FailsHealthCheck)
 {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
   _health_checker->hit_exception();
 
   pjsip_endpt_register_module(stack_data.endpt, &mod_ok);

--- a/sprout/ut/common_sip_processing_test.cpp
+++ b/sprout/ut/common_sip_processing_test.cpp
@@ -92,7 +92,9 @@ public:
     _overload_counter = new StatisticCounter("rejected_overload",
                                              stack_data.stats_aggregator);
 
-    init_common_sip_processing(_lm, _requests_counter, _overload_counter);
+    _health_checker = new HealthChecker();
+
+    init_common_sip_processing(_lm, _requests_counter, _overload_counter, _health_checker);
   }
 
   ~CommonProcessingTest()
@@ -101,6 +103,7 @@ public:
     delete(_lm);
     delete(_requests_counter);
     delete(_overload_counter);
+    delete(_health_checker);
     unregister_common_processing_module();
     pjsip_tsx_layer_dump(true);
 
@@ -277,7 +280,80 @@ protected:
   LoadMonitor* _lm;
   StatisticCounter* _requests_counter;
   StatisticCounter* _overload_counter;
+  HealthChecker* _health_checker;
 };
+
+// Helper PJSIP modules which return a response that goes back through
+// common_sip_processing code.
+
+static pj_bool_t always_ok(pjsip_rx_data* rdata)
+{
+  pjsip_tx_data *tdata;
+  pjsip_response_addr res_addr;
+  pj_str_t string;
+  pj_cstr(&string, "OK"),
+  pjsip_endpt_create_tdata(stack_data.endpt, &tdata);
+  pjsip_get_response_addr(tdata->pool, rdata, &res_addr);
+  pjsip_endpt_create_response(stack_data.endpt,
+                              rdata,
+                              PJSIP_SC_OK,
+                              &string,
+                              &tdata);
+  pjsip_endpt_send_response(stack_data.endpt, &res_addr, tdata, NULL, NULL);
+  return PJ_TRUE;
+}
+
+static pj_bool_t always_reject(pjsip_rx_data* rdata)
+{
+  pjsip_tx_data *tdata;
+  pjsip_response_addr res_addr;
+  pj_str_t string;
+  pj_cstr(&string, "Bad Request"),
+  pjsip_endpt_create_tdata(stack_data.endpt, &tdata);
+  pjsip_get_response_addr(tdata->pool, rdata, &res_addr);
+  pjsip_endpt_create_response(stack_data.endpt,
+                              rdata,
+                              PJSIP_SC_BAD_REQUEST,
+                              &string,
+                              &tdata);
+  pjsip_endpt_send_response(stack_data.endpt, &res_addr, tdata, NULL, NULL);
+  return PJ_TRUE;
+}
+
+static pjsip_module mod_ok =
+{
+  NULL, NULL,                           /* prev, next.          */
+  pj_str("mod-ok"),      /* Name.                */
+  -1,                                   /* Id                   */
+  PJSIP_MOD_PRIORITY_UA_PROXY_LAYER, /* Priority             */
+  NULL,                                 /* load()               */
+  NULL,                                 /* start()              */
+  NULL,                                 /* stop()               */
+  NULL,                                 /* unload()             */
+  &always_ok,                   /* on_rx_request()      */
+  NULL,                   /* on_rx_response()     */
+  NULL,                   /* on_tx_request()      */
+  NULL,                   /* on_tx_response()     */
+  NULL,                                 /* on_tsx_state()       */
+};
+
+static pjsip_module mod_reject =
+{
+  NULL, NULL,                           /* prev, next.          */
+  pj_str("mod-reject"),      /* Name.                */
+  -1,                                   /* Id                   */
+  PJSIP_MOD_PRIORITY_UA_PROXY_LAYER, /* Priority             */
+  NULL,                                 /* load()               */
+  NULL,                                 /* start()              */
+  NULL,                                 /* stop()               */
+  NULL,                                 /* unload()             */
+  &always_reject,                   /* on_rx_request()      */
+  NULL,                   /* on_rx_response()     */
+  NULL,                   /* on_tx_request()      */
+  NULL,                   /* on_tx_response()     */
+  NULL,                                 /* on_tsx_state()       */
+};
+
 
 TEST_F(CommonProcessingTest, RequestAllowed)
 {
@@ -365,4 +441,109 @@ TEST_F(CommonProcessingTest, BadResponseDropped)
 
   // Expect it to just vanish.
   ASSERT_EQ(0, txdata_count());
+}
+
+// If:
+//  - an exception has already been hit
+//  - the health-checker runs a check
+//  - and all the requests seen recently have not had a response
+// then Sprout should be aborted.
+TEST_F(CommonProcessingTest, DeathTest_MissingResponseFailsHealthCheck)
+{
+  _health_checker->hit_exception();
+
+  // Inject a message.
+  Message msg1;
+  inject_msg(msg1.get_request(), _tp);
+
+  // Expect it to just vanish.
+  ASSERT_EQ(0, txdata_count());
+
+  ASSERT_DEATH(_health_checker->do_check(), "Health check failed");
+}
+
+// If:
+//  - the health-checker runs a check
+//  - and all the requests seen recently have not had a response
+//  - but an exception has not already been hit
+// then Sprout should not be aborted.
+TEST_F(CommonProcessingTest, MissingResponseWithoutExceptionPassesHealthCheck)
+{
+  // Inject a message.
+  Message msg1;
+  inject_msg(msg1.get_request(), _tp);
+
+  // Expect it to just vanish.
+  ASSERT_EQ(0, txdata_count());
+
+  // This should not crash
+  _health_checker->do_check();
+}
+
+// If:
+//  - an exception has already been hit
+//  - the health-checker runs a check
+//  - and one of the INVITE requests seen recently had a 200 OK response
+// then Sprout should not be aborted.
+TEST_F(CommonProcessingTest, Invite200PassesHealthCheck)
+{
+  _health_checker->hit_exception();
+
+  pjsip_endpt_register_module(stack_data.endpt, &mod_ok);
+
+  // Inject a message.
+  Message msg1;
+  inject_msg(msg1.get_request(), _tp);
+
+  // Expect a response from mod_ok.
+  ASSERT_EQ(1, txdata_count());
+
+  // This should not crash
+  _health_checker->do_check();
+  pjsip_endpt_unregister_module(stack_data.endpt, &mod_ok);
+}
+
+// If:
+//  - an exception has already been hit
+//  - the health-checker runs a check
+//  - and all of the INVITE requests seen recently had a 400 response
+// then Sprout should be aborted.
+TEST_F(CommonProcessingTest, DeathTest_Invite400FailsHealthCheck)
+{
+  _health_checker->hit_exception();
+
+  pjsip_endpt_register_module(stack_data.endpt, &mod_reject);
+
+  // Inject a message.
+  Message msg1;
+  inject_msg(msg1.get_request(), _tp);
+
+  // Expect a response from mod_reject.
+  ASSERT_EQ(1, txdata_count());
+
+  ASSERT_DEATH(_health_checker->do_check(), "Health check failed");
+  pjsip_endpt_unregister_module(stack_data.endpt, &mod_reject);
+}
+
+// If:
+//  - an exception has already been hit
+//  - the health-checker runs a check
+//  - and no INVITE requests have been seen recently
+// then Sprout should be aborted.
+TEST_F(CommonProcessingTest, DeathTest_Message200FailsHealthCheck)
+{
+  _health_checker->hit_exception();
+
+  pjsip_endpt_register_module(stack_data.endpt, &mod_ok);
+
+  // Inject a message.
+  Message msg1;
+  msg1._method = "MESSAGE";
+  inject_msg(msg1.get_request(), _tp);
+
+  // Expect a response from mod_ok.
+  ASSERT_EQ(1, txdata_count());
+
+  ASSERT_DEATH(_health_checker->do_check(), "Health check failed");
+  pjsip_endpt_unregister_module(stack_data.endpt, &mod_ok);
 }


### PR DESCRIPTION
This integrates https://github.com/Metaswitch/cpp-common/pull/241 with Sprout. As we agreed, I've just made any INVITE/200 pass health-checking for simplicity; I haven't done anything to ignore I-CSCF 200 OKs if we have an S-CSCF. I've updated my copy of the spec to say so - I'll send that to you for a quick review once I've implemented the Homestead/Chronos/Ralf code, in case implementing those leads to any spec changes.

I've tested:
* pretty extensively in UT (see below)
* live, by checking for the `19-02-2015 17:08:06.773 UTC Debug health_checker.cpp:68: Check for overall system health passed - not aborting` log in Sprout

