### PR TITLE
[Reviewer: Andy] Don't retry SIP transactions on SIP-level timeout - it's too slow

### DIFF
--- a/sprout/basicproxy.cpp
+++ b/sprout/basicproxy.cpp
@@ -1863,8 +1863,11 @@ void BasicProxy::UACTsx::on_tsx_state(pjsip_event* event)
           PJUtils::blacklist_server(_servers[_current_server]);
         }
 
-        // Attempt a retry.
-        retrying = retry_request();
+        // Don't retry - if we've waited for a SIP transaction to time out,
+        // the upstream transaction has probably failed anyway.  Not retrying
+        // also avoids us sending an INVITE with a chasing CANCEL when an AS
+        // is unresponsive (see
+        // https://github.com/Metaswitch/sprout/issues/1095).
       }
       else if ((_tsx->state == PJSIP_TSX_STATE_COMPLETED) &&
                (_tsx->status_code == PJSIP_SC_SERVICE_UNAVAILABLE))


### PR DESCRIPTION
Andy,

Please can you review this partial fix to issue #1095?  It simply disables retry on transaction-level timeouts - they're too slow to be any use and cause extra work (and possible race conditions/crashes) when they're hit.

Thanks,

Matt