### PR TITLE
[Reviewer: Ellie] Bracket the IPv6 address before using it (ready to merge)

### DIFF
--- a/sprout/icscfplugin.cpp
+++ b/sprout/icscfplugin.cpp
@@ -86,7 +86,7 @@ bool ICSCFPlugin::load(struct options& opt, std::list<Sproutlet*>& sproutlets)
     // Determine the S-CSCF and hence BGCF URIs.
     std::string scscf_cluster_uri = std::string(stack_data.scscf_uri.ptr,
                                                 stack_data.scscf_uri.slen);
-    std::string bgcf_uri = "sip:bgcf." + scscf_cluster_uri.substr(4);
+    std::string bgcf_uri = "sip:bgcf@" + scscf_cluster_uri.substr(4);
 
     // Create the S-CSCF selector.
     _scscf_selector = new SCSCFSelector();

--- a/sprout/scscfplugin.cpp
+++ b/sprout/scscfplugin.cpp
@@ -89,7 +89,7 @@ bool SCSCFPlugin::load(struct options& opt, std::list<Sproutlet*>& sproutlets)
     }
 
     std::string scscf_node_uri = "sip:" + node_ip + ":" + std::to_string(opt.scscf_port);
-    std::string bgcf_uri = "sip:bgcf." + scscf_cluster_uri.substr(4);
+    std::string bgcf_uri = "sip:bgcf@" + scscf_cluster_uri.substr(4);
     std::string icscf_uri;
     if (opt.icscf_enabled)
     {
@@ -106,8 +106,8 @@ bool SCSCFPlugin::load(struct options& opt, std::list<Sproutlet*>& sproutlets)
       }
       else
       {
-        // No port number, so best we can do is strap icscf. on the front.
-        icscf_uri = "sip:icscf." + scscf_cluster_uri.substr(4);
+        // No port number, so best we can do is strap 'icscf@' on the front.
+        icscf_uri = "sip:icscf@" + scscf_cluster_uri.substr(4);
       }
     }
     else

--- a/sprout/scscfplugin.cpp
+++ b/sprout/scscfplugin.cpp
@@ -40,6 +40,7 @@
  */
 
 #include "cfgoptions.h"
+#include "ipv6utils.h"
 #include "sproutletplugin.h"
 #include "scscfsproutlet.h"
 
@@ -80,10 +81,14 @@ bool SCSCFPlugin::load(struct options& opt, std::list<Sproutlet*>& sproutlets)
     // Determine the S-CSCF, BGCF and I-CSCF URIs.
     std::string scscf_cluster_uri = std::string(stack_data.scscf_uri.ptr,
                                                 stack_data.scscf_uri.slen);
-    std::string scscf_node_uri = "sip:" +
-                                 std::string(stack_data.local_host.ptr,
-                                             stack_data.local_host.slen) +
-                                 ":" + std::to_string(opt.scscf_port);
+    std::string node_ip(stack_data.local_host.ptr, stack_data.local_host.slen);
+    
+    if (is_ipv6(node_ip))
+    {
+      node_ip = "[" + node_ip + "]";
+    }
+
+    std::string scscf_node_uri = "sip:" + node_ip + ":" + std::to_string(opt.scscf_port);
     std::string bgcf_uri = "sip:bgcf." + scscf_cluster_uri.substr(4);
     std::string icscf_uri;
     if (opt.icscf_enabled)

--- a/sprout/ut/scscf_test.cpp
+++ b/sprout/ut/scscf_test.cpp
@@ -352,7 +352,7 @@ public:
     _scscf_sproutlet = new SCSCFSproutlet("sip:homedomain:5058",
                                           "sip:127.0.0.1:5058",
                                           "",
-                                          "sip:bgcf.homedomain:5058",
+                                          "sip:bgcf@homedomain:5058",
                                           5058,
                                           _store,
                                           NULL,


### PR DESCRIPTION
Fixes #1029. With this change, and the following config:

```
$ cat /etc/clearwater/local_config
local_ip=fd5f:5d21:845:1402:407e:aa42:6989:4d58
public_ip=fd5f:5d21:845:1402:407e:aa42:6989:4d58
public_hostname=sprout-1
etcd_cluster="fd5f:5d21:845:1402:407e:aa42:6989:4d58"
```

Sprout loads without error logs and the S-CSCF sproutlet handles requests I send it (using SIPp). I don't have a full IPv6 test rig, so haven't made an end-to-end call.