### PR TITLE
Reviewer AMC: Don't crash in BGCF when ENUM returns invalid rule

### DIFF
--- a/sprout/bgcfsproutlet.cpp
+++ b/sprout/bgcfsproutlet.cpp
@@ -215,6 +215,7 @@ void BGCFSproutletTsx::on_rx_initial_request(pjsip_msg* req)
                                          "ENUM failure");
         send_response(rsp);
         free_msg(req);
+        return;
       }
     }
     else

--- a/sprout/ut/scscf_test.cpp
+++ b/sprout/ut/scscf_test.cpp
@@ -1762,7 +1762,10 @@ TEST_F(SCSCFTest, TestEnumNPBGCFTel)
   doSuccessfulFlow(msg, testing::MatchesRegex(".*+15108580401;rn.*+151085804;npdi@homedomain.*"), hdrs, false);
 }
 
-// Test where the BGCF does an ENUM lookup which returns an invalid rule.
+// Test where the BGCF does an ENUM lookup which returns an invalid rule. This
+// test uses two ENUM rules. The first one is invoked by the S-CSCF before
+// routing to the BGCF. The BGCF does the second lookup. At this point an
+// invalid rule is returned and we reply with a 404 ENUM failure.
 TEST_F(SCSCFTest, TestBGCFInvalidEnumRule)
 {
   add_host_mapping("ut.cw-ngv.com", "10.9.8.7");

--- a/sprout/ut/scscf_test.cpp
+++ b/sprout/ut/scscf_test.cpp
@@ -1762,6 +1762,22 @@ TEST_F(SCSCFTest, TestEnumNPBGCFTel)
   doSuccessfulFlow(msg, testing::MatchesRegex(".*+15108580401;rn.*+151085804;npdi@homedomain.*"), hdrs, false);
 }
 
+// Test where the BGCF does an ENUM lookup which returns an invalid rule.
+TEST_F(SCSCFTest, TestBGCFInvalidEnumRule)
+{
+  add_host_mapping("ut.cw-ngv.com", "10.9.8.7");
+  SCOPED_TRACE("");
+  register_uri(_store, _hss_connection, "6505551239", "homedomain", "sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob");
+  _hss_connection->set_impu_result("sip:6505551000@homedomain", "call", HSSConnection::STATE_REGISTERED, "");
+  Message msg;
+  msg._toscheme = "tel";
+  msg._to = "16505551239";
+  msg._route = "Route: <sip:homedomain;orig>";
+  msg._todomain = "";
+  list<HeaderMatcher> hdrs;
+  doSlowFailureFlow(msg, 404, "", "ENUM failure");
+}
+
 TEST_F(SCSCFTest, TestValidBGCFRoute)
 {
   SCOPED_TRACE("");

--- a/sprout/ut/test_stateful_proxy_enum.json
+++ b/sprout/ut/test_stateful_proxy_enum.json
@@ -31,6 +31,14 @@
         {   "name" : "Clearwater Tel URI",
             "prefix" : "16505551234",
             "regex"  : "!(^.*$)!sip:\\1@ut.cw-ngv.com!"
+        },
+        {   "name" : "Setup invalid ENUM rule",
+            "prefix" : "16505551239",
+            "regex"  : "!(^.*$)!sip:1\\1@ut.cw-ngv.com!"
+        },
+        {   "name" : "Invalid ENUM rule",
+            "prefix" : "116505551239",
+            "regex"  : "!\\+(^.*$)!sip:00\\1@ut.cw-ngv.com!"
         }
     ]
 }


### PR DESCRIPTION
Hi Andy,

Can you review this? It fixes https://github.com/Metaswitch/sprout/issues/951. The fix is as described in the issue.

The new UT crashes without the fix, and doesn't crash with the fix.

I did a code read of all the other places we called free_msg and they look fine.

Grab me if you've got any other questions.

Thanks!
Graeme