### PR TITLE
[Reviewer: Rob] Be consistent with other devices when logging SIP URIs and DNs

### DIFF
--- a/include/pjutils.h
+++ b/include/pjutils.h
@@ -74,6 +74,8 @@ pj_str_t uri_to_pj_str(pjsip_uri_context_e context,
 std::string uri_to_string(pjsip_uri_context_e context,
                           const pjsip_uri* uri);
 
+std::string strip_uri_scheme(const std::string& uri);
+
 pjsip_uri* uri_from_string(const std::string& uri_s,
                            pj_pool_t* pool,
                            pj_bool_t force_name_addr=false);
@@ -281,8 +283,8 @@ bool does_uri_represent_number(pjsip_uri* uri,
 bool get_npdi(pjsip_uri* uri);
 bool get_rn(pjsip_uri* uri, std::string& routing_value);
 
-bool add_update_session_expires(pjsip_msg* req, 
-                                pj_pool_t* pool, 
+bool add_update_session_expires(pjsip_msg* req,
+                                pj_pool_t* pool,
                                 SAS::TrailId trail);
 
 } // namespace PJUtils

--- a/sprout/handlers.cpp
+++ b/sprout/handlers.cpp
@@ -125,9 +125,9 @@ static void report_sip_all_register_marker(SAS::TrailId trail, std::string uri_s
 
     // Create and report the marker.
     SAS::Marker sip_all_register(trail, MARKER_ID_SIP_ALL_REGISTER, 1u);
-    sip_all_register.add_var_param(uri_str);
-    // Add the DN parameter. If the user part is not numeric log the whole URI
-    // so that it displays properly in SAS.
+    sip_all_register.add_var_param(PJUtils::strip_uri_scheme(uri_str));
+    // Add the DN parameter. If the user part is not numeric just log it in
+    // its entirety.
     sip_all_register.add_var_param(PJUtils::is_user_numeric(user) ?
                                    PJUtils::remove_visual_separators(user) :
                                    PJUtils::pj_str_to_string(&user));
@@ -335,7 +335,7 @@ HTTPCode RegistrationTimeoutTask::parse_response(std::string body)
   if (doc.HasParseError())
   {
     TRC_INFO("Failed to parse opaque data as JSON: %s\nError: %s",
-             json_str.c_str(), 
+             json_str.c_str(),
              rapidjson::GetParseError_En(doc.GetParseError()));
     return HTTP_BAD_REQUEST;
   }
@@ -378,7 +378,7 @@ HTTPCode DeregistrationTask::parse_request(std::string body)
          reg_it != reg_arr.End();
          ++reg_it)
     {
-      try 
+      try
       {
         std::string primary_impu;
         std::string impi = "";


### PR DESCRIPTION
This updates #1136 so that Clearwater is consistent with other the way other products log URIs and DNs on calls, registrations and subscriptions. Please can you review.

I have tested by doing the following. In each case I checked that the trace could be found by URI and DN (if appropriate) and that the results look sensible in SAS. 

* Register with a DN-like URI.
* Register with a non-DN-like URI.
* Call a DN-like URI
* Call a non-DN-like URI.

I will run through these tests on the staging system as well once the PR is merged. 