### PR TITLE
[Reviewer: Alex] Add configurable SIP send timeout

### DIFF
--- a/debian/bono.init.d
+++ b/debian/bono.init.d
@@ -175,6 +175,8 @@ get_daemon_args()
         [ "$additional_home_domains" = "" ] || DAEMON_ARGS="$DAEMON_ARGS --additional-domains $additional_home_domains"
         [ "$sip_blacklist_duration" = "" ]  || DAEMON_ARGS="$DAEMON_ARGS --sip-blacklist-duration=$sip_blacklist_duration"
         [ "$http_blacklist_duration" = "" ] || DAEMON_ARGS="$DAEMON_ARGS --http-blacklist-duration=$http_blacklist_duration"
+        [ "$sip_tcp_connect_timeout" = "" ] || DAEMON_ARGS="$DAEMON_ARGS --sip-tcp-connect-timeout=$sip_tcp_connect_timeout"
+        [ "$sip_tcp_send_timeout" = "" ]    || DAEMON_ARGS="$DAEMON_ARGS --sip-tcp-send-timeout=$sip_tcp_send_timeout"
 }
 
 #

--- a/include/cfgoptions.h
+++ b/include/cfgoptions.h
@@ -132,6 +132,7 @@ struct options
   int                                  sip_blacklist_duration;
   int                                  http_blacklist_duration;
   int                                  sip_tcp_connect_timeout;
+  int                                  sip_tcp_send_timeout;
 };
 
 // Objects that must be shared with dynamically linked sproutlets must be

--- a/include/stack.h
+++ b/include/stack.h
@@ -101,6 +101,7 @@ struct stack_data_struct
   int default_session_expires;
   int max_session_expires;
   int sip_tcp_connect_timeout;
+  int sip_tcp_send_timeout;
 };
 
 extern struct stack_data_struct stack_data;
@@ -157,6 +158,7 @@ extern pj_status_t init_stack(const std::string& sas_system_name,
                               const int default_session_expires,
                               const int max_session_expires,
                               const int sip_tcp_connect_timeout,
+                              const int sip_tcp_send_timeout,
                               QuiescingManager *quiescing_mgr,
                               const std::string& cdf_domain);
 extern pj_status_t start_pjsip_threads();

--- a/sprout-base.root/etc/init.d/sprout
+++ b/sprout-base.root/etc/init.d/sprout
@@ -272,6 +272,7 @@ get_daemon_args()
         [ "$sip_blacklist_duration" = "" ]  || DAEMON_ARGS="$DAEMON_ARGS --sip-blacklist-duration=$sip_blacklist_duration"
         [ "$http_blacklist_duration" = "" ] || DAEMON_ARGS="$DAEMON_ARGS --http-blacklist-duration=$http_blacklist_duration"
         [ "$sip_tcp_connect_timeout" = "" ] || DAEMON_ARGS="$DAEMON_ARGS --sip-tcp-connect-timeout=$sip_tcp_connect_timeout"
+        [ "$sip_tcp_send_timeout" = "" ]    || DAEMON_ARGS="$DAEMON_ARGS --sip-tcp-send-timeout=$sip_tcp_send_timeout"
 }
 
 #

--- a/sprout/main.cpp
+++ b/sprout/main.cpp
@@ -122,7 +122,8 @@ enum OptionTypes
   OPT_MAX_SESSION_EXPIRES,
   OPT_SIP_BLACKLIST_DURATION,
   OPT_HTTP_BLACKLIST_DURATION,
-  OPT_SIP_TCP_CONNECT_TIMEOUT
+  OPT_SIP_TCP_CONNECT_TIMEOUT,
+  OPT_SIP_TCP_SEND_TIMEOUT
 };
 
 
@@ -188,6 +189,7 @@ const static struct pj_getopt_option long_opt[] =
   { "sip-blacklist-duration",       required_argument, 0, OPT_SIP_BLACKLIST_DURATION},
   { "http-blacklist-duration",      required_argument, 0, OPT_HTTP_BLACKLIST_DURATION},
   { "sip-tcp-connect-timeout",      required_argument, 0, OPT_SIP_TCP_CONNECT_TIMEOUT},
+  { "sip-tcp-send-timeout",         required_argument, 0, OPT_SIP_TCP_SEND_TIMEOUT},
   { NULL,                           0,                 0, 0}
 };
 
@@ -328,6 +330,9 @@ static void usage(void)
        "                            The amount of time to blacklist an HTTP peer when it is unresponsive.\n"
        "     --sip-tcp-connect-timeout <milliseconds>\n"
        "                            The amount of time to wait for a SIP TCP connection to establish.\n"
+       "     --sip-tcp-send-timeout <milliseconds>\n"
+       "                            The amount of time to wait for data sent on a SIP TCP connection to be\n"
+       "                            acknowledged by the peer.\n"
        " -F, --log-file <directory>\n"
        "                            Log to file in specified directory\n"
        " -L, --log-level N          Set log level to N (default: 4)\n"
@@ -893,6 +898,12 @@ static pj_status_t init_options(int argc, char* argv[], struct options* options)
                options->sip_tcp_connect_timeout);
       break;
 
+    case OPT_SIP_TCP_SEND_TIMEOUT:
+      options->sip_tcp_send_timeout = atoi(pj_optarg);
+      LOG_INFO("SIP TCP send timeout set to %d",
+               options->sip_tcp_send_timeout);
+      break;
+
     case 'h':
       usage();
       return -1;
@@ -1214,6 +1225,7 @@ int main(int argc, char* argv[])
   opt.sip_blacklist_duration = SIPResolver::DEFAULT_BLACKLIST_DURATION;
   opt.http_blacklist_duration = HttpResolver::DEFAULT_BLACKLIST_DURATION;
   opt.sip_tcp_connect_timeout = 2000;
+  opt.sip_tcp_send_timeout = 2000;
 
   boost::filesystem::path p = argv[0];
   // Copy the filename to a string so that we can be sure of its lifespan -
@@ -1476,6 +1488,7 @@ int main(int argc, char* argv[])
                       opt.default_session_expires,
                       opt.max_session_expires,
                       opt.sip_tcp_connect_timeout,
+                      opt.sip_tcp_send_timeout,
                       quiescing_mgr,
                       opt.billing_cdf);
 

--- a/sprout/stack.cpp
+++ b/sprout/stack.cpp
@@ -330,6 +330,7 @@ pj_status_t create_tcp_listener_transport(int port, pj_str_t& host, pjsip_tpfact
   pj_memcpy(&cfg.addr_name, &published_name, sizeof(published_name));
   cfg.async_cnt = 50;
   cfg.connect_timeout_ms = stack_data.sip_tcp_connect_timeout;
+  cfg.send_timeout_ms = stack_data.sip_tcp_send_timeout;
 
   status = pjsip_tcp_transport_start3(stack_data.endpt, &cfg, tcp_factory);
 
@@ -554,6 +555,7 @@ pj_status_t init_stack(const std::string& system_name,
                        const int default_session_expires,
                        const int max_session_expires,
                        const int sip_tcp_connect_timeout,
+                       const int sip_tcp_send_timeout,
                        QuiescingManager *quiescing_mgr_arg,
                        const std::string& cdf_domain)
 {
@@ -601,6 +603,7 @@ pj_status_t init_stack(const std::string& system_name,
   stack_data.default_session_expires = default_session_expires;
   stack_data.max_session_expires = max_session_expires;
   stack_data.sip_tcp_connect_timeout = sip_tcp_connect_timeout;
+  stack_data.sip_tcp_send_timeout = sip_tcp_send_timeout;
 
   // Work out local and public hostnames and cluster domain names.
   stack_data.local_host = (local_host != "") ? pj_str(local_host_cstr) : *pj_gethostname();


### PR DESCRIPTION
Alex,

Please can you review this enhancement to add a `sip_tcp_send_timeout` option that controls the amount of time we'll wait for acknowledgement of a TCP PSH.

I've not UT-ed, because there isn't anything to UT, but I have tested live (from Bono to Sprout) and saw a transaction fail quickly with a transport failure if Sprout drops off the network.

Matt