### PR TITLE
[Reviewer: Ellie] Make the RegStore distinguish between data contention and genuine errors. 

### DIFF
--- a/include/regstore.h
+++ b/include/regstore.h
@@ -296,10 +296,10 @@ public:
 
     AoR* get_aor_data(const std::string& aor_id, SAS::TrailId trail);
 
-    bool set_aor_data(const std::string& aor_id,
-                      AoR* aor_data,
-                      int expiry,
-                      SAS::TrailId trail);
+    Store::Status set_aor_data(const std::string& aor_id,
+                               AoR* aor_data,
+                               int expiry,
+                               SAS::TrailId trail);
 
     std::string serialize_aor(AoR* aor_data);
     AoR* deserialize_aor(const std::string& aor_id, const std::string& s);
@@ -355,21 +355,21 @@ public:
   /// atomically.  If the underlying data has changed since it was last
   /// read, the update is rejected and this returns false; if the update
   /// succeeds, this returns true.
-  virtual bool set_aor_data(const std::string& aor_id, 
-                            AoR* data, 
-                            bool update_timers, 
-                            SAS::TrailId trail);
-  virtual bool set_aor_data(const std::string& aor_id, 
-                            AoR* data, 
-                            bool update_timers, 
-                            SAS::TrailId trail, 
-                            bool& all_bindings_expired);
+  virtual Store::Status set_aor_data(const std::string& aor_id,
+                                     AoR* data,
+                                     bool update_timers,
+                                     SAS::TrailId trail);
+  virtual Store::Status set_aor_data(const std::string& aor_id,
+                                     AoR* data,
+                                     bool update_timers,
+                                     SAS::TrailId trail,
+                                     bool& all_bindings_expired);
 
   // Send a SIP NOTIFY
-  virtual void send_notify(AoR::Subscription* s, 
-                           int cseq, 
-                           AoR::Binding* b, 
-                           std::string b_id, 
+  virtual void send_notify(AoR::Subscription* s,
+                           int cseq,
+                           AoR::Binding* b,
+                           std::string b_id,
                            SAS::TrailId trail);
 
 private:

--- a/sprout/handlers.cpp
+++ b/sprout/handlers.cpp
@@ -259,6 +259,13 @@ void RegistrationTimeoutTask::handle_response()
       _cfg->_hss->update_registration_state(_aor_id, "", HSSConnection::DEREG_TIMEOUT, 0);
     }
   }
+  else
+  {
+    // We couldn't update the RegStore but there is nothing else we can do to
+    // recover from this.
+    LOG_INFO("Could not update update RegStore on registration timeout for AoR: %s",
+             _aor_id.c_str());
+  }
 
   delete aor_data;
   report_sip_all_register_marker(trail(), _aor_id);

--- a/sprout/registrar.cpp
+++ b/sprout/registrar.cpp
@@ -231,6 +231,7 @@ RegStore::AoR* write_to_store(RegStore* primary_store,       ///<store to write 
   bool is_initial_registration = true;
   std::map<std::string, RegStore::AoR::Binding> bindings_for_notify;
   bool all_bindings_expired = false;
+  Store::Status set_rc;
 
   do
   {
@@ -428,8 +429,18 @@ RegStore::AoR* write_to_store(RegStore* primary_store,       ///<store to write 
 
     // Finally, update the cseq
     aor_data->_notify_cseq++;
+
+    set_rc = primary_store->set_aor_data(aor,
+                                         aor_data,
+                                         send_notify,
+                                         trail,
+                                         all_bindings_expired);
+    if (set_rc != Store::OK)
+    {
+      delete aor_data; aor_data = NULL;
+    }
   }
-  while (!primary_store->set_aor_data(aor, aor_data, send_notify, trail, all_bindings_expired));
+  while (set_rc == Store::DATA_CONTENTION);
 
   // If we allocated the backup AoR, tidy up.
   if (backup_aor_alloced)

--- a/sprout/registration_utils.cpp
+++ b/sprout/registration_utils.cpp
@@ -383,7 +383,8 @@ static bool expire_bindings(RegStore *store, const std::string& aor, const std::
     // to update the store.
     all_bindings_expired = (all_bindings_expired && (set_rc == Store::OK));
 
-  } while (set_rc == Store::DATA_CONTENTION);
+  }
+  while (set_rc == Store::DATA_CONTENTION);
 
   return all_bindings_expired;
 }

--- a/sprout/ut/handlers_test.cpp
+++ b/sprout/ut/handlers_test.cpp
@@ -169,6 +169,64 @@ TEST_F(RegistrationTimeoutTasksTest, MissingBindingJSONTest)
   ASSERT_EQ(status, 400);
 }
 
+
+class RegistrationTimeoutTasksMockStoreTest : public SipTest
+{
+  FakeChronosConnection* chronos_connection;
+  MockRegStore* store;
+  FakeHSSConnection* fake_hss;
+
+  MockHttpStack stack;
+  MockHttpStack::Request* req;
+  RegistrationTimeoutTask::Config* chronos_config;
+
+  RegistrationTimeoutTask* handler;
+
+  static void SetUpTestCase()
+  {
+    SipTest::SetUpTestCase(false);
+  }
+
+  void SetUp()
+  {
+    chronos_connection = new FakeChronosConnection();
+    store = new MockRegStore();
+    fake_hss = new FakeHSSConnection();
+    req = new MockHttpStack::Request(&stack, "/", "timers");
+    chronos_config = new RegistrationTimeoutTask::Config(store, NULL, fake_hss);
+    handler = new RegistrationTimeoutTask(*req, chronos_config, 0);
+  }
+
+  void TearDown()
+  {
+    delete handler;
+    delete chronos_config;
+    delete req;
+    delete fake_hss;
+    delete store; store = NULL;
+    delete chronos_connection; chronos_connection = NULL;
+  }
+
+};
+
+TEST_F(RegistrationTimeoutTasksMockStoreTest, RegStoreWritesFail)
+{
+  // Set up the RegStore to fail all sets and respond to all gets with not
+  // found.
+  RegStore::AoR* aor = new RegStore::AoR("sip:6505550231@homedomain");
+  EXPECT_CALL(*store, get_aor_data(_, _)).WillOnce(Return(aor));
+  EXPECT_CALL(*store, set_aor_data(_, _, _, _, _)).WillOnce(Return(Store::ERROR));
+
+  // Parse and handle the request
+  std::string body = "{\"aor_id\": \"sip:6505550231@homedomain\", \"binding_id\": \"<urn:uuid:00000000-0000-0000-0000-b4dd32817622>:1\"}";
+  int status = handler->parse_response(body);
+
+  ASSERT_EQ(status, 200);
+
+  handler->handle_response();
+}
+
+
 class DeregistrationTaskTest : public SipTest
 {
   MockRegStore* _regstore;
@@ -403,6 +461,29 @@ TEST_F(DeregistrationTaskTest, MissingPrimaryIMPUJSONTest)
   _task->run();
   EXPECT_TRUE(log.contains("Invalid JSON - registration doesn't contain primary-impu"));
 }
+
+
+TEST_F(DeregistrationTaskTest, RegStoreWritesFail)
+{
+  // We don't want a remote store for this test.
+  MockRegStore* tmp = _remotestore;
+  _remotestore = NULL;
+
+  // Build the request
+  std::string body = "{\"registrations\": [{\"primary-impu\": \"sip:6505550231@homedomain\", \"impi\": \"6505550231\"}]}";
+  build_dereg_request(body);
+
+  RegStore::AoR* aor = new RegStore::AoR("sip:6505550231@homedomain");
+  EXPECT_CALL(*_regstore, get_aor_data(_, _)).WillOnce(Return(aor));
+  EXPECT_CALL(*_regstore, set_aor_data(_, _, _, _, _)).WillOnce(Return(Store::ERROR));
+
+  // Run the task
+  EXPECT_CALL(*_httpstack, send_reply(_, 500, _));
+  _task->run();
+
+  _remotestore = tmp;
+}
+
 
 class AuthTimeoutTest : public SipTest
 {

--- a/sprout/ut/handlers_test.cpp
+++ b/sprout/ut/handlers_test.cpp
@@ -230,13 +230,13 @@ class DeregistrationTaskTest : public SipTest
       if (aors[ii] != NULL)
       {
         // Write the information to the local store
-        EXPECT_CALL(*_regstore, set_aor_data(aor_ids[ii], _, _, _, _)).WillOnce(Return(true));
+        EXPECT_CALL(*_regstore, set_aor_data(aor_ids[ii], _, _, _, _)).WillOnce(Return(Store::OK));
 
         // Write the information to the remote store
         EXPECT_CALL(*_remotestore, get_aor_data(aor_ids[ii], _)).WillRepeatedly(Return(remote_aor));
         if (remote_aor != NULL)
         {
-          EXPECT_CALL(*_remotestore, set_aor_data(aor_ids[ii], _, _, _, _)).WillOnce(Return(true));
+          EXPECT_CALL(*_remotestore, set_aor_data(aor_ids[ii], _, _, _, _)).WillOnce(Return(Store::OK));
         }
       }
     }
@@ -313,7 +313,7 @@ TEST_F(DeregistrationTaskTest, AoRPrivateIdPairsTest)
   _task->run();
 }
 
-// Test when the RegStore can't be accessed. 
+// Test when the RegStore can't be accessed.
 TEST_F(DeregistrationTaskTest, RegStoreFailureTest)
 {
   // Build the request

--- a/sprout/ut/mock_reg_store.h
+++ b/sprout/ut/mock_reg_store.h
@@ -49,11 +49,11 @@ public:
 
   MOCK_METHOD2(get_aor_data, AoR*(const std::string& aor_id,
                                   SAS::TrailId trail));
-  MOCK_METHOD5(set_aor_data, bool(const std::string& aor_id, 
-                                  AoR* data, 
-                                  bool update_timers, 
-                                  SAS::TrailId trail, 
-                                  bool& all_bindings_expired));
+  MOCK_METHOD5(set_aor_data, Store::Status(const std::string& aor_id,
+                                           AoR* data,
+                                           bool update_timers,
+                                           SAS::TrailId trail,
+                                           bool& all_bindings_expired));
   MOCK_METHOD5(send_notify, void(AoR::Subscription* s,
                                  int cseq,
                                  AoR::Binding* b,

--- a/sprout/ut/registrar_test.cpp
+++ b/sprout/ut/registrar_test.cpp
@@ -1910,10 +1910,6 @@ public:
     cwtest_advance_time_ms(33000L);
     poll();
 
-    // Stop and restart the layer just in case
-    //pjsip_tsx_layer_instance()->stop();
-    //pjsip_tsx_layer_instance()->start();
-
     destroy_registrar();
     delete _acr_factory; _acr_factory = NULL;
     delete _hss_connection; _hss_connection = NULL;

--- a/sprout/ut/registrar_test.cpp
+++ b/sprout/ut/registrar_test.cpp
@@ -1965,7 +1965,6 @@ TEST_F(RegistrarTestMockStore, SimpleMainlineAuthHeader)
   ASSERT_EQ(1, txdata_count());
   pjsip_msg* out = current_txdata()->msg;
   out = pop_txdata()->msg;
-  EXPECT_EQ(200, out->line.status.code);
-  EXPECT_EQ("OK", str_pj(out->line.status.reason));
+  EXPECT_EQ(500, out->line.status.code);
   free_txdata();
 }

--- a/sprout/ut/registrar_test.cpp
+++ b/sprout/ut/registrar_test.cpp
@@ -1939,13 +1939,13 @@ protected:
 };
 
 
-// Check that the RegStore does not infinite loop when the underlying store is
+// Check that the registrar does not infinite loop when the underlying store is
 // in an odd state, specifically when it:
 // -  Returns NOT_FOUND to all gets
 // -  Returns ERROR to all sets.
 //
 // This is a repro for https://github.com/Metaswitch/sprout/issues/977
-TEST_F(RegistrarTestMockStore, SimpleMainlineAuthHeader)
+TEST_F(RegistrarTestMockStore, RegStoreWritesFail)
 {
   EXPECT_CALL(*_local_data_store, get_data(_, _, _, _, _))
     .WillOnce(Return(Store::NOT_FOUND));
@@ -1964,7 +1964,6 @@ TEST_F(RegistrarTestMockStore, SimpleMainlineAuthHeader)
   inject_msg(msg.get());
   ASSERT_EQ(1, txdata_count());
   pjsip_msg* out = current_txdata()->msg;
-  out = pop_txdata()->msg;
   EXPECT_EQ(500, out->line.status.code);
   free_txdata();
 }

--- a/sprout/ut/subscription_test.cpp
+++ b/sprout/ut/subscription_test.cpp
@@ -97,6 +97,8 @@ public:
   {
     _local_data_store->flush_all();  // start from a clean slate on each test
     _remote_data_store->flush_all();
+
+    _log_traffic = PrintingTestLogger::DEFAULT.isPrinting();
   }
 
   ~SubscriptionTest()
@@ -593,6 +595,8 @@ public:
 
     _hss_connection->set_impu_result("sip:6505550231@homedomain", "", HSSConnection::STATE_REGISTERED, "");
     _hss_connection->set_impu_result("tel:6505550231", "", HSSConnection::STATE_REGISTERED, "");
+
+    _log_traffic = PrintingTestLogger::DEFAULT.isPrinting();
   }
 
   static void TearDownTestCase()
@@ -642,7 +646,7 @@ TEST_F(SubscriptionTestMockStore, RegStoreWritesFail)
   SubscribeMessage msg;
   inject_msg(msg.get());
 
-  ASSERT_EQ(2, txdata_count());
+  ASSERT_EQ(1, txdata_count());
   pjsip_msg* out = current_txdata()->msg;
   EXPECT_EQ(500, out->line.status.code);
   free_txdata();

--- a/sprout/ut/subscription_test.cpp
+++ b/sprout/ut/subscription_test.cpp
@@ -46,11 +46,13 @@
 #include "fakehssconnection.hpp"
 #include "test_interposer.hpp"
 #include "fakechronosconnection.hpp"
+#include "mock_store.h"
 
-using namespace std;
-using testing::MatchesRegex;
-using testing::HasSubstr;
-using testing::Not;
+using ::testing::MatchesRegex;
+using ::testing::HasSubstr;
+using ::testing::Not;
+using ::testing::_;
+using ::testing::Return;
 
 /// Fixture for SubscriptionTest.
 class SubscriptionTest : public SipTest
@@ -566,3 +568,82 @@ void SubscriptionTest::check_OK_and_NOTIFY(bool terminated)
   inject_msg(respond_to_current_txdata(200));
 }
 
+
+/// Fixture for Subscription tests that use a mock store instead of a fake one.
+class SubscriptionTestMockStore : public SipTest
+{
+public:
+  static void SetUpTestCase()
+  {
+    SipTest::SetUpTestCase();
+    add_host_mapping("sprout.example.com", "10.8.8.1");
+  }
+
+  void SetUp()
+  {
+    _chronos_connection = new FakeChronosConnection();
+    _local_data_store = new MockStore();
+    _store = new RegStore((Store*)_local_data_store, _chronos_connection);
+    _analytics = new AnalyticsLogger(&PrintingTestLogger::DEFAULT);
+    _hss_connection = new FakeHSSConnection();
+    _acr_factory = new ACRFactory();
+    pj_status_t ret = init_subscription(_store, NULL, _hss_connection, _acr_factory, _analytics, 300);
+    ASSERT_EQ(PJ_SUCCESS, ret);
+    stack_data.scscf_uri = pj_str("sip:all.the.sprout.nodes:5058;transport=TCP");
+
+    _hss_connection->set_impu_result("sip:6505550231@homedomain", "", HSSConnection::STATE_REGISTERED, "");
+    _hss_connection->set_impu_result("tel:6505550231", "", HSSConnection::STATE_REGISTERED, "");
+  }
+
+  static void TearDownTestCase()
+  {
+    SipTest::TearDownTestCase();
+  }
+
+  void TearDown()
+  {
+    destroy_subscription();
+    delete _acr_factory; _acr_factory = NULL;
+    delete _hss_connection; _hss_connection = NULL;
+    delete _analytics; _analytics = NULL;
+    delete _store; _store = NULL;
+    delete _local_data_store; _local_data_store = NULL;
+    delete _chronos_connection; _chronos_connection = NULL;
+  }
+
+  SubscriptionTestMockStore() : SipTest(&mod_subscription)
+  {
+  }
+
+protected:
+  MockStore* _local_data_store;
+  RegStore* _store;
+  AnalyticsLogger* _analytics;
+  ACRFactory* _acr_factory;
+  FakeHSSConnection* _hss_connection;
+  FakeChronosConnection* _chronos_connection;
+};
+
+
+// Check that the subscription module does not infinite loop when the underlying
+// store is in an odd state, specifically when it:
+// -  Returns NOT_FOUND to all gets
+// -  Returns ERROR to all sets.
+//
+// This is a repro for https://github.com/Metaswitch/sprout/issues/977
+TEST_F(SubscriptionTestMockStore, RegStoreWritesFail)
+{
+  EXPECT_CALL(*_local_data_store, get_data(_, _, _, _, _))
+    .WillOnce(Return(Store::NOT_FOUND));
+
+  EXPECT_CALL(*_local_data_store, set_data(_, _, _, _, _, _))
+    .WillOnce(Return(Store::ERROR));
+
+  SubscribeMessage msg;
+  inject_msg(msg.get());
+
+  ASSERT_EQ(2, txdata_count());
+  pjsip_msg* out = current_txdata()->msg;
+  EXPECT_EQ(500, out->line.status.code);
+  free_txdata();
+}


### PR DESCRIPTION
Ellie, please could you review my fix for #977.

This changes `RegStore::set_aor_data` to return a `Store::Status` rather than simply success/failure. I have also updated the users of the store to fail the request in progress if the store returns `Store::ERROR` (the exception is the registration timeout handler which continues to return 200 OK to chronos). 

Existing UTs all run fine, and I have added new UTs to cover failures of the RegStore. I will also check the live tests run OK, but I'm having trouble setting up a working deployment at the moment. 