### PR TITLE
[Reviewer: Matt] POSIX regexes for ENUM

### DIFF
--- a/sprout/enumservice.cpp
+++ b/sprout/enumservice.cpp
@@ -69,7 +69,7 @@ bool EnumService::parse_regex_replace(const std::string& regex_replace, boost::r
     LOG_DEBUG("Split regex into match=%s, replace=%s", match_replace[0].c_str(), match_replace[1].c_str());
     try
     {
-      regex.assign(match_replace[0]);
+      regex.assign(match_replace[0], boost::regex::extended);
       replace = match_replace[1];
       success = true;
     }


### PR DESCRIPTION
Fixes https://github.com/Metaswitch/sprout/issues/950. Exising UTs pass, and I've added a specific UT to confirm that Perl regexes aren't used.