### PR TITLE
[Reviewer: Andy] Change how S-CSCF value is checked to avoid error logs

### DIFF
--- a/sprout-base.root/usr/share/clearwater/clearwater-cluster-manager/plugins/sprout_chronos_plugin.py
+++ b/sprout-base.root/usr/share/clearwater/clearwater-cluster-manager/plugins/sprout_chronos_plugin.py
@@ -84,9 +84,9 @@ class SproutChronosPlugin(SynchroniserPluginBase):
 
 
 def load_as_plugin(local_server, local_site, remote_site):
-    is_icscf_only = (subprocess.check_output('. /etc/clearwater/config && echo $scscf',
+    is_icscf_only = (subprocess.check_output('. /etc/clearwater/config && echo -n $scscf',
                                              shell=True,
-                                             stderr=subprocess.STDOUT) == "0\n")
+                                             stderr=subprocess.STDOUT) == "0")
     if not is_icscf_only:
         _log.info("Loading the Sprout Chronos plugin")
         return SproutChronosPlugin(local_server, local_site, remote_site)

--- a/sprout-base.root/usr/share/clearwater/clearwater-cluster-manager/plugins/sprout_chronos_plugin.py
+++ b/sprout-base.root/usr/share/clearwater/clearwater-cluster-manager/plugins/sprout_chronos_plugin.py
@@ -38,6 +38,7 @@ from metaswitch.clearwater.cluster_manager.plugin_utils import \
     write_chronos_cluster_settings, run_command
 from metaswitch.clearwater.cluster_manager.alarms import issue_alarm
 from metaswitch.clearwater.cluster_manager import constants
+import subprocess
 import logging
 
 _log = logging.getLogger("sprout_chronos_plugin")
@@ -83,6 +84,9 @@ class SproutChronosPlugin(SynchroniserPluginBase):
 
 
 def load_as_plugin(local_server, local_site, remote_site):
-    is_icscf_only = (run_command('. /etc/clearwater/config; [ "x$scscf" = "x0" ]') == 0)
+    is_icscf_only = (subprocess.check_output('. /etc/clearwater/config && echo $scscf',
+                                             shell=True,
+                                             stderr=subprocess.STDOUT) == "0\n")
     if not is_icscf_only:
+        _log.info("Loading the Sprout Chronos plugin")
         return SproutChronosPlugin(local_server, local_site, remote_site)

--- a/sprout-base.root/usr/share/clearwater/clearwater-cluster-manager/plugins/sprout_memcached_plugin.py
+++ b/sprout-base.root/usr/share/clearwater/clearwater-cluster-manager/plugins/sprout_memcached_plugin.py
@@ -76,9 +76,9 @@ class SproutMemcachedPlugin(SynchroniserPluginBase):
 
 
 def load_as_plugin(ip, local_site, remote_site):
-    is_icscf_only = (subprocess.check_output('. /etc/clearwater/config && echo $scscf',
+    is_icscf_only = (subprocess.check_output('. /etc/clearwater/config && echo -n $scscf',
                                              shell=True,
-                                             stderr=subprocess.STDOUT) == "0\n")
+                                             stderr=subprocess.STDOUT) == "0")
     if not is_icscf_only:
         _log.info("Loading the Sprout Memcached plugin")
         return SproutMemcachedPlugin(ip, local_site, remote_site)

--- a/sprout-base.root/usr/share/clearwater/clearwater-cluster-manager/plugins/sprout_memcached_plugin.py
+++ b/sprout-base.root/usr/share/clearwater/clearwater-cluster-manager/plugins/sprout_memcached_plugin.py
@@ -38,6 +38,7 @@ from metaswitch.clearwater.cluster_manager.plugin_utils import \
 from metaswitch.clearwater.cluster_manager.alarms import issue_alarm
 from metaswitch.clearwater.cluster_manager import constants
 import logging
+import subprocess
 import os
 
 _log = logging.getLogger("sprout_memcached_plugin")
@@ -75,6 +76,9 @@ class SproutMemcachedPlugin(SynchroniserPluginBase):
 
 
 def load_as_plugin(ip, local_site, remote_site):
-    is_icscf_only = (run_command('. /etc/clearwater/config; [ "x$scscf" = "x0" ]') == 0)
+    is_icscf_only = (subprocess.check_output('. /etc/clearwater/config && echo $scscf',
+                                             shell=True,
+                                             stderr=subprocess.STDOUT) == "0\n")
     if not is_icscf_only:
+        _log.info("Loading the Sprout Memcached plugin")
         return SproutMemcachedPlugin(ip, local_site, remote_site)

--- a/sprout-base.root/usr/share/clearwater/clearwater-cluster-manager/plugins/sprout_remote_memcached_plugin.py
+++ b/sprout-base.root/usr/share/clearwater/clearwater-cluster-manager/plugins/sprout_remote_memcached_plugin.py
@@ -37,6 +37,7 @@ from metaswitch.clearwater.cluster_manager.plugin_utils import \
     run_command, write_memcached_cluster_settings
 from metaswitch.clearwater.cluster_manager.alarms import issue_alarm
 from metaswitch.clearwater.cluster_manager import constants
+import subprocess
 import logging
 import os
 
@@ -82,6 +83,9 @@ class SproutRemoteMemcachedPlugin(SynchroniserPluginBase):
 
 
 def load_as_plugin(ip, local_site, remote_site):
-    is_icscf_only = (run_command('. /etc/clearwater/config; [ "x$scscf" = "x0" ]') == 0)
+    is_icscf_only = (subprocess.check_output('. /etc/clearwater/config && echo $scscf',
+                                             shell=True,
+                                             stderr=subprocess.STDOUT) == "0\n")
     if not (is_icscf_only or remote_site == ""):
+        _log.info("Loading the Sprout remote Memcached plugin")
         return SproutRemoteMemcachedPlugin(ip, local_site, remote_site)

--- a/sprout-base.root/usr/share/clearwater/clearwater-cluster-manager/plugins/sprout_remote_memcached_plugin.py
+++ b/sprout-base.root/usr/share/clearwater/clearwater-cluster-manager/plugins/sprout_remote_memcached_plugin.py
@@ -83,9 +83,9 @@ class SproutRemoteMemcachedPlugin(SynchroniserPluginBase):
 
 
 def load_as_plugin(ip, local_site, remote_site):
-    is_icscf_only = (subprocess.check_output('. /etc/clearwater/config && echo $scscf',
+    is_icscf_only = (subprocess.check_output('. /etc/clearwater/config && echo -n $scscf',
                                              shell=True,
-                                             stderr=subprocess.STDOUT) == "0\n")
+                                             stderr=subprocess.STDOUT) == "0")
     if not (is_icscf_only or remote_site == ""):
         _log.info("Loading the Sprout remote Memcached plugin")
         return SproutRemoteMemcachedPlugin(ip, local_site, remote_site)


### PR DESCRIPTION
The cluster-manager logs contain the following in the mainline case:
```
27-05-2015 17:55:34.406 UTC ERROR plugin_utils.py:58: Command . /etc/clearwater/config; [ "x$scscf" = "x0" ] failed with return code 1 and printed output ''
```
This PR changes how we check the SCSCF value to avoid the misleading error log. Tested live