### PR TITLE
[Reviewer: Ellie] Encode Message-Body correctly

### DIFF
--- a/sprout/acr.cpp
+++ b/sprout/acr.cpp
@@ -1067,19 +1067,23 @@ std::string RalfACR::get_message(pj_time_val timestamp)
            i != _msg_bodies.end();
            ++i)
       {
-        writer.String("Content-Type");
-        writer.String(i->type.c_str());
-        writer.String("Content-Length");
-        writer.Int(i->length);
-
-        if (!i->disposition.empty())
+        writer.StartObject();
         {
-          writer.String("Content-Disposition");
-          writer.String(i->disposition.c_str());
-        }
+          writer.String("Content-Type");
+          writer.String(i->type.c_str());
+          writer.String("Content-Length");
+          writer.Int(i->length);
 
-        writer.String("Originator");
-        writer.Int(i->originator);
+          if (!i->disposition.empty())
+          {
+            writer.String("Content-Disposition");
+            writer.String(i->disposition.c_str());
+          }
+
+          writer.String("Originator");
+          writer.Int(i->originator);
+        }
+        writer.EndObject();
       }
 
       writer.EndArray();

--- a/sprout/ut/acr_scscfpublish.json
+++ b/sprout/ut/acr_scscfpublish.json
@@ -1,0 +1,52 @@
+{
+  "event": {
+    "Accounting-Record-Type": 1,
+    "Event-Timestamp": 1,
+    "Service-Information": {
+      "IMS-Information": {
+        "Cause-Code" : -1,
+        "Event-Type": {
+          "Expires" : 300,
+          "SIP-Method": "PUBLISH"
+        },
+        "From-Address": "\"6505550000\" <sip:6505550000@homedomain>",
+        "IMS-Charging-Identifier": "1234bc9876e",
+        "Instance-Id" : "<urn:uuid:00000000-0000-0000-0000-b665231f1213>",
+        "Inter-Operator-Identifier": [
+          {
+            "Originating-IOI": "homedomain"
+          }
+        ],
+        "Node-Functionality": 0,
+        "Requested-Party-Address" : "sip:homedomain",
+        "Role-Of-Node": 0,
+        "Route-Header-Received": "<sip:sprout.homedomain:5054;transport=TCP;lr;orig>",
+        "Time-Stamps": {
+          "SIP-Request-Timestamp": 1,
+          "SIP-Request-Timestamp-Fraction": 0,
+          "SIP-Response-Timestamp": 1,
+          "SIP-Response-Timestamp-Fraction": 25
+        },
+        "User-Session-Id": "0123456789abcdef-10.83.18.38",
+        "Message-Body":[
+          {
+            "Content-Type":"text/plain",
+            "Content-Length":12,
+            "Content-Disposition":"render",
+            "Originator":0
+          }
+        ]
+      }
+    }
+  },
+  "peers": {
+    "ccf": [
+      "192.1.1.1",
+      "192.1.1.2"
+    ],
+    "ecf": [
+      "192.1.1.3",
+      "192.1.1.4"
+    ]
+  }
+}


### PR DESCRIPTION
Ellie,

Please can you review this fix to encode Message-Body correctly?  It's encoded as an array of strings when it should be an array of objects containing strings.  Reviewing with `?w=1` might be clearer.

Live-tested only as there's no UT for ACRs.

Matt