### PR TITLE
[Reviewer: Andy] Check for install

### DIFF
--- a/debian/sprout-base.postinst
+++ b/debian/sprout-base.postinst
@@ -97,10 +97,10 @@ case "$1" in
         # Stop the cluster/config managers, so that it is restarted by Monit
         # and picks up the new plugins. We check whether the process is 
         # installed to avoid warning logs when etcd isn't being used
-        if [ -e "/etc/init.d/clearwater-cluster-manager" ]; then
+        if [ -x "/etc/init.d/clearwater-cluster-manager" ]; then
           service clearwater-cluster-manager stop || /bin/true
         fi  
-        if [ -e "/etc/init.d/clearwater-config-manager" ]; then
+        if [ -x "/etc/init.d/clearwater-config-manager" ]; then
           service clearwater-config-manager stop || /bin/true
         fi 
 

--- a/debian/sprout-base.postinst
+++ b/debian/sprout-base.postinst
@@ -95,9 +95,14 @@ case "$1" in
         /usr/share/clearwater/infrastructure/scripts/sprout.monit
 
         # Stop the cluster/config managers, so that it is restarted by Monit
-        # and picks up the new plugins.
-        service clearwater-cluster-manager stop || /bin/true
-        service clearwater-config-manager stop || /bin/true
+        # and picks up the new plugins. We check whether the process is 
+        # installed to avoid warning logs when etcd isn't being used
+        if [ -e "/etc/init.d/clearwater-cluster-manager" ]; then
+          service clearwater-cluster-manager stop || /bin/true
+        fi  
+        if [ -e "/etc/init.d/clearwater-config-manager" ]; then
+          service clearwater-config-manager stop || /bin/true
+        fi 
 
         # Restart sprout.  Always do this by terminating sprout so monit will
         # restart it more-or-less immediately.  (monit restart seems to have


### PR DESCRIPTION
Checks whether cluster/config manager is installed before stopping them. If you're happy with this, I'll make the same fix to Memento/Ralf/Homer/Homestead

Part of the fix for #1084 