### PR TITLE
[Reviewer: Andy] Do all SAS Call-Id/Via branch logging in one place

### DIFF
--- a/sprout/authentication.cpp
+++ b/sprout/authentication.cpp
@@ -809,9 +809,6 @@ pj_bool_t authenticate_rx_request(pjsip_rx_data* rdata)
   SAS::Marker start_marker(trail, MARKER_ID_START, 1u);
   SAS::report_marker(start_marker);
 
-  PJUtils::report_sas_to_from_markers(trail, rdata->msg_info.msg);
-  PJUtils::mark_sas_call_branch_ids(trail, NULL, rdata->msg_info.msg);
-
   // Add a SAS end marker
   SAS::Marker end_marker(trail, MARKER_ID_END, 1u);
   SAS::report_marker(end_marker);

--- a/sprout/basicproxy.cpp
+++ b/sprout/basicproxy.cpp
@@ -166,10 +166,6 @@ pj_bool_t BasicProxy::on_rx_response(pjsip_rx_data *rdata)
       res_addr.dst_host.addr.port = hvia->sent_by.port;
     }
 
-    // Report SIP call and branch ID markers on the trail to make sure it gets
-    // associated with the INVITE transaction at SAS.
-    PJUtils::mark_sas_call_branch_ids(get_trail(rdata), rdata->msg_info.cid, rdata->msg_info.msg);
-
     // Forward response
     status = pjsip_endpt_send_response(stack_data.endpt, &res_addr, tdata, NULL, NULL);
 
@@ -1246,21 +1242,6 @@ void BasicProxy::UASTsx::on_tsx_start(const pjsip_rx_data* rdata)
   TRC_DEBUG("Report SAS start marker - trail (%llx)", trail());
   SAS::Marker start_marker(trail(), MARKER_ID_START, 1u);
   SAS::report_marker(start_marker);
-
-  PJUtils::report_sas_to_from_markers(trail(), rdata->msg_info.msg);
-
-  if ((rdata->msg_info.msg->line.req.method.id == PJSIP_REGISTER_METHOD) ||
-      ((pjsip_method_cmp(&rdata->msg_info.msg->line.req.method, pjsip_get_subscribe_method())) == 0) ||
-      ((pjsip_method_cmp(&rdata->msg_info.msg->line.req.method, pjsip_get_notify_method())) == 0))
-  {
-    // Omit the Call-ID for these requests, as the same Call-ID can be
-    // reused over a long period of time and produce huge SAS trails.
-    PJUtils::mark_sas_call_branch_ids(trail(), NULL, rdata->msg_info.msg);
-  }
-  else
-  {
-    PJUtils::mark_sas_call_branch_ids(trail(), rdata->msg_info.cid, rdata->msg_info.msg);
-  }
 }
 
 

--- a/sprout/bono.cpp
+++ b/sprout/bono.cpp
@@ -329,10 +329,6 @@ static pj_bool_t proxy_on_rx_response(pjsip_rx_data *rdata)
       res_addr.dst_host.addr.port = hvia->sent_by.port;
     }
 
-    // Report SIP call and branch ID markers on the trail to make sure it gets
-    // associated with the INVITE transaction at SAS.
-    PJUtils::mark_sas_call_branch_ids(get_trail(rdata), rdata->msg_info.cid, rdata->msg_info.msg);
-
     // We don't know the transaction, so be pessimistic and strip
     // everything.
     TrustBoundary::process_stateless_message(tdata);
@@ -468,7 +464,6 @@ void process_tsx_request(pjsip_rx_data* rdata)
     // associated with the INVITE transaction at SAS.  There's no need to
     // report the branch IDs as they won't be used for correlation.
     TRC_DEBUG("Statelessly forwarding ACK");
-    PJUtils::mark_sas_call_branch_ids(get_trail(rdata), rdata->msg_info.cid, NULL);
 
     trust->process_request(tdata);
 
@@ -2380,21 +2375,6 @@ void UASTransaction::log_on_tsx_start(const pjsip_rx_data* rdata)
   TRC_DEBUG("Report SAS start marker - trail (%llx)", trail());
   SAS::Marker start_marker(trail(), MARKER_ID_START, 1u);
   SAS::report_marker(start_marker);
-
-  PJUtils::report_sas_to_from_markers(trail(), rdata->msg_info.msg);
-
-  if ((rdata->msg_info.msg->line.req.method.id == PJSIP_REGISTER_METHOD) ||
-      ((pjsip_method_cmp(&rdata->msg_info.msg->line.req.method, pjsip_get_subscribe_method())) == 0) ||
-      ((pjsip_method_cmp(&rdata->msg_info.msg->line.req.method, pjsip_get_notify_method())) == 0))
-  {
-    // Omit the Call-ID for these requests, as the same Call-ID can be
-    // reused over a long period of time and produce huge SAS trails.
-    PJUtils::mark_sas_call_branch_ids(get_trail(rdata), NULL, rdata->msg_info.msg);
-  }
-  else
-  {
-    PJUtils::mark_sas_call_branch_ids(get_trail(rdata), _analytics.cid, rdata->msg_info.msg);
-  }
 }
 
 // Generate analytics logs relating to a transaction completing.

--- a/sprout/common_sip_processing.cpp
+++ b/sprout/common_sip_processing.cpp
@@ -40,10 +40,8 @@
  */
 
 extern "C" {
-#include <pjsip.h>
 #include <pjlib-util.h>
 #include <pjlib.h>
-#include "pjsip-simple/evsub.h"
 }
 #include <arpa/inet.h>
 
@@ -230,6 +228,11 @@ static void sas_log_rx_msg(pjsip_rx_data* rdata)
   // Store the trail in the message as it gets passed up the stack.
   set_trail(rdata, trail);
 
+  PJUtils::report_sas_to_from_markers(trail, rdata->msg_info.msg);
+
+  pjsip_cid_hdr* cid = (pjsip_cid_hdr*)rdata->msg_info.cid;
+  PJUtils::mark_sas_call_branch_ids(trail, cid, rdata->msg_info.msg);
+
   // Log the message event.
   SAS::Event event(trail, SASEvent::RX_SIP_MSG, 0);
   event.add_static_param(pjsip_transport_get_type_from_flag(rdata->tp_info.transport->flag));
@@ -252,6 +255,10 @@ static void sas_log_tx_msg(pjsip_tx_data *tdata)
   }
   else if (trail != 0)
   {
+    PJUtils::report_sas_to_from_markers(trail, tdata->msg);
+
+    PJUtils::mark_sas_call_branch_ids(trail, NULL, tdata->msg);
+
     // Log the message event.
     SAS::Event event(trail, SASEvent::TX_SIP_MSG, 0);
     event.add_static_param(pjsip_transport_get_type_from_flag(tdata->tp_info.transport->flag));
@@ -289,8 +296,6 @@ static pj_bool_t process_on_rx_msg(pjsip_rx_data* rdata)
     // Retry-After header with a zero length timeout.
     TRC_DEBUG("Rejected request due to overload");
 
-    pjsip_cid_hdr* cid = (pjsip_cid_hdr*)rdata->msg_info.cid;
-
     // LCOV_EXCL_START - can't meaningfully verify SAS in UT
     SAS::TrailId trail = get_trail(rdata);
 
@@ -302,21 +307,6 @@ static pj_bool_t process_on_rx_msg(pjsip_rx_data* rdata)
     event.add_static_param(load_monitor->get_current_latency());
     event.add_static_param(load_monitor->get_rate_limit());
     SAS::report_event(event);
-
-    PJUtils::report_sas_to_from_markers(trail, rdata->msg_info.msg);
-
-    if ((rdata->msg_info.msg->line.req.method.id == PJSIP_REGISTER_METHOD) ||
-        ((pjsip_method_cmp(&rdata->msg_info.msg->line.req.method, pjsip_get_subscribe_method())) == 0) ||
-        ((pjsip_method_cmp(&rdata->msg_info.msg->line.req.method, pjsip_get_notify_method())) == 0))
-    {
-      // Omit the Call-ID for these requests, as the same Call-ID can be
-      // reused over a long period of time and produce huge SAS trails.
-      PJUtils::mark_sas_call_branch_ids(trail, NULL, rdata->msg_info.msg);
-    }
-    else
-    {
-      PJUtils::mark_sas_call_branch_ids(trail, cid, rdata->msg_info.msg);
-    }
 
     SAS::Marker end_marker(trail, MARKER_ID_END, 1u);
     SAS::report_marker(end_marker);

--- a/sprout/pjutils.cpp
+++ b/sprout/pjutils.cpp
@@ -44,6 +44,8 @@
 extern "C" {
 #include <pjlib-util.h>
 #include <pjlib.h>
+#include <pjsip.h>
+#include "pjsip-simple/evsub.h"
 }
 
 #include "sprout_pd_definitions.h"
@@ -1686,13 +1688,26 @@ std::string PJUtils::get_header_value(pjsip_hdr* header)
 /// Add SAS markers for the specified call ID and branch IDs on the message (either may be omitted).
 void PJUtils::mark_sas_call_branch_ids(const SAS::TrailId trail, pjsip_cid_hdr* cid_hdr, pjsip_msg* msg)
 {
-  // If we have a call ID, log it.
+    SAS::Marker::Scope scope;
+    if ((msg->line.req.method.id == PJSIP_REGISTER_METHOD) ||
+      ((pjsip_method_cmp(&msg->line.req.method, pjsip_get_subscribe_method())) == 0) ||
+      ((pjsip_method_cmp(&msg->line.req.method, pjsip_get_notify_method())) == 0))
+  {
+    // Don't correlate flows based on Call-ID for REGISTER/SUBSCRIBE/NOTIFY - you get massive trace
+    // files.
+    scope = SAS::Marker::Scope::None;
+  }
+  else
+  {
+    scope = SAS::Marker::Scope::Trace;
+  }
+
   if (cid_hdr != NULL)
   {
     TRC_DEBUG("Logging SAS Call-ID marker, Call-ID %.*s", cid_hdr->id.slen, cid_hdr->id.ptr);
     SAS::Marker cid_marker(trail, MARKER_ID_SIP_CALL_ID, 1u);
     cid_marker.add_var_param(cid_hdr->id.slen, cid_hdr->id.ptr);
-    SAS::report_marker(cid_marker, SAS::Marker::Scope::Trace);
+    SAS::report_marker(cid_marker, scope);
   }
 
   // If we have a message, look for branch IDs too.
@@ -1707,16 +1722,6 @@ void PJUtils::mark_sas_call_branch_ids(const SAS::TrailId trail, pjsip_cid_hdr* 
       {
         SAS::Marker via_marker(trail, MARKER_ID_VIA_BRANCH_PARAM, 1u);
         via_marker.add_var_param(top_via->branch_param.slen, top_via->branch_param.ptr);
-        SAS::report_marker(via_marker, SAS::Marker::Scope::Trace);
-      }
-
-      // Now see if we can find the next Via header and log it if so.  This will have been added by
-      // the previous server.  This means we'll be able to correlate with its trail.
-      pjsip_via_hdr* second_via = (pjsip_via_hdr*)pjsip_msg_find_hdr(msg, PJSIP_H_VIA, top_via->next);
-      if (second_via != NULL)
-      {
-        SAS::Marker via_marker(trail, MARKER_ID_VIA_BRANCH_PARAM, 2u);
-        via_marker.add_var_param(second_via->branch_param.slen, second_via->branch_param.ptr);
         SAS::report_marker(via_marker, SAS::Marker::Scope::Trace);
       }
     }

--- a/sprout/registrar.cpp
+++ b/sprout/registrar.cpp
@@ -599,9 +599,6 @@ void process_register_request(pjsip_rx_data* rdata)
   SAS::Marker start_marker(trail, MARKER_ID_START, 1u);
   SAS::report_marker(start_marker);
 
-  PJUtils::report_sas_to_from_markers(trail, rdata->msg_info.msg);
-  PJUtils::mark_sas_call_branch_ids(trail, NULL, rdata->msg_info.msg);
-
   // Query the HSS for the associated URIs.
   std::vector<std::string> uris;
   std::map<std::string, Ifcs> ifc_map;

--- a/sprout/subscription.cpp
+++ b/sprout/subscription.cpp
@@ -442,9 +442,6 @@ void process_subscription_request(pjsip_rx_data* rdata)
   SAS::Marker start_marker(trail, MARKER_ID_START, 1u);
   SAS::report_marker(start_marker);
 
-  PJUtils::report_sas_to_from_markers(trail, rdata->msg_info.msg);
-  PJUtils::mark_sas_call_branch_ids(trail, NULL, rdata->msg_info.msg);
-
   // Query the HSS for the associated URIs.
   std::vector<std::string> uris;
   std::map<std::string, Ifcs> ifc_map;


### PR DESCRIPTION
Fixes https://github.com/Metaswitch/sprout/issues/923 and https://github.com/Metaswitch/sprout/issues/575.

For testing, I'm planning to register and make a call through Perimeta, Sprout and CFS TAS and verify that the whole thing gets correlated in SAS, and also check that the number of messages we send to SAS hasn't increased overall for that call flow. Sound sensible?