### PR TITLE
[Reviewer: Matt] Drop ACKs which the I-CSCF shouldn't be handling

### DIFF
--- a/sprout/icscfsproutlet.cpp
+++ b/sprout/icscfsproutlet.cpp
@@ -117,9 +117,15 @@ SproutletTsx* ICSCFSproutlet::get_tsx(SproutletTsxHelper* helper,
   {
     return (SproutletTsx*)new ICSCFSproutletRegTsx(helper, this);
   }
-  else
+  else if (req->line.req.method.id != PJSIP_ACK_METHOD)
   {
     return (SproutletTsx*)new ICSCFSproutletTsx(helper, this);
+  }
+  else
+  {
+    // ACKs are never "initial requests" (as used by TS 24.229), so never perform
+    // I-CSCF processing - just forward them as-is, or fail them.
+    return NULL;
   }
 }
 

--- a/sprout/ut/icscfsproutlet_test.cpp
+++ b/sprout/ut/icscfsproutlet_test.cpp
@@ -3117,3 +3117,26 @@ TEST_F(ICSCFSproutletTest, RouteOrigInviteBadServerName)
 
   delete tp;
 }
+
+// Test the case where the I-CSCF receives an ACK. This is not valid and should be dropped.
+TEST_F(ICSCFSproutletTest, RouteOutOfDialogAck)
+{
+  // Create a TCP connection to the I-CSCF listening port.
+  TransportFlow* tp = new TransportFlow(TransportFlow::Protocol::TCP,
+                                        stack_data.icscf_port,
+                                        "1.2.3.4",
+                                        49152);
+
+  // Inject an ACK request to a local URI
+  Message msg1;
+  msg1._method = "ACK";
+  msg1._requri = "sip:3196914123@homedomain;transport=UDP";
+  inject_msg(msg1.get_request(), tp);
+
+  // Expect it to just be dropped
+  ASSERT_EQ(0, txdata_count());
+  free_txdata(); 
+  delete tp; 
+}
+
+

--- a/sprout/ut/scscf_test.cpp
+++ b/sprout/ut/scscf_test.cpp
@@ -1652,7 +1652,7 @@ TEST_F(SCSCFTest, TestEnumLocalSIPURINumber)
   msg._extra = "Record-Route: <sip:homedomain>\nP-Asserted-Identity: <sip:+16505551000@homedomain>";
   add_host_mapping("ut.cw-ngv.com", "10.9.8.7");
   list<HeaderMatcher> hdrs;
-  // ENUM fails and wr route to the BGCF, but there are no routes so the call
+  // ENUM fails and we route to the BGCF, but there are no routes so the call
   // is rejected.
   doSlowFailureFlow(msg, 404, "", "No route to target");
 }
@@ -1682,11 +1682,14 @@ TEST_F(SCSCFTest, TestEnumReqURIwithNPData)
 
   Message msg;
   msg._to = "+15108580301;npdi";
+  msg._requri = "sip:+15108580301;npdi@homedomain;user=phone";
   msg._route = "Route: <sip:homedomain;orig>";
   msg._extra = "Record-Route: <sip:homedomain>\nP-Asserted-Identity: <sip:+16505551000@homedomain>";
   add_host_mapping("ut.cw-ngv.com", "10.9.8.7");
-  list<HeaderMatcher> hdrs;
-  doSuccessfulFlow(msg, testing::MatchesRegex(".*+15108580301;npdi@homedomain.*"), hdrs, false);
+  // ENUM fails and we route to the BGCF, but there are no routes so the call
+  // is rejected. (This is unfortunately the same behaviour as we'd get if a rewrite was done, so
+  // we're relying on code coverage metrics to confirm that this function works.) 
+  doSlowFailureFlow(msg, 404, "", "No route to target");
 }
 
 // Test where the request URI represents a number and has NP data. The ENUM


### PR DESCRIPTION
Matt,

Can you review this fix for https://github.com/Metaswitch/sprout/issues/1091? I've:
* taken your initial fix
* added code to not forward requests on if they'd loop - I've made the checking quite strict to avoid false positives
* added a UT for this case
* fixed up one of the S-CSCF tests, which sent in a Request-URI of `sip:+15108580301;npdi@homedomain` and expected it to not be changed, which now falls foul of the "don't forward unchanged requests" logic. I've made this a `user=phone` URI (so that SIP routing rules aren't applied) and checked that there are no new coverage warnings. I'm going to talk to Ellie to see if she has any ideas on how to test this more rigorously.