### PR TITLE
[Reviewer: Rob] Log the to/from URI as SIP URI markers

### DIFF
--- a/include/pjutils.h
+++ b/include/pjutils.h
@@ -271,6 +271,7 @@ pj_bool_t is_user_global(const std::string& user);
 pj_bool_t is_user_global(const pj_str_t& user);
 
 std::string remove_visual_separators(const std::string& user);
+std::string remove_visual_separators(const pj_str_t& number);
 
 pj_bool_t is_user_numeric(const std::string& user);
 pj_bool_t is_user_numeric(const pj_str_t& user);

--- a/sprout/handlers.cpp
+++ b/sprout/handlers.cpp
@@ -126,7 +126,9 @@ static void report_sip_all_register_marker(SAS::TrailId trail, std::string uri_s
     // Create and report the marker.
     SAS::Marker sip_all_register(trail, MARKER_ID_SIP_ALL_REGISTER, 1u);
     sip_all_register.add_var_param(uri_str);
-    sip_all_register.add_var_param(user.slen, user.ptr);
+    sip_all_register.add_var_param(PJUtils::is_user_numeric(user) ?
+                                   PJUtils::remove_visual_separators(user) :
+                                   PJUtils::pj_str_to_string(&user));
     SAS::report_marker(sip_all_register);
   }
   else

--- a/sprout/handlers.cpp
+++ b/sprout/handlers.cpp
@@ -126,6 +126,8 @@ static void report_sip_all_register_marker(SAS::TrailId trail, std::string uri_s
     // Create and report the marker.
     SAS::Marker sip_all_register(trail, MARKER_ID_SIP_ALL_REGISTER, 1u);
     sip_all_register.add_var_param(uri_str);
+    // Add the DN parameter. If the user part is not numeric log the whole URI
+    // so that it displays properly in SAS.
     sip_all_register.add_var_param(PJUtils::is_user_numeric(user) ?
                                    PJUtils::remove_visual_separators(user) :
                                    PJUtils::pj_str_to_string(&user));

--- a/sprout/pjutils.cpp
+++ b/sprout/pjutils.cpp
@@ -1978,6 +1978,8 @@ void PJUtils::report_sas_to_from_markers(SAS::TrailId trail, pjsip_msg* msg)
       pj_str_t to_user = user_from_uri(to_uri);
       SAS::Marker sip_all_register(trail, MARKER_ID_SIP_ALL_REGISTER, 1u);
       sip_all_register.add_var_param(to_uri_str);
+      // Add the DN parameter. If the user part is not numeric log the whole URI
+      // so that it displays properly in SAS.
       sip_all_register.add_var_param(is_user_numeric(to_user) ?
                                      remove_visual_separators(to_user) :
                                      to_uri_str);
@@ -1998,6 +2000,8 @@ void PJUtils::report_sas_to_from_markers(SAS::TrailId trail, pjsip_msg* msg)
                                             SASEvent::SubscribeNotifyType::SUBSCRIBE :
                                             SASEvent::SubscribeNotifyType::NOTIFY);
       sip_subscribe_notify.add_var_param(to_uri_str);
+      // Add the DN parameter. If the user part is not numeric log the whole URI
+      // so that it displays properly in SAS.
       sip_subscribe_notify.add_var_param(is_user_numeric(to_user) ?
                                          remove_visual_separators(to_user) :
                                          to_uri_str);

--- a/sprout/pjutils.cpp
+++ b/sprout/pjutils.cpp
@@ -2010,16 +2010,26 @@ void PJUtils::report_sas_to_from_markers(SAS::TrailId trail, pjsip_msg* msg)
       if (to_uri != NULL)
       {
         pj_str_t to_user = user_from_uri(to_uri);
+
         SAS::Marker called_dn(trail, MARKER_ID_CALLED_DN, 1u);
         called_dn.add_var_param(to_user.slen, to_user.ptr);
         SAS::report_marker(called_dn);
+
+        SAS::Marker called_uri(trail, MARKER_ID_INBOUND_CALLED_URI, 1u);
+        called_uri.add_var_param(uri_to_string(PJSIP_URI_IN_FROMTO_HDR, to_uri));
+        SAS::report_marker(called_uri);
       }
+
       if (from_uri != NULL)
       {
         pj_str_t from_user = user_from_uri(from_uri);
         SAS::Marker calling_dn(trail, MARKER_ID_CALLING_DN, 1u);
         calling_dn.add_var_param(from_user.slen, from_user.ptr);
         SAS::report_marker(calling_dn);
+
+        SAS::Marker calling_uri(trail, MARKER_ID_INBOUND_CALLING_URI, 1u);
+        calling_uri.add_var_param(uri_to_string(PJSIP_URI_IN_FROMTO_HDR, from_uri));
+        SAS::report_marker(calling_uri);
       }
     }
   }


### PR DESCRIPTION
Rob, please could you review this PR that fixes #924. Although we are logging some new markers, the perf impact should be negligible (as they are still much smaller than the SIP message itself).

Tested live, by checking a call could be found by searching on both the calling and called URIs. 