### PR TITLE
[Reviewer: Ellie] Create an empty /etc/clearwater/remote_cluster_settings if we have a …

### DIFF
--- a/sprout-base.root/etc/init.d/sprout
+++ b/sprout-base.root/etc/init.d/sprout
@@ -111,8 +111,18 @@ get_settings()
           echo "servers=$cluster_ip:11211" > /etc/clearwater/cluster_settings
         fi
 
-        # If the remote cluster settings file exists then start sprout with geo-redundancy enabled
-        [ -f /etc/clearwater/remote_cluster_settings ] && remote_memstore_arg="--remote-memstore=/etc/clearwater/remote_cluster_settings"
+        # If a remote site name is set, then start sprout with geo-redundancy enabled
+        if [ -n "$remote_site_name" ]
+        then
+          remote_memstore_arg="--remote-memstore=/etc/clearwater/remote_cluster_settings"
+          # Create /etc/clearwater/remote_cluster_settings if it doesn't exist
+          # This means 'service sprout reload' will pick up changes
+          if [ ! -f /etc/clearwater/remote_cluster_settings ]
+          then
+            echo "servers=" > /etc/clearwater/remote_cluster_settings
+          fi  
+        fi
+
 
         # Set up defaults for user settings then pull in any overrides.
         # Sprout uses blocking look-up services, so must run multi-threaded.

--- a/sprout-base.root/etc/init.d/sprout
+++ b/sprout-base.root/etc/init.d/sprout
@@ -111,18 +111,14 @@ get_settings()
           echo "servers=$cluster_ip:11211" > /etc/clearwater/cluster_settings
         fi
 
-        # If a remote site name is set, then start sprout with geo-redundancy enabled
-        if [ -n "$remote_site_name" ]
-        then
-          remote_memstore_arg="--remote-memstore=/etc/clearwater/remote_cluster_settings"
-          # Create /etc/clearwater/remote_cluster_settings if it doesn't exist
-          # This means 'service sprout reload' will pick up changes
-          if [ ! -f /etc/clearwater/remote_cluster_settings ]
-          then
-            echo "servers=" > /etc/clearwater/remote_cluster_settings
-          fi  
-        fi
+        remote_memstore_arg="--remote-memstore=/etc/clearwater/remote_cluster_settings"
 
+        # Create /etc/clearwater/remote_cluster_settings if it doesn't exist
+        # This means 'service sprout reload' will pick up changes
+        if [ ! -f /etc/clearwater/remote_cluster_settings ]
+        then
+          echo "servers=" > /etc/clearwater/remote_cluster_settings
+        fi  
 
         # Set up defaults for user settings then pull in any overrides.
         # Sprout uses blocking look-up services, so must run multi-threaded.

--- a/sprout/main.cpp
+++ b/sprout/main.cpp
@@ -1658,9 +1658,8 @@ int main(int argc, char* argv[])
 
         if (!(((MemcachedStore*)remote_data_store)->has_servers()))
         {
-          LOG_ERROR("Remote cluster settings file '%s' does not contain a valid set of servers",
-                    opt.remote_store_servers.c_str());
-          return 1;
+          LOG_WARNING("Remote cluster settings file '%s' does not contain a valid set of servers",
+                      opt.remote_store_servers.c_str());
         };
       }
     }


### PR DESCRIPTION
…remote site

Pretty standard - this just gets a blank remote_cluster_settings in place, ready to be updated by etcd without requiring a software restart.

I've tested by:
* upgrading Sprout to this version
* checking that an empty remote_cluster_settings was created
* checking that Sprout started up, used this file and didn't crash
* Registering, making a call and unregistering, checking we didn't crash or have any odd logs
* Adding a server to remote_cluster_settings, reloading, and checking that it was used

I had debug logging turned on throughout, in case any debug logs caused a crash (one did).

I initially made the remote_cluster_settings stuff conditional on remote_site_name, but then removed this so it's unconditional - this fixes https://github.com/Metaswitch/sprout/issues/871, and means that non-etcd GR deployments still work, without the need to add remote_site_name. (In theory it would allow you to add a remote site without impacting service, although I don't think we need to test/prove this.)