### PR TITLE
[Reviewer: Alex] Extra ENT logs in support of clearwater-config-manager

### DIFF
--- a/include/sprout_pd_definitions.h
+++ b/include/sprout_pd_definitions.h
@@ -456,7 +456,7 @@ static const PDLog CL_SPROUT_SCSCF_FILE_MISSING
   PDLOG_ERR,
   "The file listing S-CSCFs is not present.",
   "Sprout is configured as an I-CSCF, but the /etc/clearwater/s-cscf.json file (defining which S-CSCFs to use) does not exist.",
-  "This prevents the I-CSCF from selecting an S-CSCF.",
+  "The Sprout I-CSCF will not be able to select an S-CSCF.",
   "If you are expecting clearwater-config-manager to be managing this file, check that it is running and that there are no ENT logs relating to it or clearwater-etcd. If you are managing /etc/clearwater/s-cscf.json manually, follow the documentation to create it."
 );
 
@@ -466,7 +466,7 @@ static const PDLog CL_SPROUT_SCSCF_FILE_EMPTY
   PDLOG_ERR,
   "The file listing S-CSCFs is empty.",
   "Sprout is configured as an I-CSCF, but the /etc/clearwater/s-cscf.json file (defining which S-CSCFs to use) is empty.",
-  "This prevents the I-CSCF from selecting an S-CSCF.",
+  "The Sprout I-CSCF will not be able to select an S-CSCF.",
   "If you are expecting clearwater-config-manager to be managing this file, check that it is running and that there are no ENT logs relating to it or clearwater-etcd. If you are managing /etc/clearwater/s-cscf.json manually, follow the documentation to create it."
 );
 
@@ -476,7 +476,7 @@ static const PDLog CL_SPROUT_SCSCF_FILE_INVALID
   PDLOG_ERR,
   "The file listing S-CSCFs is invalid.",
   "Sprout is configured as an I-CSCF, but the /etc/clearwater/s-cscf.json file (defining which S-CSCFs to use) is invalid due to invalid JSON or missing elements.",
-  "This prevents the I-CSCF from selecting an S-CSCF.",
+  "The Sprout I-CSCF will not be able to select an S-CSCF.",
   "Follow the documentation to create this file correctly."
 );
 

--- a/include/sprout_pd_definitions.h
+++ b/include/sprout_pd_definitions.h
@@ -161,18 +161,6 @@ static const PDLog CL_SPROUT_XDM_NO_HOMESTEAD
   "/etc/clearwater/config file. "
 );
 
-static const PDLog CL_SPROUT_BAD_S_CSCF_JSON
-(
-  PDLogBase::CL_SPROUT_ID + 11,
-  PDLOG_ERR,
-  "Missing or malformed /etc/clearwater/s-cscf.json file.",
-  "The s-cscf.json file must be corrected or created to allow the I-CSCF to "
-  "select an S-CSCF for a subscriber.",
-  "This prevents the I-CSCF from selecting an S-CSCF.",
-  "Correct or add the /etc/clearwater/s-cscf.json file "
-  "and reload the application."
-);
-
 static const PDLog1<const char*> CL_SPROUT_SIP_INIT_INTERFACE_FAIL
 (
   PDLogBase::CL_SPROUT_ID + 12,
@@ -430,6 +418,96 @@ static const PDLog CL_SPROUT_PLUGIN_FAILURE
   "The service is no longer available.",
   "The application will exit and restart until the problem is fixed.",
   "Check the configuration in /etc/clearwater/config."
+);
+
+static const PDLog1<const char*> CL_SPROUT_ENUM_FILE_MISSING
+(
+  PDLogBase::CL_SPROUT_ID + 39,
+  PDLOG_ERR,
+  "The ENUM file is not present.",
+  "Sprout is configured to use file-based ENUM, but the configuration file does not exist.",
+  "Sprout will not be able to translate telephone numbers into routable URIs.",
+  "Confirm that %s is the correct file to be using. If not, correct /etc/clearwater/shared_config. If so, create it according to the documentation. If you are expecting clearwater-config-manager to be managing this file, check that it is running and that there are no ENT logs relating to it or clearwater-etcd."
+);
+
+static const PDLog1<const char*> CL_SPROUT_ENUM_FILE_EMPTY
+(
+  PDLogBase::CL_SPROUT_ID + 40,
+  PDLOG_ERR,
+  "The ENUM file is empty.",
+  "Sprout is configured to use file-based ENUM, but the configuration file is empty.",
+  "Sprout will not be able to translate telephone numbers into routable URIs.",
+  "Confirm that %s is the correct file to be using. If not, correct /etc/clearwater/shared_config. If so, create it according to the documentation. If you are expecting clearwater-config-manager to be managing this file, check that it is running and that there are no ENT logs relating to it or clearwater-etcd."
+);
+
+static const PDLog1<const char*> CL_SPROUT_ENUM_FILE_INVALID
+(
+  PDLogBase::CL_SPROUT_ID + 41,
+  PDLOG_ERR,
+  "The ENUM file is invalid.",
+  "Sprout is configured to use file-based ENUM, but the configuration file does not exist.",
+  "Sprout will not be able to translate telephone numbers into routable URIs.",
+  "Confirm that %s is the correct file to be using. If not, correct /etc/clearwater/shared_config. If so, check that it is a valid and correctly formatted file."
+);
+
+static const PDLog CL_SPROUT_SCSCF_FILE_MISSING
+(
+  PDLogBase::CL_SPROUT_ID + 42,
+  PDLOG_ERR,
+  "The file listing S-CSCFs is not present.",
+  "Sprout is configured as an I-CSCF, but the /etc/clearwater/s-cscf.json file (defining which S-CSCFs to use) does not exist.",
+  "This prevents the I-CSCF from selecting an S-CSCF.",
+  "If you are expecting clearwater-config-manager to be managing this file, check that it is running and that there are no ENT logs relating to it or clearwater-etcd. If you are managing /etc/clearwater/s-cscf.json manually, follow the documentation to create it."
+);
+
+static const PDLog CL_SPROUT_SCSCF_FILE_EMPTY
+(
+  PDLogBase::CL_SPROUT_ID + 43,
+  PDLOG_ERR,
+  "The file listing S-CSCFs is empty.",
+  "Sprout is configured as an I-CSCF, but the /etc/clearwater/s-cscf.json file (defining which S-CSCFs to use) is empty.",
+  "This prevents the I-CSCF from selecting an S-CSCF.",
+  "If you are expecting clearwater-config-manager to be managing this file, check that it is running and that there are no ENT logs relating to it or clearwater-etcd. If you are managing /etc/clearwater/s-cscf.json manually, follow the documentation to create it."
+);
+
+static const PDLog CL_SPROUT_SCSCF_FILE_INVALID
+(
+  PDLogBase::CL_SPROUT_ID + 44,
+  PDLOG_ERR,
+  "The file listing S-CSCFs is invalid.",
+  "Sprout is configured as an I-CSCF, but the /etc/clearwater/s-cscf.json file (defining which S-CSCFs to use) is invalid due to invalid JSON or missing elements.",
+  "This prevents the I-CSCF from selecting an S-CSCF.",
+  "Follow the documentation to create this file correctly."
+);
+
+static const PDLog CL_SPROUT_BGCF_FILE_MISSING
+(
+  PDLogBase::CL_SPROUT_ID + 45,
+  PDLOG_NOTICE,
+  "The file listing BGCF routes is not present.",
+  "The /etc/clearwater/bgcf.json file, defining which BGCF routes to use, does not exist.",
+  "Sprout will not be able to route any calls outside the local deployment.",
+  "If you are expecting clearwater-config-manager to be managing this file, check that it is running and that there are no ENT logs relating to it or clearwater-etcd. If you are not expecting clearwater-config-manager to manage this, but are expecting to route calls off-net, follow the documentation to create routes in /etc/clearwater/bgcf.json. Otherwise, no action is needed."
+);
+
+static const PDLog CL_SPROUT_BGCF_FILE_EMPTY
+(
+  PDLogBase::CL_SPROUT_ID + 46,
+  PDLOG_ERR,
+  "The file listing BGCF routes is empty.",
+  "The /etc/clearwater/bgcf.json file, defining which BGCF routes to use, is empty.",
+  "Sprout will not be able to route any calls outside the local deployment.",
+  "If you are expecting clearwater-config-manager to be managing this file, check that it is running and that there are no ENT logs relating to it or clearwater-etcd. If you are not expecting clearwater-config-manager to manage this, but are expecting to route calls off-net, follow the documentation to create routes in /etc/clearwater/bgcf.json. Otherwise, delete this empty file."
+);
+
+static const PDLog CL_SPROUT_BGCF_FILE_INVALID
+(
+  PDLogBase::CL_SPROUT_ID + 47,
+  PDLOG_ERR,
+  "The file listing BGCF routes is not present or empty.",
+  "The /etc/clearwater/bgcf.json file, defining which BGCF routes to use, is not valid (due to invalid JSON or missing elements).",
+  "Sprout will not be able to route some or all calls outside the local deployment.", 
+  "If you are expecting to route calls off-net, follow the documentation to create routes in /etc/clearwater/bgcf.json. Otherwise, delete this file."
 );
 
 #endif

--- a/sprout-base.root/usr/share/clearwater/clearwater-cluster-manager/plugins/sprout_chronos_plugin.py
+++ b/sprout-base.root/usr/share/clearwater/clearwater-cluster-manager/plugins/sprout_chronos_plugin.py
@@ -37,6 +37,7 @@ from metaswitch.clearwater.cluster_manager.plugin_base import \
 from metaswitch.clearwater.cluster_manager.plugin_utils import \
     write_chronos_cluster_settings, run_command
 from metaswitch.clearwater.cluster_manager.alarms import issue_alarm
+from metaswitch.clearwater.cluster_manager import pdlogs
 from metaswitch.clearwater.cluster_manager import constants
 import subprocess
 import logging
@@ -50,12 +51,16 @@ class SproutChronosPlugin(SynchroniserPluginBase):
         self._key = "/clearwater/{}/sprout/clustering/chronos".format(params.local_site)
         _log.debug("Raising not-clustered alarm")
         issue_alarm(constants.RAISE_CHRONOS_NOT_YET_CLUSTERED)
+        pdlogs.NOT_YET_CLUSTERED_ALARM.log(cluster_desc=self.cluster_description())
 
     def key(self):
         return self._key
 
     def files(self):
         return ["/etc/chronos/chronos_cluster.conf"]
+
+    def cluster_description(self):
+        return "local chronos cluster"
 
     def on_cluster_changing(self, cluster_view):
         _log.debug("Sprout's Chronos cluster is changing")

--- a/sprout-base.root/usr/share/clearwater/clearwater-cluster-manager/plugins/sprout_memcached_plugin.py
+++ b/sprout-base.root/usr/share/clearwater/clearwater-cluster-manager/plugins/sprout_memcached_plugin.py
@@ -36,6 +36,7 @@ from metaswitch.clearwater.cluster_manager.plugin_base import \
 from metaswitch.clearwater.cluster_manager.plugin_utils import \
     run_command, write_memcached_cluster_settings
 from metaswitch.clearwater.cluster_manager.alarms import issue_alarm
+from metaswitch.clearwater.cluster_manager import pdlogs
 from metaswitch.clearwater.cluster_manager import constants
 import logging
 import subprocess
@@ -47,6 +48,7 @@ _log = logging.getLogger("sprout_memcached_plugin")
 class SproutMemcachedPlugin(SynchroniserPluginBase):
     def __init__(self, params):
         issue_alarm(constants.RAISE_MEMCACHED_NOT_YET_CLUSTERED)
+        pdlogs.NOT_YET_CLUSTERED_ALARM.log(cluster_desc=self.cluster_description())
         self._key = "/clearwater/{}/sprout/clustering/memcached".format(params.local_site)
 
     def key(self):
@@ -54,6 +56,9 @@ class SproutMemcachedPlugin(SynchroniserPluginBase):
 
     def files(self):
         return ["/etc/clearwater/cluster_settings"]
+
+    def cluster_description(self):
+        return "local memcached cluster"
 
     def on_cluster_changing(self, cluster_view):
         write_memcached_cluster_settings("/etc/clearwater/cluster_settings",

--- a/sprout-base.root/usr/share/clearwater/clearwater-cluster-manager/plugins/sprout_remote_memcached_plugin.py
+++ b/sprout-base.root/usr/share/clearwater/clearwater-cluster-manager/plugins/sprout_remote_memcached_plugin.py
@@ -58,6 +58,9 @@ class SproutRemoteMemcachedPlugin(SynchroniserPluginBase):
     def files(self):
         return ["/etc/clearwater/remote_cluster_settings"]
 
+    def cluster_description(self):
+        return "remote memcached cluster"
+
     def on_cluster_changing(self, cluster_view):
         if self._remote_site != "":
             write_memcached_cluster_settings("/etc/clearwater/remote_cluster_settings",

--- a/sprout/bgcfservice.cpp
+++ b/sprout/bgcfservice.cpp
@@ -46,6 +46,7 @@
 #include "sas.h"
 #include "sproutsasevent.h"
 #include "pjutils.h"
+#include "sprout_pd_definitions.h"
 
 BgcfService::BgcfService(std::string configuration) :
   _configuration(configuration),
@@ -65,6 +66,7 @@ void BgcfService::update_routes()
   {
     LOG_STATUS("No BGCF configuration (file %s does not exist)",
                _configuration.c_str());
+    CL_SPROUT_BGCF_FILE_MISSING.log();
     return;
   }
 
@@ -80,6 +82,7 @@ void BgcfService::update_routes()
     // LCOV_EXCL_START
     LOG_ERROR("Failed to read BGCF configuration data from %s", 
               _configuration.c_str());
+    CL_SPROUT_BGCF_FILE_EMPTY.log();
     return;
     // LCOV_EXCL_STOP
   }
@@ -93,6 +96,7 @@ void BgcfService::update_routes()
     LOG_ERROR("Failed to read BGCF configuration data: %s\nError: %s",
               bgcf_str.c_str(),
               rapidjson::GetParseError_En(doc.GetParseError()));
+    CL_SPROUT_BGCF_FILE_INVALID.log();
     return;
   }
 
@@ -153,6 +157,7 @@ void BgcfService::update_routes()
       else
       {
         LOG_WARNING("Badly formed BGCF route entry");
+        CL_SPROUT_BGCF_FILE_INVALID.log();
       }
     }
 
@@ -162,6 +167,7 @@ void BgcfService::update_routes()
   catch (JsonFormatError err)
   {
     LOG_ERROR("Badly formed BGCF configuration file - missing routes object");
+    CL_SPROUT_BGCF_FILE_INVALID.log();
   }
 }
 

--- a/sprout/enumservice.cpp
+++ b/sprout/enumservice.cpp
@@ -49,6 +49,7 @@
 #include "utils.h"
 #include "log.h"
 #include "sproutsasevent.h"
+#include "sprout_pd_definitions.h"
 
 
 const boost::regex EnumService::CHARS_TO_STRIP_FROM_UAS = boost::regex("([^0-9+]|(?<=.)[^0-9])");
@@ -98,6 +99,7 @@ JSONEnumService::JSONEnumService(std::string configuration)
   {
     LOG_STATUS("No ENUM configuration (file %s does not exist)",
                configuration.c_str());
+    CL_SPROUT_ENUM_FILE_MISSING.log(configuration.c_str());
     return;
   }
 
@@ -113,6 +115,7 @@ JSONEnumService::JSONEnumService(std::string configuration)
     // LCOV_EXCL_START
     LOG_ERROR("Failed to read ENUM configuration data from %s",
               configuration.c_str());
+    CL_SPROUT_ENUM_FILE_EMPTY.log(configuration.c_str());
     return;
     // LCOV_EXCL_STOP
   }
@@ -126,6 +129,7 @@ JSONEnumService::JSONEnumService(std::string configuration)
     LOG_ERROR("Failed to read ENUM configuration data: %s\nError: %s",
               enum_str.c_str(),
               rapidjson::GetParseError_En(doc.GetParseError()));
+    CL_SPROUT_ENUM_FILE_INVALID.log(configuration.c_str());
     return;
   }
 
@@ -169,12 +173,14 @@ JSONEnumService::JSONEnumService(std::string configuration)
         // Badly formed number block.
         LOG_WARNING("Badly formed ENUM number block (hit error at %s:%d)",
                     err._file, err._line);
+        CL_SPROUT_ENUM_FILE_INVALID.log(configuration.c_str());
       }
     }
   }
   catch (JsonFormatError err)
   {
     LOG_ERROR("Badly formed ENUM configuration data - missing number_blocks object");
+    CL_SPROUT_ENUM_FILE_INVALID.log(configuration.c_str());
   }
 }
 

--- a/sprout/scscfselector.cpp
+++ b/sprout/scscfselector.cpp
@@ -63,9 +63,9 @@ void SCSCFSelector::update_scscf()
   if ((stat(_configuration.c_str(), &s) != 0) &&
       (errno == ENOENT))
   {
-    CL_SPROUT_BAD_S_CSCF_JSON.log();
     LOG_STATUS("No S-CSCF configuration data (file %s does not exist)",
                _configuration.c_str());
+    CL_SPROUT_SCSCF_FILE_MISSING.log();
     return;
   }
 
@@ -81,6 +81,7 @@ void SCSCFSelector::update_scscf()
     // LCOV_EXCL_START
     LOG_ERROR("Failed to read S-CSCF configuration data from %s",
               _configuration.c_str());
+    CL_SPROUT_SCSCF_FILE_EMPTY.log();
     return;
     // LCOV_EXCL_STOP
   }
@@ -94,6 +95,7 @@ void SCSCFSelector::update_scscf()
     LOG_ERROR("Failed to read S-CSCF configuration data: %s\nError: %s",
               scscf_str.c_str(),
               rapidjson::GetParseError_En(doc.GetParseError()));
+    CL_SPROUT_SCSCF_FILE_INVALID.log();
     return;
   }
 
@@ -142,6 +144,7 @@ void SCSCFSelector::update_scscf()
         // Badly formed number block.
         LOG_WARNING("Badly formed S-CSCF entry (hit error at %s:%d)",
                     err._file, err._line);
+        CL_SPROUT_SCSCF_FILE_INVALID.log();
       }
     }
 
@@ -150,6 +153,7 @@ void SCSCFSelector::update_scscf()
   catch (JsonFormatError err)
   {
     LOG_ERROR("Badly formed S-CSCF configuration file - missing s-cscfs object");
+    CL_SPROUT_SCSCF_FILE_INVALID.log();
   }
 }
 


### PR DESCRIPTION
Tested live:

```
Jun  4 13:12:50 ip-10-181-26-75 sprout[704]: 2041 - Description: The ENUM file is invalid. @@Cause: Sprout is configured to use file-based ENUM, but the configuration file does not exist. @@Effect: Sprout will not be able to translate telephone numbers into routable URIs. @@Action: Confirm that /etc/clearwater/enum.json is the correct file to be using. If not, correct /etc/clearwater/shared_config. If so, check that it is a valid and correctly formatted file.
Jun  4 13:12:50 ip-10-181-26-75 sprout[704]: 2047 - Description: The file listing BGCF routes is not present or empty. @@Cause: The /etc/clearwater/bgcf.json file, defining which BGCF routes to use, is not valid (due to invalid JSON or missing elements). @@Effect: Sprout will not be able to route some or all calls outside the local deployment. @@Action: If you are expecting to route calls off-net, follow the documentation to create routes in /etc/clearwater/bgcf.json. Otherwise, delete this file.
Jun  4 13:12:50 ip-10-181-26-75 sprout[704]: 2044 - Description: The file listing S-CSCFs is invalid. @@Cause: Sprout is configured as an I-CSCF, but the /etc/clearwater/s-cscf.json file (defining which S-CSCFs to use) is invalid due to invalid JSON or missing elements. @@Effect: This prevents the I-CSCF from selecting an S-CSCF. @@Action: Follow the documentation to create this file correctly.

Jun  4 13:15:27 ip-10-181-26-75 sprout[1833]: 2040 - Description: The ENUM file is empty. @@Cause: Sprout is configured to use file-based ENUM, but the configuration file is empty. @@Effect: Sprout will not be able to translate telephone numbers into routable URIs. @@Action: Confirm that /etc/clearwater/enum.json is the correct file to be using. If not, correct /etc/clearwater/shared_config. If so, create it according to the documentation. If you are expecting clearwater-config-manager to be managing this file, check that it is running and that there are no ENT logs relating to it or clearwater-etcd.
Jun  4 13:15:27 ip-10-181-26-75 sprout[1833]: 2046 - Description: The file listing BGCF routes is empty. @@Cause: The /etc/clearwater/bgcf.json file, defining which BGCF routes to use, is empty. @@Effect: Sprout will not be able to route any calls outside the local deployment. @@Action: If you are expecting clearwater-config-manager to be managing this file, check that it is running and that there are no ENT logs relating to it or clearwater-etcd. If you are not expecting clearwater-config-manager to manage this, but are expecting to route calls off-net, follow the documentation to create routes in /etc/clearwater/bgcf.json. Otherwise, delete this empty file.
Jun  4 13:15:27 ip-10-181-26-75 sprout[1833]: 2043 - Description: The file listing S-CSCFs is empty. @@Cause: Sprout is configured as an I-CSCF, but the /etc/clearwater/s-cscf.json file (defining which S-CSCFs to use) is empty. @@Effect: This prevents the I-CSCF from selecting an S-CSCF. @@Action: If you are expecting clearwater-config-manager to be managing this file, check that it is running and that there are no ENT logs relating to it or clearwater-etcd. If you are managing /etc/clearwater/s-cscf.json manually, follow the documentation to create it.

Jun  4 13:16:08 ip-10-181-26-75 sprout[2213]: 2039 - Description: The ENUM file is not present. @@Cause: Sprout is configured to use file-based ENUM, but the configuration file does not exist. @@Effect: Sprout will not be able to translate telephone numbers into routable URIs. @@Action: Confirm that /etc/clearwater/enum.json is the correct file to be using. If not, correct /etc/clearwater/shared_config. If so, create it according to the documentation. If you are expecting clearwater-config-manager to be managing this file, check that it is running and that there are no ENT logs relating to it or clearwater-etcd.
Jun  4 13:16:08 ip-10-181-26-75 sprout[2213]: 2045 - Description: The file listing BGCF routes is not present. @@Cause: The /etc/clearwater/bgcf.json file, defining which BGCF routes to use, does not exist. @@Effect: Sprout will not be able to route any calls outside the local deployment. @@Action: If you are expecting clearwater-config-manager to be managing this file, check that it is running and that there are no ENT logs relating to it or clearwater-etcd. If you are not expecting clearwater-config-manager to manage this, but are expecting to route calls off-net, follow the documentation to create routes in /etc/clearwater/bgcf.json. Otherwise, no action is needed.
Jun  4 13:16:08 ip-10-181-26-75 sprout[2213]: 2042 - Description: The file listing S-CSCFs is not present. @@Cause: Sprout is configured as an I-CSCF, but the /etc/clearwater/s-cscf.json file (defining which S-CSCFs to use) does not exist. @@Effect: This prevents the I-CSCF from selecting an S-CSCF. @@Action: If you are expecting clearwater-config-manager to be managing this file, check that it is running and that there are no ENT logs relating to it or clearwater-etcd. If you are managing /etc/clearwater/s-cscf.json manually, follow the documentation to create it.

```