### PR TITLE
Reviewer: Rob] Don't remove restund user when upgrading

### DIFF
--- a/debian/restund.prerm
+++ b/debian/restund.prerm
@@ -74,7 +74,9 @@ case "$1" in
         rm -f /etc/monit/conf.d/$NAME.monit
         reload clearwater-monit &> /dev/null || true
         service $NAME stop || true
-        remove_user
+        if [ "$1" != "upgrade" ]; then
+          remove_user
+        fi
         remove_section /etc/security/limits.conf $NAME
     ;;
 


### PR DESCRIPTION
A really boring PR to not delete the restund user when upgrading restund. This prevents an error message when upgrading. This follows the pattern we use for the bono/sprout users.

Tested by upgrading restund and checking that no error message was produced. Restund was running happily after the upgrade. 