### PR TITLE
[Reviewer: Andy] Default CCF on ACRs from Bono

### DIFF
--- a/include/acr.h
+++ b/include/acr.h
@@ -162,6 +162,8 @@ public:
   /// Convert the ENUM node role to a displayable string.
   static std::string node_role_str(NodeRole role);
 
+  /// Set the default CCF for this ACR.
+  virtual void set_default_ccf(const std::string& default_ccf);
 };
 
 
@@ -253,6 +255,9 @@ public:
   /// Returns the JSON encoded message in string form.
   /// @param   timestamp      Timestamp to be used as Event-Timestamp AVP.
   virtual std::string get_message(pj_time_val timestamp=unspec);
+
+  /// Set the default CCF for this ACR.
+  virtual void set_default_ccf(const std::string& default_ccf);
 
 private:
 

--- a/include/sproutsasevent.h
+++ b/include/sproutsasevent.h
@@ -172,6 +172,8 @@ namespace SASEvent
 
   const int INVALID_SESSION_EXPIRES_HEADER = SPROUT_BASE + 0x0000E6;
 
+  const int NO_CCFS_FOR_ACR = SPROUT_BASE + 0xF0;
+
 } //namespace SASEvent
 
 #endif

--- a/sprout/acr.cpp
+++ b/sprout/acr.cpp
@@ -616,7 +616,12 @@ void RalfACR::server_capabilities(const ServerCapabilities& caps)
 
 void RalfACR::send_message(pj_time_val timestamp)
 {
-  if ((!_ccfs.empty()) || (!_ecfs.empty()))
+  // If we have a CCF or ECF, or this isn't a record type that needs one, send
+  // the message.
+  if ((!_ccfs.empty()) ||
+      (!_ecfs.empty()) ||
+      (_record_type == INTERIM_RECORD) ||
+      (_record_type == STOP_RECORD))
   {
     // Encode and send the request using the Ralf HTTP connection.
     LOG_VERBOSE("Sending %s Ralf ACR (%p)",
@@ -635,9 +640,9 @@ void RalfACR::send_message(pj_time_val timestamp)
   }
   else
   {
-    // There's no CCF or ECF to send to.  Drop the ACR.  This is a software
-    // or configuration fault - we shouldn't be trying to supply an ACR
-    // without a CCF.
+    // There's no CCF or ECF to send to, and we need one.  Drop the ACR.  This
+    // is a software or configuration fault - we shouldn't be trying to supply
+    // an ACR without a CCF.
     LOG_ERROR("No CCF or ECF to send ACR for session %s to - dropping!",
               _user_session_id.c_str());
   }

--- a/sprout/acr.cpp
+++ b/sprout/acr.cpp
@@ -40,6 +40,7 @@
 #include "constants.h"
 #include "custom_headers.h"
 #include "acr.h"
+#include "sproutsasevent.h"
 
 const pj_time_val ACR::unspec = {-1,0};
 
@@ -643,8 +644,10 @@ void RalfACR::send_message(pj_time_val timestamp)
     // There's no CCF or ECF to send to, and we need one.  Drop the ACR.  This
     // is a software or configuration fault - we shouldn't be trying to supply
     // an ACR without a CCF.
-    LOG_ERROR("No CCF or ECF to send ACR for session %s to - dropping!",
-              _user_session_id.c_str());
+    LOG_INFO("No CCF or ECF to send ACR for session %s to - dropping!",
+             _user_session_id.c_str());
+    SAS::Event event(_trail, SASEvent::NO_CCFS_FOR_ACR, 0);
+    SAS::report_event(event);
   }
 }
 

--- a/sprout/stateful_proxy.cpp
+++ b/sprout/stateful_proxy.cpp
@@ -442,6 +442,7 @@ void process_tsx_request(pjsip_rx_data* rdata)
     acr = cscf_acr_factory->get_acr(get_trail(rdata),
                                     CALLING_PARTY,
                                     acr_node_role(rdata->msg_info.msg));
+    acr->set_default_ccf(PJUtils::pj_str_to_string(&stack_data.cdf_domain));
   }
   else
   {
@@ -512,6 +513,7 @@ void process_tsx_request(pjsip_rx_data* rdata)
         acr = cscf_acr_factory->get_acr(get_trail(rdata),
                                         CALLING_PARTY,
                                         acr_node_role(rdata->msg_info.msg));
+        acr->set_default_ccf(PJUtils::pj_str_to_string(&stack_data.cdf_domain));
       }
     }
     else
@@ -545,21 +547,25 @@ void process_tsx_request(pjsip_rx_data* rdata)
           acr = cscf_acr_factory->get_acr(get_trail(rdata),
                                           CALLING_PARTY,
                                           NODE_ROLE_ORIGINATING);
+          acr->set_default_ccf(PJUtils::pj_str_to_string(&stack_data.cdf_domain));
           downstream_acr = cscf_acr_factory->get_acr(get_trail(rdata),
                                                      CALLING_PARTY,
                                                      NODE_ROLE_TERMINATING);
+          downstream_acr->set_default_ccf(PJUtils::pj_str_to_string(&stack_data.cdf_domain));
         }
         else if (charge_orig)
         {
           acr = cscf_acr_factory->get_acr(get_trail(rdata),
                                           CALLING_PARTY,
                                           NODE_ROLE_ORIGINATING);
+          acr->set_default_ccf(PJUtils::pj_str_to_string(&stack_data.cdf_domain));
         }
         else if (charge_term)
         {
           acr = cscf_acr_factory->get_acr(get_trail(rdata),
                                           CALLING_PARTY,
                                           NODE_ROLE_TERMINATING);
+          acr->set_default_ccf(PJUtils::pj_str_to_string(&stack_data.cdf_domain));
         }
       }
 
@@ -818,6 +824,7 @@ void process_cancel_request(pjsip_rx_data* rdata)
   ACR* acr = cscf_acr_factory->get_acr(get_trail(rdata),
                                        CALLING_PARTY,
                                        acr_node_role(rdata->msg_info.msg));
+  acr->set_default_ccf(PJUtils::pj_str_to_string(&stack_data.cdf_domain));
   acr->rx_request(rdata->msg_info.msg, rdata->pkt_info.timestamp);
   acr->send_message();
   delete acr;
@@ -897,14 +904,15 @@ static void reject_request(pjsip_rx_data* rdata, int status_code)
   ACR* acr = cscf_acr_factory->get_acr(get_trail(rdata),
                                        CALLING_PARTY,
                                        acr_node_role(rdata->msg_info.msg));
+  acr->set_default_ccf(PJUtils::pj_str_to_string(&stack_data.cdf_domain));
   acr->rx_request(rdata->msg_info.msg, rdata->pkt_info.timestamp);
 
   if (rdata->msg_info.msg->line.req.method.id != PJSIP_ACK_METHOD)
   {
     // Not an ACK, so we should send a response.
-    LOG_ERROR("Reject %.*s request with %d status code",
-              rdata->msg_info.msg->line.req.method.name.slen,
-              rdata->msg_info.msg->line.req.method.name.ptr, status_code);
+    LOG_INFO("Reject %.*s request with %d status code",
+             rdata->msg_info.msg->line.req.method.name.slen,
+             rdata->msg_info.msg->line.req.method.name.ptr, status_code);
     pjsip_tx_data* tdata;
 
     // Use default status text except for cases where PJSIP doesn't know
@@ -1536,7 +1544,7 @@ int proxy_process_access_routing(pjsip_rx_data *rdata,
     if (!trusted)
     {
       // Request is not from a trusted source, so reject or discard it.
-      LOG_WARNING("Rejecting request from untrusted source");
+      LOG_INFO("Rejecting request from untrusted source");
       if (src_flow != NULL)
       {
         src_flow->dec_ref();
@@ -1956,6 +1964,7 @@ void UASTransaction::proxy_calculate_targets(pjsip_msg* msg,
         _bgcf_acr = bgcf_acr_factory->get_acr(trail,
                                               CALLING_PARTY,
                                               acr_node_role(msg));
+        _bgcf_acr->set_default_ccf(PJUtils::pj_str_to_string(&stack_data.cdf_domain));
 
         if ((_downstream_acr != _upstream_acr) &&
             (!_as_chain_links.empty()))
@@ -2636,6 +2645,7 @@ void UASTransaction::routing_proxy_handle_initial_non_cancel(const ServingState&
       _icscf_acr = icscf_acr_factory->get_acr(trail(),
                                               CALLING_PARTY,
                                               acr_node_role(_req->msg));
+      _icscf_acr->set_default_ccf(PJUtils::pj_str_to_string(&stack_data.cdf_domain));
       _icscf_acr->rx_request(_req->msg);
 
       // Create an I-CSCF router for the LIR query.
@@ -2988,6 +2998,7 @@ bool UASTransaction::move_to_terminating_chain()
       _downstream_acr = cscf_acr_factory->get_acr(trail(),
                                                   CALLING_PARTY,
                                                   acr_node_role(_req->msg));
+      _downstream_acr->set_default_ccf(PJUtils::pj_str_to_string(&stack_data.cdf_domain));
       _downstream_acr->rx_request(_req->msg);
 
       // These headers name the originating user, so should not survive


### PR DESCRIPTION
Andy,

Please can you review this fix to #1006?  It's basically as we discussed - a new `ACR::set_default_ccf` method.

I've also changed `ACR::send_message` to report an error if there are no CCFs or ECFs - it's an interface violation to send like this.

I've also downgraded a couple of spammy error logs to infos.

All live-tested, and UTs run cleanly.

Matt