### PR TITLE
Reviewer MIRW: Mangelwurzel leaves the Req URI alone on in dialog requests

### DIFF
--- a/docs/Mangelwurzel.md
+++ b/docs/Mangelwurzel.md
@@ -11,8 +11,7 @@ Mangelwurzel is installed on top of sprout-base. It can be installed through the
 Mangelwurzel is invoked and configured through iFCs. The URI must contain mangelwurzel (and must obviously be routable to the mangelwurzel node). Typically it would be either sip:mangelwurzel.homedomain or sip:mangelwurzel@<mangelwurzel_addr>. There are also a number of optional parameters encoded on the URI which define mangelwurzel's configuration. They are as follows:
 
 * dialog – Present if the dialog identifiers (From tag, To tag and call ID) should be changed.
-* req-uri – Present if the Request URI of this request should be changed.
-* contact – Present if the Contact header for this request should be changed.
+* req-uri – Present if the Request URI (and Contact URI) of this request should be changed.
 * to – Present if the To header of this request should be changed.
 * routes – Present if the route set of this request should be changed.
 * mangalgorithm – Specifies the algorithm to use for URI manipulation. Takes values of rot13 or reverse.

--- a/include/mangelwurzel/mangelwurzel.h
+++ b/include/mangelwurzel/mangelwurzel.h
@@ -90,7 +90,6 @@ public:
     Config() :
       dialog(false),
       req_uri(false),
-      contact(false),
       to(false),
       change_domain(false),
       routes(false),
@@ -104,12 +103,9 @@ public:
     /// Whether or not to mangle the dialog identifiers on messages.
     bool dialog;
 
-    /// Whether or not to mangle the Request URI on requests (and the Contact
-    /// header on responses).
+    /// Whether or not to mangle the Request URI and Contact URI on requests
+    /// (and the Contact URI on responses).
     bool req_uri;
-
-    /// Whether or not to mangle the Contact URI on requests.
-    bool contact;
 
     /// Whether or not to mangle the To URI on requests.
     bool to;

--- a/sprout/mangelwurzel/mangelwurzel.cpp
+++ b/sprout/mangelwurzel/mangelwurzel.cpp
@@ -237,7 +237,6 @@ void MangelwurzelTsx::on_rx_response(pjsip_msg* rsp, int fork_id)
 /// headers and send the request on. It can also change the request in various
 /// ways depending on the configuration in its Route header.
 /// - It can mangle the dialog identifiers using its mangalgorithm.
-/// - It can mangle the Request URI using its mangalgorithm.
 /// - It can mangle the Contact URI using its mangalgorithm.
 /// - It can mangle the To URI using its mangalgorithm.
 /// - It can edit the S-CSCF Route header to turn the request into either an
@@ -262,11 +261,6 @@ void MangelwurzelTsx::on_rx_in_dialog_request(pjsip_msg* req)
   if (_config.dialog)
   {
     mangle_dialog_identifiers(req, pool);
-  }
-
-  if (_config.req_uri)
-  {
-    mangle_req_uri(req, pool);
   }
 
   if (_config.contact)

--- a/sprout/mangelwurzel/mangelwurzel.cpp
+++ b/sprout/mangelwurzel/mangelwurzel.cpp
@@ -47,7 +47,6 @@
 /// Mangelwurzel URI parameter constants.
 static const pj_str_t DIALOG_PARAM = pj_str((char *)"dialog");
 static const pj_str_t REQ_URI_PARAM = pj_str((char *)"req-uri");
-static const pj_str_t CONTACT_PARAM = pj_str((char *)"contact");
 static const pj_str_t TO_PARAM = pj_str((char *)"to");
 static const pj_str_t ROUTES_PARAM = pj_str((char *)"routes");
 static const pj_str_t DOMAIN_PARAM = pj_str((char *)"change-domain");
@@ -79,10 +78,6 @@ SproutletTsx* Mangelwurzel::get_tsx(SproutletTsxHelper* helper,
     if (pjsip_param_find(&route_hdr_uri->other_param, &REQ_URI_PARAM) != NULL)
     {
       config.req_uri = true;
-    }
-    if (pjsip_param_find(&route_hdr_uri->other_param, &CONTACT_PARAM) != NULL)
-    {
-      config.contact = true;
     }
     if (pjsip_param_find(&route_hdr_uri->other_param, &TO_PARAM) != NULL)
     {
@@ -143,8 +138,7 @@ SproutletTsx* Mangelwurzel::get_tsx(SproutletTsxHelper* helper,
 /// the request in various ways depending on the configuration in its Route
 /// header.
 /// - It can mangle the dialog identifiers using its mangalgorithm.
-/// - It can mangle the Request URI using its mangalgorithm.
-/// - It can mangle the Contact URI using its mangalgorithm.
+/// - It can mangle the Request URI and Contact URI using its mangalgorithm.
 /// - It can mangle the To URI using its mangalgorithm.
 /// - It can edit the S-CSCF Route header to turn the request into either an
 ///   originating or terminating request.
@@ -175,10 +169,6 @@ void MangelwurzelTsx::on_rx_initial_request(pjsip_msg* req)
   if (_config.req_uri)
   {
     mangle_req_uri(req, pool);
-  }
-
-  if (_config.contact)
-  {
     mangle_contact(req, pool);
   }
 
@@ -237,7 +227,7 @@ void MangelwurzelTsx::on_rx_response(pjsip_msg* rsp, int fork_id)
 /// headers and send the request on. It can also change the request in various
 /// ways depending on the configuration in its Route header.
 /// - It can mangle the dialog identifiers using its mangalgorithm.
-/// - It can mangle the Contact URI using its mangalgorithm.
+/// - It can mangle the Request URI and Contact URI using its mangalgorithm.
 /// - It can mangle the To URI using its mangalgorithm.
 /// - It can edit the S-CSCF Route header to turn the request into either an
 ///   originating or terminating request.
@@ -263,8 +253,9 @@ void MangelwurzelTsx::on_rx_in_dialog_request(pjsip_msg* req)
     mangle_dialog_identifiers(req, pool);
   }
 
-  if (_config.contact)
+  if (_config.req_uri)
   {
+    mangle_req_uri(req, pool);
     mangle_contact(req, pool);
   }
 

--- a/sprout/mangelwurzel/ut/mangelwurzel_test.cpp
+++ b/sprout/mangelwurzel/ut/mangelwurzel_test.cpp
@@ -492,5 +492,4 @@ TEST_F(MangelwurzelTest, InDialogReq)
   EXPECT_EQ("Route: <sip:3c2b1a_ido@niamodemoh.tuorps:5054;transport=TCP;lr>",
             get_headers(req, "Route"));
   EXPECT_EQ("", get_headers(req, "Via"));
-  EXPECT_THAT(req, ReqUriEquals("sip:1000555056@homedomain"));
 }

--- a/sprout/mangelwurzel/ut/mangelwurzel_test.cpp
+++ b/sprout/mangelwurzel/ut/mangelwurzel_test.cpp
@@ -229,7 +229,6 @@ TEST_F(MangelwurzelTest, CreateDefaults)
   EXPECT_TRUE(mangelwurzel_tsx != NULL);
   EXPECT_FALSE(mangelwurzel_tsx->_config.dialog);
   EXPECT_FALSE(mangelwurzel_tsx->_config.req_uri);
-  EXPECT_FALSE(mangelwurzel_tsx->_config.contact);
   EXPECT_FALSE(mangelwurzel_tsx->_config.to);
   EXPECT_FALSE(mangelwurzel_tsx->_config.change_domain);
   EXPECT_FALSE(mangelwurzel_tsx->_config.routes);
@@ -251,7 +250,7 @@ TEST_F(MangelwurzelTest, CreateFullConfig)
   // Set all the parameters on the Route header URI. Check the values are all
   // accurate in the transaction's config.
   hdr->name_addr.uri =
-    PJUtils::uri_from_string("sip:mangelwurzel.homedomain;dialog;req-uri;contact;to;routes;change-domain;orig;ootb;mangalgorithm=reverse",
+    PJUtils::uri_from_string("sip:mangelwurzel.homedomain;dialog;req-uri;to;routes;change-domain;orig;ootb;mangalgorithm=reverse",
                              stack_data.pool);
   EXPECT_CALL(*_helper, route_hdr()).WillOnce(Return(hdr));
 
@@ -262,7 +261,6 @@ TEST_F(MangelwurzelTest, CreateFullConfig)
   EXPECT_TRUE(mangelwurzel_tsx != NULL);
   EXPECT_TRUE(mangelwurzel_tsx->_config.dialog);
   EXPECT_TRUE(mangelwurzel_tsx->_config.req_uri);
-  EXPECT_TRUE(mangelwurzel_tsx->_config.contact);
   EXPECT_TRUE(mangelwurzel_tsx->_config.to);
   EXPECT_TRUE(mangelwurzel_tsx->_config.change_domain);
   EXPECT_TRUE(mangelwurzel_tsx->_config.routes);
@@ -361,7 +359,6 @@ TEST_F(MangelwurzelTest, InitialReq)
   MangelwurzelTsx::Config config;
   config.dialog = true;
   config.req_uri = true;
-  config.contact = true;
   config.to = true;
   config.routes = true;
   config.change_domain = true;
@@ -373,7 +370,7 @@ TEST_F(MangelwurzelTest, InitialReq)
   // mangelwurzel to request it when it Record-Routes itself.
   pjsip_route_hdr* hdr = pjsip_rr_hdr_create(stack_data.pool);
   hdr->name_addr.uri =
-    PJUtils::uri_from_string("sip:mangelwurzel.homedomain;dialog;req-uri;contact;to;routes;change-domain;orig;ootb;mangalgorithm=rot13",
+    PJUtils::uri_from_string("sip:mangelwurzel.homedomain;dialog;req-uri;to;routes;change-domain;orig;ootb;mangalgorithm=rot13",
                              stack_data.pool);
   EXPECT_CALL(*_helper, route_hdr()).WillRepeatedly(Return(hdr));
 
@@ -396,7 +393,7 @@ TEST_F(MangelwurzelTest, InitialReq)
             get_headers(req, "Route"));
   EXPECT_EQ("", get_headers(req, "Via"));
   EXPECT_THAT(req, ReqUriEquals("sip:1050005556@ubzrqbznva"));
-  EXPECT_EQ("Record-Route: <sip:mangelwurzel.homedomain;dialog;req-uri;contact;to;routes;change-domain;orig;ootb;mangalgorithm=rot13>\r\nRecord-Route: <sip:ubzrqbznva>",
+  EXPECT_EQ("Record-Route: <sip:mangelwurzel.homedomain;dialog;req-uri;to;routes;change-domain;orig;ootb;mangalgorithm=rot13>\r\nRecord-Route: <sip:ubzrqbznva>",
             get_headers(req, "Record-Route"));
 }
 
@@ -416,7 +413,6 @@ TEST_F(MangelwurzelTest, Response)
   MangelwurzelTsx::Config config;
   config.dialog = true;
   config.req_uri = true;
-  config.contact = true;
   config.to = true;
   config.routes = true;
   config.change_domain = true;
@@ -465,7 +461,6 @@ TEST_F(MangelwurzelTest, InDialogReq)
   MangelwurzelTsx::Config config;
   config.dialog = true;
   config.req_uri = true;
-  config.contact = true;
   config.to = true;
   config.routes = true;
   config.change_domain = false;
@@ -492,4 +487,5 @@ TEST_F(MangelwurzelTest, InDialogReq)
   EXPECT_EQ("Route: <sip:3c2b1a_ido@niamodemoh.tuorps:5054;transport=TCP;lr>",
             get_headers(req, "Route"));
   EXPECT_EQ("", get_headers(req, "Via"));
+  EXPECT_THAT(req, ReqUriEquals("sip:1000555056@homedomain"));
 }


### PR DESCRIPTION
Hi Matt,

Please can you review my change to mangelwurzel so that it doesn't mangle the Request URI on in-dialog requests? As discussed, mangling the Request URI on in-dialog requests because we've mangled it on the initial request doesn't make sense. We may wish to mangle it for other reasons on in-dialog requests, but right now we don't have a well defined use case for this.

I've tested by running the UTs and deploying on a system.

I've updated the design.

Thanks,
Graeme