### PR TITLE
[Reviewer: Ellie] Honour upstream_port=0, which should use SRV records for upstream_hos…

### DIFF
--- a/sprout/main.cpp
+++ b/sprout/main.cpp
@@ -893,14 +893,6 @@ static pj_status_t init_options(int argc, char* argv[], struct options* options)
     }
   }
 
-  // If the upstream proxy port is not set, default it to the trusted port.
-  // We couldn't do this earlier because the trusted port might be set after
-  // the upstream proxy.
-  if (options->upstream_proxy_port == 0)
-  {
-    options->upstream_proxy_port = options->pcscf_trusted_port;
-  }
-
   return PJ_SUCCESS;
 }
 


### PR DESCRIPTION
…tname

This lets Bono use SRV if the upstream_port setting is explicitly set to 0. (It has to be explicitly set to 0 - init.d defaults it to 5054 otherwise, which is consistent with us generally not requiring SRV records by default.

`upstream_port=0` isn't very intuitive for SRV, but I think it's good enough. Fixes #1021.