### PR TITLE
Fixes for etcd issue #110

### DIFF
--- a/sprout-base.root/usr/share/clearwater/clearwater-config-manager/scripts/upload_json
+++ b/sprout-base.root/usr/share/clearwater/clearwater-config-manager/scripts/upload_json
@@ -47,8 +47,8 @@ then
 fi
 
 # Check we can contact `etcd`
-local_site_name=site1
 . /etc/clearwater/config
+[ ! -z $local_site_name ] || local_site_name=site1
 nc -z $local_ip 4000
 if [[ $? != 0 ]]
 then

--- a/sprout-base.root/usr/share/clearwater/clearwater-config-manager/scripts/upload_json
+++ b/sprout-base.root/usr/share/clearwater/clearwater-config-manager/scripts/upload_json
@@ -49,7 +49,7 @@ fi
 # Check we can contact `etcd`
 . /etc/clearwater/config
 [ ! -z $local_site_name ] || local_site_name=site1
-nc -z $local_ip 4000
+nc -z ${management_local_ip:-$local_ip} 4000
 if [[ $? != 0 ]]
 then
   echo "The Clearwater Configuration store (etcd) is not running"
@@ -65,6 +65,6 @@ fi
 
 # Upload the file to etcd
 curl -X PUT \
-     http://$local_ip:4000/v2/keys/clearwater/$local_site_name/configuration/$KEY \
+     http://${management_local_ip:-$local_ip}:4000/v2/keys/clearwater/$local_site_name/configuration/$KEY \
      --data-urlencode \
      value@$CONFPATH/$FILENAME > /dev/null


### PR DESCRIPTION
This is a continuation of the changes in etcd which involves using management_local_ip instead of local_ip throughout the scripts. For some reason this PR is picking up the local_site_name changes that you'll probably want to skip.