### PR TITLE
[Reviewer: Ellie] Ignore separators in is_user_numeric

### DIFF
--- a/include/bgcfservice.h
+++ b/include/bgcfservice.h
@@ -68,12 +68,6 @@ private:
   std::string _configuration;
   Updater<void, BgcfService>* _updater;
 
-  // Strip any visual separators from the number
-  static const boost::regex CHARS_TO_STRIP;
-  static std::string remove_visual_separators(const std::string& number)
-  { 
-    return boost::regex_replace(number, CHARS_TO_STRIP, std::string("")); 
-  };
 };
 
 #endif

--- a/include/pjutils.h
+++ b/include/pjutils.h
@@ -267,6 +267,8 @@ pjsip_uri* translate_sip_uri_to_tel_uri(const pjsip_sip_uri* sip_uri,
 pj_bool_t is_user_global(const std::string& user);
 pj_bool_t is_user_global(const pj_str_t& user);
 
+std::string remove_visual_separators(const std::string& user);
+
 pj_bool_t is_user_numeric(const std::string& user);
 pj_bool_t is_user_numeric(const pj_str_t& user);
 

--- a/sprout/bgcfservice.cpp
+++ b/sprout/bgcfservice.cpp
@@ -45,8 +45,7 @@
 #include "log.h"
 #include "sas.h"
 #include "sproutsasevent.h"
-
-const boost::regex BgcfService::CHARS_TO_STRIP = boost::regex("[.)(-]");
+#include "pjutils.h"
 
 BgcfService::BgcfService(std::string configuration) :
   _configuration(configuration),
@@ -143,7 +142,7 @@ void BgcfService::update_routes()
         {
           routing_value = (*routes_it)["number"].GetString();
           new_number_routes.insert(
-                    std::make_pair(remove_visual_separators(routing_value),
+                    std::make_pair(PJUtils::remove_visual_separators(routing_value),
                                    route_vec));
         }
 
@@ -242,7 +241,7 @@ std::vector<std::string> BgcfService::get_route_from_number(
   {
     int len = std::min(number.size(), (*it).first.size());
 
-    if (remove_visual_separators(number).compare(0, 
+    if (PJUtils::remove_visual_separators(number).compare(0, 
                                                  len, 
                                                  (*it).first, 
                                                  0, 

--- a/sprout/bgcfservice.cpp
+++ b/sprout/bgcfservice.cpp
@@ -241,11 +241,11 @@ std::vector<std::string> BgcfService::get_route_from_number(
   {
     int len = std::min(number.size(), (*it).first.size());
 
-    if (PJUtils::remove_visual_separators(number).compare(0, 
-                                                 len, 
-                                                 (*it).first, 
-                                                 0, 
-                                                 len) == 0)
+    if (PJUtils::remove_visual_separators(number).compare(0,
+                                                          len,
+                                                          (*it).first,
+                                                          0,
+                                                          len) == 0)
     {
       // Found a match, so return it
       LOG_DEBUG("Match found. Number: %s, prefix: %s",

--- a/sprout/pjutils.cpp
+++ b/sprout/pjutils.cpp
@@ -2089,14 +2089,23 @@ pj_bool_t PJUtils::is_user_global(const pj_str_t& user)
 }
 
 
+static const boost::regex CHARS_TO_STRIP = boost::regex("[.)(-]");
+
+// Strip any visual separators from the number
+std::string PJUtils::remove_visual_separators(const std::string& number)
+{ 
+  return boost::regex_replace(number, CHARS_TO_STRIP, std::string("")); 
+};
+
 /// Determines whether a user string is purely numeric (maybe with a leading +).
 ///
 /// @returns                      PJ_TRUE if the user is numeric, PJ_FALSE if
 ///                               not.
 /// @param user                   The user to test.
-pj_bool_t PJUtils::is_user_numeric(const std::string& user)
+pj_bool_t PJUtils::is_user_numeric(const std::string& user_raw)
 {
   pj_bool_t rc = PJ_TRUE;
+  std::string user = PJUtils::remove_visual_separators(user_raw);
 
   for (size_t i = 0; i < user.size(); i++)
   {

--- a/sprout/pjutils.cpp
+++ b/sprout/pjutils.cpp
@@ -2097,7 +2097,8 @@ std::string PJUtils::remove_visual_separators(const std::string& number)
   return boost::regex_replace(number, CHARS_TO_STRIP, std::string("")); 
 };
 
-/// Determines whether a user string is purely numeric (maybe with a leading +).
+/// Determines whether a user string is a valid phone number
+/// (maybe with a leading + or separator characters).
 ///
 /// @returns                      PJ_TRUE if the user is numeric, PJ_FALSE if
 ///                               not.

--- a/sprout/sprout_test.mk
+++ b/sprout/sprout_test.mk
@@ -147,7 +147,7 @@ TARGET_SOURCES_TEST := test_main.cpp \
                        alarm_test.cpp \
                        communicationmonitor_test.cpp \
                        common_sip_processing_test.cpp \
-		       pjutils_test.cpp
+                       pjutils_test.cpp
 
 # Put the interposer in here, so it will be loaded before pjsip.
 TARGET_EXTRA_OBJS_TEST := gmock-all.o \

--- a/sprout/sprout_test.mk
+++ b/sprout/sprout_test.mk
@@ -146,7 +146,8 @@ TARGET_SOURCES_TEST := test_main.cpp \
                        mangelwurzel_test.cpp \
                        alarm_test.cpp \
                        communicationmonitor_test.cpp \
-                       common_sip_processing_test.cpp
+                       common_sip_processing_test.cpp \
+		       pjutils_test.cpp
 
 # Put the interposer in here, so it will be loaded before pjsip.
 TARGET_EXTRA_OBJS_TEST := gmock-all.o \

--- a/sprout/ut/pjutils_test.cpp
+++ b/sprout/ut/pjutils_test.cpp
@@ -1,0 +1,66 @@
+/**
+ * @file pjutils_test.cpp UT for PJUtils.
+ *
+ * Project Clearwater - IMS in the Cloud
+ * Copyright (C) 2015 Metaswitch Networks Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version, along with the "Special Exception" for use of
+ * the program along with SSL, set forth below. This program is distributed
+ * in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * The author can be reached by email at clearwater@metaswitch.com or by
+ * post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+ *
+ * Special Exception
+ * Metaswitch Networks Ltd  grants you permission to copy, modify,
+ * propagate, and distribute a work formed by combining OpenSSL with The
+ * Software, or a work derivative of such a combination, even if such
+ * copying, modification, propagation, or distribution would otherwise
+ * violate the terms of the GPL. You must comply with the GPL in all
+ * respects for all of the code used other than OpenSSL.
+ * "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+ * Project and licensed under the OpenSSL Licenses, or a work based on such
+ * software and licensed under the OpenSSL Licenses.
+ * "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+ * under which the OpenSSL Project distributes the OpenSSL toolkit software,
+ * as those licenses appear in the file LICENSE-OPENSSL.
+ */
+
+///
+///----------------------------------------------------------------------------
+
+#include <string>
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "basetest.hpp"
+#include "pjutils.h"
+
+class PJUtilsTest : public BaseTest
+{
+
+  PJUtilsTest() 
+  {
+  }
+
+  virtual ~PJUtilsTest()
+  {
+  }
+};
+
+TEST_F(PJUtilsTest, IsUserNumeric)
+{
+  EXPECT_TRUE(PJUtils::is_user_numeric("+1234"));
+  EXPECT_TRUE(PJUtils::is_user_numeric("1234"));
+  EXPECT_TRUE(PJUtils::is_user_numeric("(1)-23-4"));
+  EXPECT_TRUE(PJUtils::is_user_numeric("1-23-4"));
+  EXPECT_TRUE(PJUtils::is_user_numeric("+1.23.4"));
+}


### PR DESCRIPTION
Fixes https://github.com/Metaswitch/sprout/issues/964. I think this accepts all valid instances of `global_number_digits` from http://www.in2eps.com/fo-abnf/tk-fo-abnf-sipuri.html#teluri - I haven't worried about the additional complexity of local_number_digits, because we use this function to decide:
* whether to do an ENUM lookup
* whether to convert a SIP URI to a TEL URI in the I-CSCF

and both operations are only valid for global E.164 numbers (even if we have `enforce_user_phone=N`, it just doesn't make sense to do a ENUM or LIR lookup for `tel:*1234A#`).