### PR TITLE
[Reviewer: Ellie] Don't try and load MIBs on Sprout/Bono startup to avoid log spam

### DIFF
--- a/debian/bono.init.d
+++ b/debian/bono.init.d
@@ -80,6 +80,7 @@ log_directory=/var/log/$NAME
 #
 setup_environment()
 {
+        export MIBS=""
         export LD_LIBRARY_PATH=/usr/share/clearwater/sprout/lib
         ulimit -Hn 1000000
         ulimit -Sn 1000000

--- a/sprout-base.root/etc/init.d/sprout
+++ b/sprout-base.root/etc/init.d/sprout
@@ -80,6 +80,7 @@ log_directory=/var/log/$NAME
 #
 setup_environment()
 {
+        export MIBS=""
         export LD_LIBRARY_PATH=/usr/share/clearwater/sprout/lib
         ulimit -Hn 1000000
         ulimit -Sn 1000000


### PR DESCRIPTION
I saw some of the errors from https://github.com/Metaswitch/sprout/issues/1128 in the Sprout log. This stops them.