### PR TITLE
[Reviewer: Andy] Retry AV tombstones writes that fail due to CAS

### DIFF
--- a/include/avstore.h
+++ b/include/avstore.h
@@ -63,11 +63,11 @@ public:
   ///                  the Authentication Vector.
   /// @returns True if we successfully set the data in memcached,
   /// false otherwise.
-  bool set_av(const std::string& impi,
-              const std::string& nonce,
-              const rapidjson::Document* av,
-              uint64_t cas,
-              SAS::TrailId trail);
+  Store::Status set_av(const std::string& impi,
+                       const std::string& nonce,
+                       const rapidjson::Document* av,
+                       uint64_t cas,
+                       SAS::TrailId trail);
 
   /// Retrieves the Authentication Vector for the specified private user identity
   /// and nonce.


### PR DESCRIPTION
Andy,

Please can you review this fix to make Sprout retry AV tombstones writes that fail due to CAS.  We don't normally expect them to fail due to genuine CAS, but they can fail if we read from a backup and then try to write back to a (previously-unavailable) primary.  This fixes #1010.

There's no UT infrastructure for failing memcached writes, but I have tested live.  I ran up a system with 2 Sprouts and ran light (10kBHCA) stress through it.  Without the patch, shortly after I killed Memcached, I saw logs of the following form:

```
02-05-2015 00:58:22.963 UTC Error avstore.cpp:78: Failed to write Authentication Vector for private_id 2010000421@mirw.cw-ngv.com
02-05-2015 00:58:22.963 UTC Error authentication.cpp:619: Tried to tombstone AV for 2010000421@mirw.cw-ngv.com/0f3ea1dc23b199f5 after processing an authentication, but failed
```

With the patch, I just saw the first log, not the second (as it was retried and succeeded).

Matt