### PR TITLE
Review AMC:  Only translate user=phone SIP URIs to tel URIs in ICSCF if number is global (or enforce_global_lookups not set)

### DIFF
--- a/include/icscfsproutlet.h
+++ b/include/icscfsproutlet.h
@@ -75,7 +75,7 @@ public:
                  SCSCFSelector* scscf_selector,
                  EnumService* enum_service,
                  bool enforce_global_only_lookups,
-                 bool enforce_user_phone, 
+                 bool enforce_user_phone,
                  bool override_npdi);
 
   virtual ~ICSCFSproutlet();
@@ -85,6 +85,13 @@ public:
   SproutletTsx* get_tsx(SproutletTsxHelper* helper,
                         const std::string& alias,
                         pjsip_msg* req);
+
+#ifdef UNIT_TEST
+  inline void set_global_only_lookups_enforced(bool enforce_global_only_lookups)
+  {
+    _global_only_lookups = enforce_global_only_lookups;
+  }
+#endif
 
 private:
 
@@ -112,6 +119,11 @@ private:
   inline bool should_override_npdi() const
   {
     return _override_npdi;
+  }
+
+  inline bool are_global_only_lookups_enforced() const
+  {
+    return _global_only_lookups;
   }
 
   /// Attempts to use ENUM to translate the specified Tel URI into a SIP URI.

--- a/sprout/icscfsproutlet.cpp
+++ b/sprout/icscfsproutlet.cpp
@@ -502,7 +502,7 @@ void ICSCFSproutletTsx::on_rx_initial_request(pjsip_msg* req)
 
       if ((!pj_strcmp(&sip_uri->user_param, &STR_USER_PHONE)) &&
           (PJUtils::is_user_numeric(sip_uri->user)) &&
-          (PJUtils::is_user_global(sip_uri->user)) &&
+          (!_icscf->are_global_only_lookups_enforced() || PJUtils::is_user_global(sip_uri->user)) &&
           (!PJUtils::is_uri_gruu(uri)))
       {
         LOG_DEBUG("Change request URI from SIP URI to tel URI");
@@ -552,7 +552,7 @@ void ICSCFSproutletTsx::on_rx_initial_request(pjsip_msg* req)
     if ((!_icscf->should_require_user_phone()) &&
         (PJSIP_URI_SCHEME_IS_SIP(uri)) &&
         (PJUtils::is_user_numeric(((pjsip_sip_uri*)uri)->user)) &&
-        (PJUtils::is_user_global(((pjsip_sip_uri*)uri)->user)) &&
+        (!_icscf->are_global_only_lookups_enforced() || PJUtils::is_user_global(((pjsip_sip_uri*)uri)->user)) &&
         (!PJUtils::is_uri_gruu(uri)))
     {
       LOG_DEBUG("enforce_user_phone set to false, try using a tel URI");

--- a/sprout/icscfsproutlet.cpp
+++ b/sprout/icscfsproutlet.cpp
@@ -493,14 +493,16 @@ void ICSCFSproutletTsx::on_rx_initial_request(pjsip_msg* req)
     _originating = false;
     pjsip_uri* uri = PJUtils::term_served_user(req);
 
-    // If the Req URI is a SIP URI with the user=phone parameter set, we should
-    // replace it with a tel URI, as per TS24.229 5.3.2.1.
+    // If the Req URI is a SIP URI with the user=phone parameter set, is not a
+    // GRUU and the user part starts with '+' (i.e. is a global phone number),
+    // we should replace it with a tel URI, as per TS24.229 5.3.2.1.
     if (PJSIP_URI_SCHEME_IS_SIP(uri))
     {
       pjsip_sip_uri* sip_uri = (pjsip_sip_uri*)uri;
 
       if ((!pj_strcmp(&sip_uri->user_param, &STR_USER_PHONE)) &&
           (PJUtils::is_user_numeric(sip_uri->user)) &&
+          (PJUtils::is_user_global(sip_uri->user)) &&
           (!PJUtils::is_uri_gruu(uri)))
       {
         LOG_DEBUG("Change request URI from SIP URI to tel URI");
@@ -546,10 +548,11 @@ void ICSCFSproutletTsx::on_rx_initial_request(pjsip_msg* req)
     // Before doing that we should check whether the enforce_user_phone flag is
     // set. If it isn't, and we have a numeric SIP URI, it is possible that
     // this should have been a tel URI, so translate it and do the HSS lookup
-    // again.
+    // again.  Once again, only do this for global numbers.
     if ((!_icscf->should_require_user_phone()) &&
         (PJSIP_URI_SCHEME_IS_SIP(uri)) &&
         (PJUtils::is_user_numeric(((pjsip_sip_uri*)uri)->user)) &&
+        (PJUtils::is_user_global(((pjsip_sip_uri*)uri)->user)) &&
         (!PJUtils::is_uri_gruu(uri)))
     {
       LOG_DEBUG("enforce_user_phone set to false, try using a tel URI");

--- a/sprout/ut/icscfsproutlet_test.cpp
+++ b/sprout/ut/icscfsproutlet_test.cpp
@@ -2715,6 +2715,61 @@ TEST_F(ICSCFSproutletTest, RouteTermInviteUserPhone)
   delete tp;
 }
 
+// The following test (similar to RouteTermInviteUserPhone apart from the
+// absence of leading "+" characters on the user) verifies that I-CSCF doesn't
+// perform a Tel URI conversion if the number is not globally specified (i.e.
+// doesn't start with a "+")
+TEST_F(ICSCFSproutletTest, RouteTermInviteLocalUserPhoneFailure)
+{
+  pjsip_tx_data* tdata;
+
+  // Create a TCP connection to the I-CSCF listening port.
+  TransportFlow* tp = new TransportFlow(TransportFlow::Protocol::TCP,
+                                        stack_data.icscf_port,
+                                        "1.2.3.4",
+                                        49152);
+
+  // Set up the HSS responses for the terminating location query.
+  _hss_connection->set_result("/impu/tel%3A16505551234/location",
+                              "{\"result-code\": 2001,"
+                              " \"scscf\": \"sip:scscf1.homedomain:5058;transport=TCP\"}");
+
+  // Inject an INVITE request to a sip URI representing a telephone number with a
+  // P-Served-User header.
+  Message msg1;
+  msg1._method = "INVITE";
+  msg1._requri = "sip:16505551234@homedomain;user=phone;isub=1234;ext=4321";
+  msg1._to = "16505551234";
+  msg1._via = tp->to_string(false);
+  msg1._extra = "Contact: sip:16505551000@" +
+                tp->to_string(true) +
+                ";ob;expires=300;+sip.ice;reg-id=1;+sip.instance=\"<urn:uuid:00000000-0000-0000-0000-b665231f1213>\"\r\n";
+  msg1._extra += "P-Served-User: <sip:16505551000@homedomain>";
+  msg1._route = "Route: <sip:homedomain>";
+  inject_msg(msg1.get_request(), tp);
+
+  // Expecting 100 Trying and final 404 responses.  I-CSCF shouldn't perform
+  // a TelURI conversion and therefore shouldn't match on the HSS result
+  // inserted above.
+  ASSERT_EQ(2, txdata_count());
+
+  // Check the 100 Trying.
+  tdata = current_txdata();
+  RespMatcher(100).matches(tdata->msg);
+  tp->expect_target(tdata);
+  free_txdata();
+
+  // Check the 404 Not Found.
+  tdata = current_txdata();
+  RespMatcher(404).matches(tdata->msg);
+  tp->expect_target(tdata);
+  free_txdata();
+
+  _hss_connection->delete_result("/impu/tel%3A16505551234/location");
+
+  delete tp;
+}
+
 
 TEST_F(ICSCFSproutletTest, RouteTermInviteNumericSIPURI)
 {

--- a/sprout/ut/icscfsproutlet_test.cpp
+++ b/sprout/ut/icscfsproutlet_test.cpp
@@ -338,6 +338,37 @@ public:
   }
 
 protected:
+  // Common test setup for the RouteTermInviteLocalUserPhone tests
+  TransportFlow *RouteTermInviteLocalUserPhoneSetup()
+  {
+    // Create a TCP connection to the I-CSCF listening port.
+    TransportFlow* tp = new TransportFlow(TransportFlow::Protocol::TCP,
+                                          stack_data.icscf_port,
+                                          "1.2.3.4",
+                                          49152);
+
+    // Set up the HSS responses for the terminating location query.
+    _hss_connection->set_result("/impu/tel%3A16505551234/location",
+                                "{\"result-code\": 2001,"
+                                " \"scscf\": \"sip:scscf1.homedomain:5058;transport=TCP\"}");
+
+    // Inject an INVITE request to a sip URI representing a telephone number with a
+    // P-Served-User header.
+    Message msg1;
+    msg1._method = "INVITE";
+    msg1._requri = "sip:16505551234@homedomain;user=phone;isub=1234;ext=4321";
+    msg1._to = "16505551234";
+    msg1._via = tp->to_string(false);
+    msg1._extra = "Contact: sip:16505551000@" +
+                  tp->to_string(true) +
+                  ";ob;expires=300;+sip.ice;reg-id=1;+sip.instance=\"<urn:uuid:00000000-0000-0000-0000-b665231f1213>\"\r\n";
+    msg1._extra += "P-Served-User: <sip:16505551000@homedomain>";
+    msg1._route = "Route: <sip:homedomain>";
+    inject_msg(msg1.get_request(), tp);
+
+    return tp;
+  }
+
 };
 
 
@@ -2718,35 +2749,16 @@ TEST_F(ICSCFSproutletTest, RouteTermInviteUserPhone)
 // The following test (similar to RouteTermInviteUserPhone apart from the
 // absence of leading "+" characters on the user) verifies that I-CSCF doesn't
 // perform a Tel URI conversion if the number is not globally specified (i.e.
-// doesn't start with a "+")
+// doesn't start with a "+") AND enforce_global_lookups is on.
 TEST_F(ICSCFSproutletTest, RouteTermInviteLocalUserPhoneFailure)
 {
   pjsip_tx_data* tdata;
 
-  // Create a TCP connection to the I-CSCF listening port.
-  TransportFlow* tp = new TransportFlow(TransportFlow::Protocol::TCP,
-                                        stack_data.icscf_port,
-                                        "1.2.3.4",
-                                        49152);
+  // Turn on enforcement of global-only user=phone to Tel URI lookups in I-CSCF
+  _icscf_sproutlet->set_global_only_lookups_enforced(true);
 
-  // Set up the HSS responses for the terminating location query.
-  _hss_connection->set_result("/impu/tel%3A16505551234/location",
-                              "{\"result-code\": 2001,"
-                              " \"scscf\": \"sip:scscf1.homedomain:5058;transport=TCP\"}");
-
-  // Inject an INVITE request to a sip URI representing a telephone number with a
-  // P-Served-User header.
-  Message msg1;
-  msg1._method = "INVITE";
-  msg1._requri = "sip:16505551234@homedomain;user=phone;isub=1234;ext=4321";
-  msg1._to = "16505551234";
-  msg1._via = tp->to_string(false);
-  msg1._extra = "Contact: sip:16505551000@" +
-                tp->to_string(true) +
-                ";ob;expires=300;+sip.ice;reg-id=1;+sip.instance=\"<urn:uuid:00000000-0000-0000-0000-b665231f1213>\"\r\n";
-  msg1._extra += "P-Served-User: <sip:16505551000@homedomain>";
-  msg1._route = "Route: <sip:homedomain>";
-  inject_msg(msg1.get_request(), tp);
+  // Setup common config and submit test INVITE
+  TransportFlow* tp = RouteTermInviteLocalUserPhoneSetup();
 
   // Expecting 100 Trying and final 404 responses.  I-CSCF shouldn't perform
   // a TelURI conversion and therefore shouldn't match on the HSS result
@@ -2770,6 +2782,60 @@ TEST_F(ICSCFSproutletTest, RouteTermInviteLocalUserPhoneFailure)
   delete tp;
 }
 
+// The following test checks that the user=phone => Tel URI conversion IS
+// performed for location lookup for local numbers if enforce_global_lookups
+// is OFF
+TEST_F(ICSCFSproutletTest, RouteTermInviteLocalUserPhoneSuccess)
+{
+  pjsip_tx_data* tdata;
+
+  // Turn off enforcement of global-only user=phone to Tel URI lookups in I-CSCF
+  _icscf_sproutlet->set_global_only_lookups_enforced(false);
+
+  // Setup common config and submit test INVITE
+  TransportFlow* tp = RouteTermInviteLocalUserPhoneSetup();
+
+  // Expecting 100 Trying and forwarded INVITE
+  ASSERT_EQ(2, txdata_count());
+
+  // Check the 100 Trying.
+  tdata = current_txdata();
+  RespMatcher(100).matches(tdata->msg);
+  tp->expect_target(tdata);
+  free_txdata();
+
+  // INVITE request should be forwarded to the server named in the HSS
+  // response, scscf1.homedomain.
+  tdata = current_txdata();
+  expect_target("TCP", "10.10.10.1", 5058, tdata);
+  ReqMatcher r1("INVITE");
+  r1.matches(tdata->msg);
+
+  // Check that a Route header has been added routing the INVITE to the
+  // selected S-CSCF.  This must include the orig parameter.
+  string route = get_headers(tdata->msg, "Route");
+  ASSERT_EQ("Route: <sip:scscf1.homedomain:5058;transport=TCP;lr>", route);
+
+  // Check that no Record-Route headers have been added.
+  string rr = get_headers(tdata->msg, "Record-Route");
+  ASSERT_EQ("", rr);
+
+  // Send a 200 OK response.
+  inject_msg(respond_to_current_txdata(200));
+
+  // Check the response is forwarded back to the source.
+  ASSERT_EQ(1, txdata_count());
+  tdata = current_txdata();
+  tp->expect_target(tdata);
+  RespMatcher r2(200);
+  r2.matches(tdata->msg);
+
+  free_txdata();
+
+  _hss_connection->delete_result("/impu/tel%3A16505551234/location");
+
+  delete tp;
+}
 
 TEST_F(ICSCFSproutletTest, RouteTermInviteNumericSIPURI)
 {


### PR DESCRIPTION
A fix to a technical spec misalignment. TS 24.229 5.3.2.1 says that "user=phone" => Tel URI conversion in I-CSCF on Initial Requests should only be done for global numbers ("...with the user part starting with a + ...") if the enforce_global_lookups feature is turned on.

Tested with a UT that verifies that an INVITE for a "user=phone" SIP URI with a non global number does not match a location record for the corresponding Tel URI and is rejected, and another that verifies that rejection doesn't happen if enforce_global_lookups is off