### PR TITLE
[Reviewer: RKD] Restart clearwater-infrastructure before starting SIPp

### DIFF
--- a/debian/clearwater-sip-stress.init.d
+++ b/debian/clearwater-sip-stress.init.d
@@ -82,6 +82,10 @@ do_start()
         #   1 if some daemons were already running (and any others have been started)
         #   2 if some daemons could not be started (some may have been started)
         RC=0
+
+        # Restart clearwater-infrastructure to pick up any config changes first.
+        service clearwater-infrastructure restart
+
         for index in $(ls -1 /usr/share/clearwater/sip-stress/users.csv.* | sed -e 's/^.*\.//g') ; do
                 start-stop-daemon --start --quiet --pidfile $PIDFILE.$index --exec $DAEMON --test > /dev/null &&
                 start-stop-daemon --start --quiet --background --make-pidfile --pidfile $PIDFILE.$index --exec $DAEMON -- $index


### PR DESCRIPTION
***Not to be merged whilst the code is frozen***

Hi Rob,

Can you have a look at my proposed change to restart clearwater-infrastructure before starting SIPp? Any reason why this isn't a good idea? Saves having to remember to do it manually, and there doesn't seem to be much reason not to just do it automatically.

Tested by adding the line to an existing clearwater-sip-stress node and starting clearwater-sip-stress.

I can't find any associated doc changes so that's good...

Thanks,
Graeme