### PR TITLE
[Reviewer: Andy] Fix path to plugin_utils

### DIFF
--- a/sprout-base.root/usr/share/clearwater/clearwater-config-manager/plugins/sprout_bgcf_json_plugin.py
+++ b/sprout-base.root/usr/share/clearwater/clearwater-config-manager/plugins/sprout_bgcf_json_plugin.py
@@ -32,7 +32,7 @@
 
 from metaswitch.clearwater.config_manager.plugin_base import \
     ConfigPluginBase
-from metaswitch.clearwater.config_manager.plugin_utils import \
+from metaswitch.clearwater.etcd_shared.plugin_utils import \
     run_command
 import logging
 import sys

--- a/sprout-base.root/usr/share/clearwater/clearwater-config-manager/plugins/sprout_enum_json_plugin.py
+++ b/sprout-base.root/usr/share/clearwater/clearwater-config-manager/plugins/sprout_enum_json_plugin.py
@@ -32,7 +32,7 @@
 
 from metaswitch.clearwater.config_manager.plugin_base import \
     ConfigPluginBase
-from metaswitch.clearwater.config_manager.plugin_utils import \
+from metaswitch.clearwater.etcd_shared.plugin_utils import \
     run_command
 import logging
 import sys

--- a/sprout-base.root/usr/share/clearwater/clearwater-config-manager/plugins/sprout_json_plugin.py
+++ b/sprout-base.root/usr/share/clearwater/clearwater-config-manager/plugins/sprout_json_plugin.py
@@ -31,7 +31,7 @@
 # as those licenses appear in the file LICENSE-OPENSSL.
 
 from metaswitch.clearwater.config_manager.plugin_base import ConfigPluginBase, FileStatus
-from metaswitch.clearwater.config_manager.plugin_utils import run_command
+from metaswitch.clearwater.etcd_shared.plugin_utils import run_command
 import logging
 
 _log = logging.getLogger("sprout_json_plugin")

--- a/sprout-base.root/usr/share/clearwater/clearwater-config-manager/plugins/sprout_scscf_json_plugin.py
+++ b/sprout-base.root/usr/share/clearwater/clearwater-config-manager/plugins/sprout_scscf_json_plugin.py
@@ -32,7 +32,7 @@
 
 from metaswitch.clearwater.config_manager.plugin_base import \
     ConfigPluginBase
-from metaswitch.clearwater.config_manager.plugin_utils import \
+from metaswitch.clearwater.etcd_shared.plugin_utils import \
     run_command
 import logging
 import sys


### PR DESCRIPTION
I picked up the latest code out of master and it didn't work. It looks like plugin_utils.py has been moved into etcd_shared, but the references here and in clearwater-etcd haven't been updated.