### PR TITLE
Add mock for create_request

### DIFF
--- a/sprout/sproutletproxy.cpp
+++ b/sprout/sproutletproxy.cpp
@@ -1127,8 +1127,10 @@ pjsip_msg* SproutletWrapper::create_request()
 
   if (status != PJ_SUCCESS)
   {
+    //LCOV_EXCL_START
     TRC_ERROR("Failed to create new request");
     return NULL;
+    //LCOV_EXCL_STOP
   }
 
   pjsip_tx_data_add_ref(new_tdata);

--- a/sprout/ut/mocktsxhelper.h
+++ b/sprout/ut/mocktsxhelper.h
@@ -61,6 +61,7 @@ public:
   MOCK_CONST_METHOD1(get_reflexive_uri, pjsip_sip_uri*(pj_pool_t*));
   MOCK_CONST_METHOD1(is_uri_reflexive, bool(const pjsip_uri*));
   MOCK_METHOD1(add_to_dialog, void(const std::string&));
+  MOCK_METHOD0(create_request, pjsip_msg*());
   MOCK_METHOD1(clone_request, pjsip_msg*(pjsip_msg*));
   MOCK_METHOD3(create_response, pjsip_msg*(pjsip_msg*, pjsip_status_code, const std::string&));
   MOCK_METHOD1(send_request, int(pjsip_msg*&));


### PR DESCRIPTION
Fixes the test build break because of a missing implementation of the new method.