### PR TITLE
[Reviewer: Rob] Make handling of 3rd party registration stats more defensive

### DIFF
--- a/sprout/registration_utils.cpp
+++ b/sprout/registration_utils.cpp
@@ -189,17 +189,20 @@ void RegistrationUtils::register_with_application_servers(Ifcs& ifcs,
        as_iter != as_list.end();
        as_iter++)
   {
-    if (expires == 0)
+    if (third_party_reg_stats_tables != NULL)
     {
-      third_party_reg_stats_tables->de_reg_tbl->increment_attempts();
-    }
-    else if (is_initial_registration)
-    {
-      third_party_reg_stats_tables->init_reg_tbl->increment_attempts();
-    }
-    else
-    {
-      third_party_reg_stats_tables->re_reg_tbl->increment_attempts();
+      if (expires == 0)
+      {
+        third_party_reg_stats_tables->de_reg_tbl->increment_attempts();
+      }
+      else if (is_initial_registration)
+      {
+        third_party_reg_stats_tables->init_reg_tbl->increment_attempts();
+      }
+      else
+      {
+        third_party_reg_stats_tables->re_reg_tbl->increment_attempts();
+      }
     }
     send_register_to_as(received_register, ok_response, *as_iter, expires, is_initial_registration, served_user, trail);
   }
@@ -223,38 +226,41 @@ static void send_register_cb(void* token, pjsip_event *event)
 
     third_party_register_failed(tsxdata->public_id, tsxdata->trail);
   }
-  
-  // printf("Expiry: %d, Is_initial_registration: %d\n", tsxdata->expires, tsxdata->is_initial_registration);
-  if (tsx->status_code == 200)
-  {  
-    if (tsxdata->expires == 0)
-    {
-      third_party_reg_stats_tables->de_reg_tbl->increment_successes();
-    }
-    else if (tsxdata->is_initial_registration)
-    {
-      third_party_reg_stats_tables->init_reg_tbl->increment_successes();
-    }
-    else
-    {
-      third_party_reg_stats_tables->re_reg_tbl->increment_successes();
-    }
-  }
-  else
-  // Count all failed registration attempts, not just ones that result in user
-  // being unsubscribed.
+
+  if (third_party_reg_stats_tables != NULL)
   {
-    if (tsxdata->expires == 0)
+    // printf("Expiry: %d, Is_initial_registration: %d\n", tsxdata->expires, tsxdata->is_initial_registration);
+    if (tsx->status_code == 200)
     {
-      third_party_reg_stats_tables->de_reg_tbl->increment_failures();
-    }
-    else if (tsxdata->is_initial_registration)
-    {
-      third_party_reg_stats_tables->init_reg_tbl->increment_failures();
+      if (tsxdata->expires == 0)
+      {
+        third_party_reg_stats_tables->de_reg_tbl->increment_successes();
+      }
+      else if (tsxdata->is_initial_registration)
+      {
+        third_party_reg_stats_tables->init_reg_tbl->increment_successes();
+      }
+      else
+      {
+        third_party_reg_stats_tables->re_reg_tbl->increment_successes();
+      }
     }
     else
+    // Count all failed registration attempts, not just ones that result in user
+    // being unsubscribed.
     {
-      third_party_reg_stats_tables->re_reg_tbl->increment_failures();
+      if (tsxdata->expires == 0)
+      {
+        third_party_reg_stats_tables->de_reg_tbl->increment_failures();
+      }
+      else if (tsxdata->is_initial_registration)
+      {
+        third_party_reg_stats_tables->init_reg_tbl->increment_failures();
+      }
+      else
+      {
+        third_party_reg_stats_tables->re_reg_tbl->increment_failures();
+      }
     }
   }
 


### PR DESCRIPTION
I hit a crash in UT caused by the registration_utils.cpp::third_party_reg_stats_tables pointer being NULL. This can happen if you call `remove_bindings` before `(de)register_with_application_servers`. I have fixed this by making `registration_utils.cpp` more defensive and checking its pointer. 

I think there is still a more minor issue where 3rd party reg stats will be wrong if we call `remove_bindings` first. I will raise an issue for this (it's really low urgency). 

Tested in UT. 