### PR TITLE
[Reviewer: Steve] Make SIP TCP connect timeout configurable

### DIFF
--- a/include/cfgoptions.h
+++ b/include/cfgoptions.h
@@ -131,6 +131,7 @@ struct options
   int                                  exception_max_ttl;
   int                                  sip_blacklist_duration;
   int                                  http_blacklist_duration;
+  int                                  sip_tcp_connect_timeout;
 };
 
 // Objects that must be shared with dynamically linked sproutlets must be

--- a/include/stack.h
+++ b/include/stack.h
@@ -100,6 +100,7 @@ struct stack_data_struct
 
   int default_session_expires;
   int max_session_expires;
+  int sip_tcp_connect_timeout;
 };
 
 extern struct stack_data_struct stack_data;
@@ -155,6 +156,7 @@ extern pj_status_t init_stack(const std::string& sas_system_name,
                               int record_routing_model,
                               const int default_session_expires,
                               const int max_session_expires,
+                              const int sip_tcp_connect_timeout,
                               QuiescingManager *quiescing_mgr,
                               const std::string& cdf_domain);
 extern pj_status_t start_pjsip_threads();

--- a/sprout-base.root/etc/init.d/sprout
+++ b/sprout-base.root/etc/init.d/sprout
@@ -275,6 +275,7 @@ get_daemon_args()
         [ "$additional_home_domains" = "" ] || DAEMON_ARGS="$DAEMON_ARGS --additional-domains=$additional_home_domains"
         [ "$sip_blacklist_duration" = "" ]  || DAEMON_ARGS="$DAEMON_ARGS --sip-blacklist-duration=$sip_blacklist_duration"
         [ "$http_blacklist_duration" = "" ] || DAEMON_ARGS="$DAEMON_ARGS --http-blacklist-duration=$http_blacklist_duration"
+        [ "$sip_tcp_connect_timeout" = "" ] || DAEMON_ARGS="$DAEMON_ARGS --sip-tcp-connect-timeout=$sip_tcp_connect_timeout"
 }
 
 #

--- a/sprout/main.cpp
+++ b/sprout/main.cpp
@@ -121,7 +121,8 @@ enum OptionTypes
   OPT_EXCEPTION_MAX_TTL,
   OPT_MAX_SESSION_EXPIRES,
   OPT_SIP_BLACKLIST_DURATION,
-  OPT_HTTP_BLACKLIST_DURATION
+  OPT_HTTP_BLACKLIST_DURATION,
+  OPT_SIP_TCP_CONNECT_TIMEOUT
 };
 
 
@@ -186,6 +187,7 @@ const static struct pj_getopt_option long_opt[] =
   { "exception-max-ttl",            required_argument, 0, OPT_EXCEPTION_MAX_TTL},
   { "sip-blacklist-duration",       required_argument, 0, OPT_SIP_BLACKLIST_DURATION},
   { "http-blacklist-duration",      required_argument, 0, OPT_HTTP_BLACKLIST_DURATION},
+  { "sip-tcp-connect-timeout",      required_argument, 0, OPT_SIP_TCP_CONNECT_TIMEOUT},
   { NULL,                           0,                 0, 0}
 };
 
@@ -324,6 +326,8 @@ static void usage(void)
        "                            The amount of time to blacklist a SIP peer when it is unresponsive.\n"
        "     --http-blacklist-duration <secs>\n"
        "                            The amount of time to blacklist an HTTP peer when it is unresponsive.\n"
+       "     --sip-tcp-connect-timeout <milliseconds>\n"
+       "                            The amount of time to wait for a SIP TCP connection to establish.\n"
        " -F, --log-file <directory>\n"
        "                            Log to file in specified directory\n"
        " -L, --log-level N          Set log level to N (default: 4)\n"
@@ -883,6 +887,12 @@ static pj_status_t init_options(int argc, char* argv[], struct options* options)
                options->http_blacklist_duration);
       break;
 
+    case OPT_SIP_TCP_CONNECT_TIMEOUT:
+      options->sip_tcp_connect_timeout = atoi(pj_optarg);
+      LOG_INFO("SIP TCP connect timeout set to %d",
+               options->sip_tcp_connect_timeout);
+      break;
+
     case 'h':
       usage();
       return -1;
@@ -1203,6 +1213,7 @@ int main(int argc, char* argv[])
   opt.exception_max_ttl = 600;
   opt.sip_blacklist_duration = SIPResolver::DEFAULT_BLACKLIST_DURATION;
   opt.http_blacklist_duration = HttpResolver::DEFAULT_BLACKLIST_DURATION;
+  opt.sip_tcp_connect_timeout = 1000;
 
   boost::filesystem::path p = argv[0];
   // Copy the filename to a string so that we can be sure of its lifespan -
@@ -1464,6 +1475,7 @@ int main(int argc, char* argv[])
                       opt.record_routing_model,
                       opt.default_session_expires,
                       opt.max_session_expires,
+                      opt.sip_tcp_connect_timeout,
                       quiescing_mgr,
                       opt.billing_cdf);
 

--- a/sprout/main.cpp
+++ b/sprout/main.cpp
@@ -1213,7 +1213,7 @@ int main(int argc, char* argv[])
   opt.exception_max_ttl = 600;
   opt.sip_blacklist_duration = SIPResolver::DEFAULT_BLACKLIST_DURATION;
   opt.http_blacklist_duration = HttpResolver::DEFAULT_BLACKLIST_DURATION;
-  opt.sip_tcp_connect_timeout = 1000;
+  opt.sip_tcp_connect_timeout = 2000;
 
   boost::filesystem::path p = argv[0];
   // Copy the filename to a string so that we can be sure of its lifespan -

--- a/sprout/stack.cpp
+++ b/sprout/stack.cpp
@@ -329,6 +329,7 @@ pj_status_t create_tcp_listener_transport(int port, pj_str_t& host, pjsip_tpfact
   pj_sockaddr_cp(&cfg.bind_addr, &addr);
   pj_memcpy(&cfg.addr_name, &published_name, sizeof(published_name));
   cfg.async_cnt = 50;
+  cfg.connect_timeout_ms = stack_data.sip_tcp_connect_timeout;
 
   status = pjsip_tcp_transport_start3(stack_data.endpt, &cfg, tcp_factory);
 
@@ -552,6 +553,7 @@ pj_status_t init_stack(const std::string& system_name,
                        int record_routing_model,
                        const int default_session_expires,
                        const int max_session_expires,
+                       const int sip_tcp_connect_timeout,
                        QuiescingManager *quiescing_mgr_arg,
                        const std::string& cdf_domain)
 {
@@ -598,6 +600,7 @@ pj_status_t init_stack(const std::string& system_name,
   // Copy other functional options to stack data.
   stack_data.default_session_expires = default_session_expires;
   stack_data.max_session_expires = max_session_expires;
+  stack_data.sip_tcp_connect_timeout = sip_tcp_connect_timeout;
 
   // Work out local and public hostnames and cluster domain names.
   stack_data.local_host = (local_host != "") ? pj_str(local_host_cstr) : *pj_gethostname();


### PR DESCRIPTION
Steve,

Please can you review the second half of my fix to the TCP connection timeout aspect of #1018?

This simply plumbs the connection timeout through to PJSIP.

Note that even after this fix there are still issues surrounding AS timeouts.  In particular,

*   if you don't specify TCP transport on the AS URI, sprout falls back to UDP after the TCP connection attempt times out, and so doesn't try other TCP targets - obviously, the work-around to this is simply to specify TCP transport
*   this fix handles the case where an AS takes too long to connect, but it doesn't handle the case where an AS accepts the connection but doesn't respond to the SIP request - maybe that's OK, though, or at least much less mainline (I think we're getting into undefined parts of the specs here).

Cheers,

Matt