### PR TITLE
[Reviewer: Ellie] Fix segfault on quiescing

### DIFF
--- a/sprout/quiescing_manager.cpp
+++ b/sprout/quiescing_manager.cpp
@@ -158,6 +158,11 @@ void QuiescingManager::process_input(int input)
          (_state == STATE_QUIESCED));
   // LCOV_EXCL_STOP
 
+  LOG_DEBUG("The Quiescing Manager received input %s (%d) "
+            "when in state %s (%d)",
+            INPUT_NAMES[input], input,
+            STATE_NAMES[_state], _state);  
+  
   switch (_state)
   {
     case STATE_ACTIVE:
@@ -305,11 +310,13 @@ void QuiescingManager::quiesce_connections()
     // Close the trusted listening port.  This prevents any new connections from
     // being established (note that on an edge proxy we should already have
     // closed the untrusted listening port).
+    LOG_DEBUG("Closing trusted port");
     _conns_handler->close_trusted_port();
 
     // Quiesce open connections.  This will close them when they no longer have
     // any outstanding transactions.  When this process has completed the
     // connection tracker will call connections_gone().
+    LOG_DEBUG("Quiescing all connections");
     _conns_handler->quiesce();
   }
 }


### PR DESCRIPTION
Fixes #853 .

There are three things I've done here:
* moved the creation of quiesce_unquiesce_thread down, so that we don't call pj_thread_register before the main thread calls pj_init
* called pj_bzero on the pj_thread_desc objects, to remove an uninitialised variable warning from valgrind
* added more debug logs around the QuiescingManager

I've tested live, by sending the QUIT signal to a Sprout (which reliably crashed before this change).