### PR TITLE
[Reviewer: Ellie] Temporarily exclude load monitor from coverage checks

### DIFF
--- a/sprout/ut/coverage-not-yet
+++ b/sprout/ut/coverage-not-yet
@@ -19,6 +19,7 @@ modules/cpp-common/src/saslogger.cpp
 modules/cpp-common/src/ipv6utils.cpp
 modules/cpp-common/src/exception_handler.cpp
 modules/cpp-common/src/utils.cpp
+modules/cpp-common/src/load_monitor.cpp
 modules/cpp-common/test_utils/mock_sas.cpp
 modules/cpp-common/test_utils/fakecurl.cpp
 modules/cpp-common/test_utils/fakehttpconnection.cpp


### PR DESCRIPTION
My new UTs for the load monitor are a bit more complex than I thought (requiring a second round of cpp-common changes), so I'm excluding the load monitor from coverage to allow you to cut the release.