### PR TITLE
Fix two spelling errors and links to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains the core Clearwater SIP function, specifically
 *   restund, the STUN/TURN server used by Clearwater
 *   sipp, a SIP stress tool used for testing Clearwater.
 
-Project Clearwater is an open-source IMS core, developed by [Metaswitch Networks](http://www.metaswitch.com) and released under the [GNU GPLv3](http://www.projectclearwater.org/download/license/). You can find more information about it on [our website](http://www.projectclearwater.org/) or [our wiki](https://github.com/Metaswitch/clearwater-docs/wiki).
+Project Clearwater is an open-source IMS core, developed by [Metaswitch Networks](http://www.metaswitch.com) and released under the [GNU GPLv3](http://www.projectclearwater.org/download/license/). You can find more information about it on [our website](http://www.projectclearwater.org/) or in [our docs](http://clearwater.readthedocs.org/en/latest/).
 
 ## Sprout and Bono
 

--- a/docs/Bono Sprout Architecture.md
+++ b/docs/Bono Sprout Architecture.md
@@ -82,7 +82,7 @@ The stateful proxy is the largest and most complex component within Sprout, part
 The stateful proxy actually registers as two modules with PJSIP.
 
 - The first module, termed the proxy module, registers for receiving requests and responses at the UA layer with a priority slight higher than the registrar.  This module handles all requests, setting up the necessary transactions, and any responses which do not correspond to an active transaction (for example, 200 OK retransmissions).
-- The second module is a special kind of PJSIP module, termed a transaction user module.  It does not get invoked for received and sent messages, instead it gets invoked by the transaction layer for events on the transaction, including sent/received messages, timer expiries and transport failures.
+- The second module is a special kind of PJSIP module, termed a transaction user module.  It does not get invoked for received and sent messages, instead it gets invoked by the transaction layer for events on the transaction, including sent/received messages, timer expires and transport failures.
 
 The function of the stateful proxy can be divided into [common processing](#commonproc), and [Bono](#bonoproc) and [Sprout](#sproutproc) specific processing.
 

--- a/docs/CallDiversionAS.md
+++ b/docs/CallDiversionAS.md
@@ -1,6 +1,6 @@
 # Call Diversion AS
 
-The Call Diversion AS is based on the call diversion function in the [MMTEL TAS](https://github.com/Metaswitch/clearwater-docs/wiki/Clearwater-Call-Diversion-Support).
+The Call Diversion AS is based on the call diversion function in the [MMTEL TAS](http://clearwater.readthedocs.org/en/latest/Clearwater_Call_Diversion_Support/index.html).
 
 However, the MMTEL TAS requires an XDMS (XML Database Management Server).  Since the call diversion configuration is fixed, this just adds unnecessary complexity.
 

--- a/docs/IscInterface.md
+++ b/docs/IscInterface.md
@@ -8,7 +8,7 @@ it works, and then walks through the design and implementation of this
 interface in Sprout.
 
 For specification details, see the
-[Application Server Guide in the wiki](https://github.com/Metaswitch/clearwater-docs/wiki/Application-Server-Guide).
+[Application Server Guide](http://clearwater.readthedocs.org/en/latest/Application_Server_Guide/index.html).
 
 Contents
 --------
@@ -190,7 +190,7 @@ function. It is invoked when the URI `sip:mmtel.<domain>` appears in
 the iFCs.
 
 The internal MMTEL AS is invoked synchronously by function call,
-rather than asychronously by SIP message passing. This complicates the
+rather than asynchronously by SIP message passing. This complicates the
 Sprout internals.
 
 When acting as an originating application server, the MMTEL AS either


### PR DESCRIPTION
I spotted the two spelling errors, and the clearwater-docs wiki just points you to the ReadTheDocs site. I made my best guess at the corresponding new pages.