### PR TITLE
[Reviewer: Ellie] Disable plugin loading for I-CSCF

### DIFF
--- a/sprout-base.root/usr/share/clearwater/clearwater-cluster-manager/plugins/sprout_chronos_plugin.py
+++ b/sprout-base.root/usr/share/clearwater/clearwater-cluster-manager/plugins/sprout_chronos_plugin.py
@@ -83,6 +83,6 @@ class SproutChronosPlugin(SynchroniserPluginBase):
 
 
 def load_as_plugin(local_server, local_site, remote_site):
-    is_icscf = (run_command('. /etc/clearwater/config; [[ "$scscf" == 0 ]]') == 0)
-    if not is_icscf:
+    is_icscf_only = (run_command('. /etc/clearwater/config; [ "x$scscf" = "x0" ]') == 0)
+    if not is_icscf_only:
         return SproutChronosPlugin(local_server, local_site, remote_site)

--- a/sprout-base.root/usr/share/clearwater/clearwater-cluster-manager/plugins/sprout_chronos_plugin.py
+++ b/sprout-base.root/usr/share/clearwater/clearwater-cluster-manager/plugins/sprout_chronos_plugin.py
@@ -83,4 +83,6 @@ class SproutChronosPlugin(SynchroniserPluginBase):
 
 
 def load_as_plugin(local_server, local_site, remote_site):
-    return SproutChronosPlugin(local_server, local_site, remote_site)
+    is_icscf = (run_command('. /etc/clearwater/config; [[ "$scscf" == 0 ]]') == 0)
+    if not is_icscf:
+        return SproutChronosPlugin(local_server, local_site, remote_site)

--- a/sprout-base.root/usr/share/clearwater/clearwater-cluster-manager/plugins/sprout_memcached_plugin.py
+++ b/sprout-base.root/usr/share/clearwater/clearwater-cluster-manager/plugins/sprout_memcached_plugin.py
@@ -75,6 +75,6 @@ class SproutMemcachedPlugin(SynchroniserPluginBase):
 
 
 def load_as_plugin(ip, local_site, remote_site):
-    is_icscf = (run_command('. /etc/clearwater/config; [[ "$scscf" == 0 ]]') == 0)
-    if not is_icscf:
+    is_icscf_only = (run_command('. /etc/clearwater/config; [ "x$scscf" = "x0" ]') == 0)
+    if not is_icscf_only:
         return SproutMemcachedPlugin(ip, local_site, remote_site)

--- a/sprout-base.root/usr/share/clearwater/clearwater-cluster-manager/plugins/sprout_memcached_plugin.py
+++ b/sprout-base.root/usr/share/clearwater/clearwater-cluster-manager/plugins/sprout_memcached_plugin.py
@@ -75,4 +75,6 @@ class SproutMemcachedPlugin(SynchroniserPluginBase):
 
 
 def load_as_plugin(ip, local_site, remote_site):
-    return SproutMemcachedPlugin(ip, local_site, remote_site)
+    is_icscf = (run_command('. /etc/clearwater/config; [[ "$scscf" == 0 ]]') == 0)
+    if not is_icscf:
+        return SproutMemcachedPlugin(ip, local_site, remote_site)

--- a/sprout-base.root/usr/share/clearwater/clearwater-cluster-manager/plugins/sprout_remote_memcached_plugin.py
+++ b/sprout-base.root/usr/share/clearwater/clearwater-cluster-manager/plugins/sprout_remote_memcached_plugin.py
@@ -82,5 +82,6 @@ class SproutRemoteMemcachedPlugin(SynchroniserPluginBase):
 
 
 def load_as_plugin(ip, local_site, remote_site):
-    if remote_site != "":
+    is_icscf = (run_command('. /etc/clearwater/config; [[ "$scscf" == 0 ]]') == 0)
+    if not (is_icscf or remote_site == ""):
         return SproutRemoteMemcachedPlugin(ip, local_site, remote_site)

--- a/sprout-base.root/usr/share/clearwater/clearwater-cluster-manager/plugins/sprout_remote_memcached_plugin.py
+++ b/sprout-base.root/usr/share/clearwater/clearwater-cluster-manager/plugins/sprout_remote_memcached_plugin.py
@@ -82,6 +82,6 @@ class SproutRemoteMemcachedPlugin(SynchroniserPluginBase):
 
 
 def load_as_plugin(ip, local_site, remote_site):
-    is_icscf = (run_command('. /etc/clearwater/config; [[ "$scscf" == 0 ]]') == 0)
-    if not (is_icscf or remote_site == ""):
+    is_icscf_only = (run_command('. /etc/clearwater/config; [ "x$scscf" = "x0" ]') == 0)
+    if not (is_icscf_only or remote_site == ""):
         return SproutRemoteMemcachedPlugin(ip, local_site, remote_site)


### PR DESCRIPTION
As discussed, only Sprout nodes which are S-CSCFs should join the Memcached or Chronos clusters. This implements that, by making the plugins run a Bash command that checks if $scscf has been explicitly set to 0.

This is pretty unpleasant code, and our S-CSCF/I-CSCF config model is hacky in other ways (e.g. it breaks shared config) - can you raise an issue (or ask for a user story) to track fixing this up?

I haven't tested, but I'll spin up a Sprout node and:
* not mention scscf in the config file and verify that these plugins load
* explicitly set scscf=5054 in the config file and verify that these plugins load
* explicitly set scscf=0 in the config file and verify that these plugins don't load