### PR TITLE
Reviewer AMC: Pull in pjmedia, requires rename of mod_auth

### DIFF
--- a/include/authentication.h
+++ b/include/authentication.h
@@ -44,7 +44,7 @@
 #include "acr.h"
 #include "analyticslogger.h"
 
-extern pjsip_module mod_auth;
+extern pjsip_module mod_authentication;
 
 pj_status_t init_authentication(const std::string& realm_name,
                                 AvStore* avstore,

--- a/sprout/authentication.cpp
+++ b/sprout/authentication.cpp
@@ -62,12 +62,12 @@ extern "C" {
 
 
 //
-// mod_auth authenticates SIP requests.  It must be inserted into the
+// mod_authentication authenticates SIP requests.  It must be inserted into the
 // stack below the transaction layer.
 //
 static pj_bool_t authenticate_rx_request(pjsip_rx_data *rdata);
 
-pjsip_module mod_auth =
+pjsip_module mod_authentication =
 {
   NULL, NULL,                         // prev, next
   pj_str("mod-auth"),                 // Name
@@ -819,7 +819,7 @@ pj_status_t init_authentication(const std::string& realm_name,
 
   // Register the authentication module.  This needs to be in the stack
   // before the transaction layer.
-  status = pjsip_endpt_register_module(stack_data.endpt, &mod_auth);
+  status = pjsip_endpt_register_module(stack_data.endpt, &mod_authentication);
 
   // Initialize the authorization server.
   pjsip_auth_srv_init_param params;
@@ -834,5 +834,5 @@ pj_status_t init_authentication(const std::string& realm_name,
 
 void destroy_authentication()
 {
-  pjsip_endpt_unregister_module(stack_data.endpt, &mod_auth);
+  pjsip_endpt_unregister_module(stack_data.endpt, &mod_authentication);
 }

--- a/sprout/sprout_base.mk
+++ b/sprout/sprout_base.mk
@@ -120,6 +120,10 @@ LDFLAGS += -lmemcached \
            -lsas \
            -lboost_filesystem
 
+# Explicitly link some pjsip modules. Some plugins require symbols in them
+# (which sprout-base doesn't), and the plugins are dynamically linked at run
+# time, so GCC won't link in the symbols they need unless we explicitly tell
+# it to.
 LDFLAGS += -Wl,--whole-archive -lpjmedia-x86_64-unknown-linux-gnu -Wl,--no-whole-archive $(shell PKG_CONFIG_PATH=${ROOT}/usr/lib/pkgconfig pkg-config --libs libpjproject)
 
 include ${MK_DIR}/platform.mk

--- a/sprout/sprout_base.mk
+++ b/sprout/sprout_base.mk
@@ -120,7 +120,7 @@ LDFLAGS += -lmemcached \
            -lsas \
            -lboost_filesystem
 
-LDFLAGS += $(shell PKG_CONFIG_PATH=${ROOT}/usr/lib/pkgconfig pkg-config --libs libpjproject)
+LDFLAGS += -Wl,--whole-archive -lpjmedia-x86_64-unknown-linux-gnu -Wl,--no-whole-archive $(shell PKG_CONFIG_PATH=${ROOT}/usr/lib/pkgconfig pkg-config --libs libpjproject)
 
 include ${MK_DIR}/platform.mk
 


### PR DESCRIPTION
We've removed all references to pjmedia from sprout_base, but some app servers require it. So we need to explicitly link it. Unfortunately, pulling this in also pulls in a reference to a symbol called mod_auth, so we rename our mod_auth. mmtel and call_diversion_as now load agian.