### PR TITLE
[Reviewer: Andy] Make sure the HTTP stack handlers are always using valid memory. 

### DIFF
--- a/sprout/main.cpp
+++ b/sprout/main.cpp
@@ -1837,21 +1837,21 @@ int main(int argc, char* argv[])
     return 1;
   }
 
+  RegistrationTimeoutTask::Config reg_timeout_config(local_reg_store, remote_reg_store, hss_connection);
+  AuthTimeoutTask::Config auth_timeout_config(av_store, hss_connection);
+  DeregistrationTask::Config deregistration_config(local_reg_store, remote_reg_store, hss_connection, sip_resolver);
+
+  // The RegistrationTimeoutTask and AuthTimeoutTask both handle
+  // chronos requests, so use the ChronosHandler.
+  ChronosHandler<RegistrationTimeoutTask, RegistrationTimeoutTask::Config> reg_timeout_handler(&reg_timeout_config);
+  ChronosHandler<AuthTimeoutTask, AuthTimeoutTask::Config> auth_timeout_handler(&auth_timeout_config);
+  HttpStackUtils::SpawningHandler<DeregistrationTask, DeregistrationTask::Config> deregistration_handler(&deregistration_config);
+  HttpStackUtils::PingHandler ping_handler;
+
   HttpStack* http_stack = NULL;
   if (opt.scscf_enabled)
   {
     http_stack = HttpStack::get_instance();
-
-    RegistrationTimeoutTask::Config reg_timeout_config(local_reg_store, remote_reg_store, hss_connection);
-    AuthTimeoutTask::Config auth_timeout_config(av_store, hss_connection);
-    DeregistrationTask::Config deregistration_config(local_reg_store, remote_reg_store, hss_connection, sip_resolver);
-
-    // The RegistrationTimeoutTask and AuthTimeoutTask both handle
-    // chronos requests, so use the ChronosHandler.
-    ChronosHandler<RegistrationTimeoutTask, RegistrationTimeoutTask::Config> reg_timeout_handler(&reg_timeout_config);
-    ChronosHandler<AuthTimeoutTask, AuthTimeoutTask::Config> auth_timeout_handler(&auth_timeout_config);
-    HttpStackUtils::SpawningHandler<DeregistrationTask, DeregistrationTask::Config> deregistration_handler(&deregistration_config);
-    HttpStackUtils::PingHandler ping_handler;
 
     try
     {


### PR DESCRIPTION
This PR moves the various HTTP handlers we use into the same scope as the `sem_wait` that main spends most of it's time in (so that the memory the handlers use won't be reused). 

This manifested as an HTTP flow from chronos to sprout appearing in the SAS call flow. I have confirmed that this change fixes that issue. 