### PR TITLE
[Reviewer: Ellie] Sprout depends on libevent-2.0-5

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -37,7 +37,7 @@ Description: Debugging symbols for sprout, the SIP Router
 
 Package: sprout-base
 Architecture: any
-Depends: clearwater-infrastructure, clearwater-tcp-scalability, clearwater-log-cleanup, sprout-libs, clearwater-memcached, libboost-regex1.46.1, libboost-system1.46.1, libboost-thread1.46.1, libzmq3, libevent-pthreads-2.0-5, chronos, clearwater-socket-factory, libboost-filesystem1.46.1, astaire
+Depends: clearwater-infrastructure, clearwater-tcp-scalability, clearwater-log-cleanup, sprout-libs, clearwater-memcached, libboost-regex1.46.1, libboost-system1.46.1, libboost-thread1.46.1, libzmq3, libevent-2.0-5, libevent-pthreads-2.0-5, chronos, clearwater-socket-factory, libboost-filesystem1.46.1, astaire
 Suggests: sprout-dbg, clearwater-logging, clearwater-snmp-handler-sprout, clearwater-snmp-handler-alarm
 Replaces: sprout
 Description: sprout-base, the SIP Router basic executable


### PR DESCRIPTION
Same as https://github.com/Metaswitch/homestead/pull/194, except libgnutls isn't required here.