### PR TITLE
[Reviewer: Andy] Make DNS blacklist duration configurable

### DIFF
--- a/debian/bono.init.d
+++ b/debian/bono.init.d
@@ -173,6 +173,8 @@ get_daemon_args()
                      $exception_max_ttl_arg"
 
         [ "$additional_home_domains" = "" ] || DAEMON_ARGS="$DAEMON_ARGS --additional-domains $additional_home_domains"
+        [ "$sip_blacklist_duration" = "" ]  || DAEMON_ARGS="$DAEMON_ARGS --sip-blacklist-duration=$sip_blacklist_duration"
+        [ "$http_blacklist_duration" = "" ] || DAEMON_ARGS="$DAEMON_ARGS --http-blacklist-duration=$http_blacklist_duration"
 }
 
 #

--- a/include/cfgoptions.h
+++ b/include/cfgoptions.h
@@ -129,6 +129,8 @@ struct options
   float                                min_token_rate;
   int                                  cass_target_latency_us;
   int                                  exception_max_ttl;
+  int                                  sip_blacklist_duration;
+  int                                  http_blacklist_duration;
 };
 
 // Objects that must be shared with dynamically linked sproutlets must be

--- a/include/sipresolver.h
+++ b/include/sipresolver.h
@@ -43,7 +43,8 @@
 class SIPResolver : public BaseResolver
 {
 public:
-  SIPResolver(DnsCachedResolver* dns_client);
+  SIPResolver(DnsCachedResolver* dns_client,
+              int blacklist_duration = DEFAULT_BLACKLIST_DURATION);
   ~SIPResolver();
 
   void resolve(const std::string& name,
@@ -53,6 +54,9 @@ public:
                int retries,
                std::vector<AddrInfo>& targets,
                SAS::TrailId trail = 0);
+
+  /// Default duration to blacklist hosts after we fail to connect to them.
+  static const int DEFAULT_BLACKLIST_DURATION = 30;
 
   std::string get_transport_str(int transport);
 };

--- a/sprout-base.root/etc/init.d/sprout
+++ b/sprout-base.root/etc/init.d/sprout
@@ -266,6 +266,8 @@ get_daemon_args()
         fi
 
         [ "$additional_home_domains" = "" ] || DAEMON_ARGS="$DAEMON_ARGS --additional-domains=$additional_home_domains"
+        [ "$sip_blacklist_duration" = "" ]  || DAEMON_ARGS="$DAEMON_ARGS --sip-blacklist-duration=$sip_blacklist_duration"
+        [ "$http_blacklist_duration" = "" ] || DAEMON_ARGS="$DAEMON_ARGS --http-blacklist-duration=$http_blacklist_duration"
 }
 
 #

--- a/sprout/pjutils.cpp
+++ b/sprout/pjutils.cpp
@@ -56,7 +56,6 @@ extern "C" {
 #include "sproutsasevent.h"
 
 static const int DEFAULT_RETRIES = 5;
-static const int DEFAULT_BLACKLIST_DURATION = 30;
 
 static void on_tsx_state(pjsip_transaction*, pjsip_event*);
 
@@ -950,7 +949,7 @@ void PJUtils::resolve_next_hop(pjsip_tx_data* tdata,
 /// resolve calls.
 void PJUtils::blacklist_server(AddrInfo& server)
 {
-  stack_data.sipresolver->blacklist(server, DEFAULT_BLACKLIST_DURATION);
+  stack_data.sipresolver->blacklist(server);
 }
 
 

--- a/sprout/sipresolver.cpp
+++ b/sprout/sipresolver.cpp
@@ -39,7 +39,8 @@
 #include "sas.h"
 #include "sproutsasevent.h"
 
-SIPResolver::SIPResolver(DnsCachedResolver* dns_client) :
+SIPResolver::SIPResolver(DnsCachedResolver* dns_client,
+                         int blacklist_duration) :
   BaseResolver(dns_client)
 {
   LOG_DEBUG("Creating SIP resolver");
@@ -54,7 +55,7 @@ SIPResolver::SIPResolver(DnsCachedResolver* dns_client) :
   create_srv_cache();
 
   // Create the blacklist.
-  create_blacklist();
+  create_blacklist(blacklist_duration);
 
   LOG_STATUS("Created SIP resolver");
 }


### PR DESCRIPTION
Andy,

Please can you review this fix to make the DNS blacklist duration configurable? There's no UT for this, but I've tested it live (and it's actually just refactoring).

This is the fix for sprout.  Once you've reviewed, I'll apply the same fix to homestead, ralf, memento, etc.

Matt