### PR TITLE
Add create_request method

### DIFF
--- a/include/sproutlet.h
+++ b/include/sproutlet.h
@@ -121,6 +121,14 @@ public:
   /// @param  uri          - The URI to check.
   virtual bool is_uri_reflexive(const pjsip_uri* uri) const = 0;
 
+  /// Creates a new, blank request.  This is typically used when creating
+  /// a downstream request to another SIP server as part of handling a
+  /// request.
+  ///
+  /// @returns             - A new, blank request message.
+  ///
+  virtual pjsip_msg* create_request() = 0;
+
   /// Clones the request.  This is typically used when forking a request if
   /// different request modifications are required on each fork or for storing
   /// off to handle late forking.
@@ -375,6 +383,15 @@ protected:
   ///
   const pjsip_route_hdr* route_hdr() const
     {return _helper->route_hdr();}
+
+  /// Creates a new, blank request.  This is typically used when creating
+  /// a downstream request to another SIP server as part of handling a
+  /// request.
+  ///
+  /// @returns             - A new, blank request message.
+  ///
+  pjsip_msg* create_request()
+    {return _helper->create_request();}
 
   /// Clones the request.  This is typically used when forking a request if
   /// different request modifications are required on each fork.

--- a/include/sproutletappserver.h
+++ b/include/sproutletappserver.h
@@ -104,6 +104,14 @@ public:
   ///                        or by an earlier transaction in the same dialog.
   virtual const std::string& dialog_id() const;
 
+  /// Creates a new, blank request.  This is typically used when creating
+  /// a downstream request to another SIP server as part of handling a
+  /// request.
+  ///
+  /// @returns             - A new, blank request message.
+  ///
+  virtual pjsip_msg* create_request();
+
   /// Clones the request.  This is typically used when forking a request if
   /// different request modifications are required on each fork or for storing
   /// off to handle late forking.

--- a/include/sproutletproxy.h
+++ b/include/sproutletproxy.h
@@ -256,6 +256,7 @@ public:
   const char* msg_info(pjsip_msg*);
   const pjsip_route_hdr* route_hdr() const;
   const std::string& dialog_id() const;
+  pjsip_msg* create_request();
   pjsip_msg* clone_request(pjsip_msg* req);
   pjsip_msg* create_response(pjsip_msg* req,
                              pjsip_status_code status_code,

--- a/sprout/sproutletappserver.cpp
+++ b/sprout/sproutletappserver.cpp
@@ -146,6 +146,16 @@ const std::string& SproutletAppServerTsxHelper::dialog_id() const
   return _rr_param_value;
 }
 
+/// Creates a new, blank request.  This is typically used when creating
+/// a downstream request to another SIP server as part of handling a
+/// request.
+///
+/// @returns             - A new, blank request message.
+pjsip_msg* SproutletAppServerTsxHelper::create_request()
+{
+  return _helper->create_request();
+}
+
 /// Clones the request.  This is typically used when forking a request if
 /// different request modifications are required on each fork or for storing
 /// off to handle late forking.

--- a/sprout/sproutletproxy.cpp
+++ b/sprout/sproutletproxy.cpp
@@ -1117,6 +1117,40 @@ const pjsip_route_hdr* SproutletWrapper::route_hdr() const
   return NULL;
 }
 
+pjsip_msg* SproutletWrapper::create_request()
+{
+  // Create a new tdata
+  pj_status_t status;
+  pjsip_tx_data* new_tdata;
+
+  status = pjsip_endpt_create_tdata(stack_data.endpt, &new_tdata);
+
+  if (status != PJ_SUCCESS)
+  {
+    TRC_ERROR("Failed to create new request");
+    return NULL;
+  }
+
+  pjsip_tx_data_add_ref(new_tdata);
+
+  // Create a message inside the tdata
+  new_tdata->msg = pjsip_msg_create(new_tdata->pool, PJSIP_REQUEST_MSG);
+
+  // Add any additional request headers from the endpoint
+  const pjsip_hdr* endpt_hdr = pjsip_endpt_get_request_headers(stack_data.endpt)->next;
+  while (endpt_hdr != pjsip_endpt_get_request_headers(stack_data.endpt))
+  {
+    pjsip_hdr* hdr = (pjsip_hdr*)pjsip_hdr_shallow_clone(new_tdata->pool, endpt_hdr);
+    pjsip_msg_add_hdr(new_tdata->msg, hdr);
+    endpt_hdr = endpt_hdr->next;
+  }
+
+  set_trail(new_tdata, trail());
+  register_tdata(new_tdata);
+
+  return new_tdata->msg;
+}
+
 pjsip_msg* SproutletWrapper::clone_request(pjsip_msg* req)
 {
   // Get the old tdata from the map of clones


### PR DESCRIPTION
This allows creation of blank REQUESTs to be used by sproutlets when making downstream requests, when re-using existing requests is not appropriate.

The caller is responsible for filling in all the mandatory SIP headers before sending the message.