### PR TITLE
[Reviewer: Ellie] Memcached clustering plugin

### DIFF
--- a/debian/sprout-base.postinst
+++ b/debian/sprout-base.postinst
@@ -94,8 +94,7 @@ case "$1" in
         add_section /etc/security/limits.conf sprout /etc/security/limits.conf.sprout
         /usr/share/clearwater/infrastructure/scripts/sprout.monit
 
-        # Stop the cluster manager, so that it is restarted by Monit and picks up the new memcached
-        # and Chronos scaling plugins.
+        # Stop the cluster manager, so that it is restarted by Monit and picks up the new plugins.
         service clearwater-cluster-manager stop || /bin/true
 
         # Restart sprout.  Always do this by terminating sprout so monit will

--- a/debian/sprout-base.postinst
+++ b/debian/sprout-base.postinst
@@ -94,6 +94,10 @@ case "$1" in
         add_section /etc/security/limits.conf sprout /etc/security/limits.conf.sprout
         /usr/share/clearwater/infrastructure/scripts/sprout.monit
 
+        # Stop the cluster manager, so that it is restarted by Monit and picks up the new memcached
+        # and Chronos scaling plugins.
+        service clearwater-cluster-manager stop || /bin/true
+
         # Restart sprout.  Always do this by terminating sprout so monit will
         # restart it more-or-less immediately.  (monit restart seems to have
         # significant lag.)

--- a/sprout-base.root/usr/share/clearwater/clearwater-cluster-manager/plugins/sprout_chronos_plugin.py
+++ b/sprout-base.root/usr/share/clearwater/clearwater-cluster-manager/plugins/sprout_chronos_plugin.py
@@ -52,6 +52,9 @@ class SproutChronosPlugin(SynchroniserPluginBase):
     def key(self):
         return "/sprout/clustering/chronos"
 
+    def files(self):
+        return ["/etc/chronos/chronos_cluster.conf"]
+
     def on_cluster_changing(self, cluster_view):
         _log.debug("Sprout's Chronos cluster is changing")
         write_chronos_cluster_settings("/etc/chronos/chronos_cluster.conf",

--- a/sprout-base.root/usr/share/clearwater/clearwater-cluster-manager/plugins/sprout_memcached_plugin.py
+++ b/sprout-base.root/usr/share/clearwater/clearwater-cluster-manager/plugins/sprout_memcached_plugin.py
@@ -1,7 +1,8 @@
+
 from metaswitch.clearwater.cluster_manager.plugin_base import \
     SynchroniserPluginBase
 from metaswitch.clearwater.cluster_manager.plugin_utils import \
-    send_sighup, write_cluster_settings
+    run_command, write_cluster_settings
 from metaswitch.clearwater.cluster_manager.alarms import issue_alarm
 from metaswitch.clearwater.cluster_manager import constants
 import logging
@@ -11,8 +12,7 @@ _log = logging.getLogger("memcached_plugin")
 
 
 class SproutMemcachedPlugin(SynchroniserPluginBase):
-    def __init__(self):
-        _log.debug("Raising not-clustered alarm")
+    def __init__(self, _ip):
         issue_alarm(constants.RAISE_MEMCACHED_NOT_YET_CLUSTERED)
 
     def key(self):
@@ -21,23 +21,18 @@ class SproutMemcachedPlugin(SynchroniserPluginBase):
     def on_cluster_changing(self, cluster_view):
         write_cluster_settings("/etc/clearwater/cluster_settings",
                                cluster_view)
-        _log.debug("Restarting Sprout")
-        send_sighup("/var/run/sprout.pid")
+        run_command("service sprout reload")
 
     def on_joining_cluster(self, cluster_view):
-        _log.debug("Sprout Memcached cluster is changing")
         self.on_cluster_changing(cluster_view)
 
     def on_new_cluster_config_ready(self, cluster_view):
-        _log.debug("Started running Astaire")
-        os.system("service astaire reload")
-        os.system("service astaire wait-sync")
-        _log.debug("Finished running Astaire")
+        run_command("service astaire reload")
+        run_command("service astaire wait-sync")
 
     def on_stable_cluster(self, cluster_view):
         self.on_cluster_changing(cluster_view)
         issue_alarm(constants.CLEAR_MEMCACHED_NOT_YET_CLUSTERED)
-        _log.debug("Sprout Memcached cluster is stable again")
 
     def on_leaving_cluster(self, cluster_view):
         pass

--- a/sprout-base.root/usr/share/clearwater/clearwater-cluster-manager/plugins/sprout_memcached_plugin.py
+++ b/sprout-base.root/usr/share/clearwater/clearwater-cluster-manager/plugins/sprout_memcached_plugin.py
@@ -40,7 +40,7 @@ from metaswitch.clearwater.cluster_manager import constants
 import logging
 import os
 
-_log = logging.getLogger("memcached_plugin")
+_log = logging.getLogger("prout_memcached_plugin")
 
 
 class SproutMemcachedPlugin(SynchroniserPluginBase):
@@ -49,6 +49,9 @@ class SproutMemcachedPlugin(SynchroniserPluginBase):
 
     def key(self):
         return "/sprout/clustering/memcached"
+
+    def files(self):
+        return ["/etc/clearwater/cluster_settings"]
 
     def on_cluster_changing(self, cluster_view):
         write_cluster_settings("/etc/clearwater/cluster_settings",

--- a/sprout-base.root/usr/share/clearwater/clearwater-cluster-manager/plugins/sprout_memcached_plugin.py
+++ b/sprout-base.root/usr/share/clearwater/clearwater-cluster-manager/plugins/sprout_memcached_plugin.py
@@ -15,21 +15,29 @@ class SproutMemcachedPlugin(SynchroniserPluginBase):
         _log.debug("Raising not-clustered alarm")
         issue_alarm(constants.RAISE_MEMCACHED_NOT_YET_CLUSTERED)
 
+    def key(self):
+        return "/sprout/clustering/memcached"
+
     def on_cluster_changing(self, cluster_view):
         write_cluster_settings("/etc/clearwater/cluster_settings",
                                cluster_view)
+        _log.debug("Restarting Sprout")
         send_sighup("/var/run/sprout.pid")
 
     def on_joining_cluster(self, cluster_view):
+        _log.debug("Sprout Memcached cluster is changing")
         self.on_cluster_changing(cluster_view)
 
     def on_new_cluster_config_ready(self, cluster_view):
+        _log.debug("Started running Astaire")
         os.system("service astaire reload")
         os.system("service astaire wait-sync")
+        _log.debug("Finished running Astaire")
 
     def on_stable_cluster(self, cluster_view):
         self.on_cluster_changing(cluster_view)
         issue_alarm(constants.CLEAR_MEMCACHED_NOT_YET_CLUSTERED)
+        _log.debug("Sprout Memcached cluster is stable again")
 
     def on_leaving_cluster(self, cluster_view):
         pass

--- a/sprout-base.root/usr/share/clearwater/clearwater-cluster-manager/plugins/sprout_memcached_plugin.py
+++ b/sprout-base.root/usr/share/clearwater/clearwater-cluster-manager/plugins/sprout_memcached_plugin.py
@@ -34,13 +34,13 @@
 from metaswitch.clearwater.cluster_manager.plugin_base import \
     SynchroniserPluginBase
 from metaswitch.clearwater.cluster_manager.plugin_utils import \
-    run_command, write_cluster_settings
+    run_command, write_memcached_cluster_settings
 from metaswitch.clearwater.cluster_manager.alarms import issue_alarm
 from metaswitch.clearwater.cluster_manager import constants
 import logging
 import os
 
-_log = logging.getLogger("prout_memcached_plugin")
+_log = logging.getLogger("sprout_memcached_plugin")
 
 
 class SproutMemcachedPlugin(SynchroniserPluginBase):
@@ -54,8 +54,8 @@ class SproutMemcachedPlugin(SynchroniserPluginBase):
         return ["/etc/clearwater/cluster_settings"]
 
     def on_cluster_changing(self, cluster_view):
-        write_cluster_settings("/etc/clearwater/cluster_settings",
-                               cluster_view)
+        write_memcached_cluster_settings("/etc/clearwater/cluster_settings",
+                                         cluster_view)
         run_command("service sprout reload")
 
     def on_joining_cluster(self, cluster_view):
@@ -73,5 +73,5 @@ class SproutMemcachedPlugin(SynchroniserPluginBase):
         pass
 
 
-def load_as_plugin():
-    return SproutMemcachedPlugin()
+def load_as_plugin(ip):
+    return SproutMemcachedPlugin(ip)

--- a/sprout-base.root/usr/share/clearwater/clearwater-cluster-manager/plugins/sprout_memcached_plugin.py
+++ b/sprout-base.root/usr/share/clearwater/clearwater-cluster-manager/plugins/sprout_memcached_plugin.py
@@ -1,3 +1,35 @@
+# Project Clearwater - IMS in the Cloud
+# Copyright (C) 2015  Metaswitch Networks Ltd
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version, along with the "Special Exception" for use of
+# the program along with SSL, set forth below. This program is distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details. You should have received a copy of the GNU General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# The author can be reached by email at clearwater@metaswitch.com or by
+# post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+#
+# Special Exception
+# Metaswitch Networks Ltd  grants you permission to copy, modify,
+# propagate, and distribute a work formed by combining OpenSSL with The
+# Software, or a work derivative of such a combination, even if such
+# copying, modification, propagation, or distribution would otherwise
+# violate the terms of the GPL. You must comply with the GPL in all
+# respects for all of the code used other than OpenSSL.
+# "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+# Project and licensed under the OpenSSL Licenses, or a work based on such
+# software and licensed under the OpenSSL Licenses.
+# "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+# under which the OpenSSL Project distributes the OpenSSL toolkit software,
+# as those licenses appear in the file LICENSE-OPENSSL.
+
 
 from metaswitch.clearwater.cluster_manager.plugin_base import \
     SynchroniserPluginBase

--- a/sprout-base.root/usr/share/clearwater/cluster-manager/plugins/sprout_memcached_plugin.py
+++ b/sprout-base.root/usr/share/clearwater/cluster-manager/plugins/sprout_memcached_plugin.py
@@ -1,0 +1,39 @@
+from metaswitch.clearwater.cluster_manager.plugin_base import \
+    SynchroniserPluginBase
+from metaswitch.clearwater.cluster_manager.plugin_utils import \
+    send_sighup, write_cluster_settings
+from metaswitch.clearwater.cluster_manager.alarms import issue_alarm
+from metaswitch.clearwater.cluster_manager import constants
+import logging
+import os
+
+_log = logging.getLogger("memcached_plugin")
+
+
+class SproutMemcachedPlugin(SynchroniserPluginBase):
+    def __init__(self):
+        _log.debug("Raising not-clustered alarm")
+        issue_alarm(constants.RAISE_MEMCACHED_NOT_YET_CLUSTERED)
+
+    def on_cluster_changing(self, cluster_view):
+        write_cluster_settings("/etc/clearwater/cluster_settings",
+                               cluster_view)
+        send_sighup("/var/run/sprout.pid")
+
+    def on_joining_cluster(self, cluster_view):
+        self.on_cluster_changing(cluster_view)
+
+    def on_new_cluster_config_ready(self, cluster_view):
+        os.system("service astaire reload")
+        os.system("service astaire wait-sync")
+
+    def on_stable_cluster(self, cluster_view):
+        self.on_cluster_changing(cluster_view)
+        issue_alarm(constants.CLEAR_MEMCACHED_NOT_YET_CLUSTERED)
+
+    def on_leaving_cluster(self, cluster_view):
+        pass
+
+
+def load_as_plugin():
+    return SproutMemcachedPlugin()


### PR DESCRIPTION
Can you review `sprout-base.root/usr/share/clearwater/clearwater-cluster-manager/plugins/sprout_memcached_plugin.py`?

Note that:
* I'll rename `write_cluster_settings` to `write_memcached_cluster_settings`
* I've gone for fairly minimal logs, because the logs generated before calling into the plugin and the logs generated by run_command should be enough to tell what's going on