### PR TITLE
[Reviewer: Ellie] Use public addresses as aliases

### DIFF
--- a/sprout-base.root/etc/init.d/sprout
+++ b/sprout-base.root/etc/init.d/sprout
@@ -218,10 +218,8 @@ get_daemon_args()
                      --http-port=9888
                      --analytics=$log_directory
                      --log-file=$log_directory
-                     --log-level=$log_level"
-
-        # Add alias host names if any are defined.
-        [ -z $alias_list ] || DAEMON_ARGS="$DAEMON_ARGS --alias=$alias_list"
+                     --log-level=$log_level
+                     --alias=$public_ip,$public_hostname,$alias_list"
 
         if [ -n "$reg_max_expires" ]
         then


### PR DESCRIPTION
Tested live, with a version of poll-sip that uses $public_hostname in the request URI. OPTIONS polls without this change fail with 483 Too Many Hops, and succeed with this change.

(I've verified that having a trailing `,` when alias_list is undefined is harmless.)