### PR TITLE
[Reviewer: Andy] Count re-entrancy in SproutletWrapper::process_actions

### DIFF
--- a/include/sproutletproxy.h
+++ b/include/sproutletproxy.h
@@ -329,6 +329,14 @@ private:
 
   bool _complete;
 
+  // All the actions are performed within SproutletWrapper::process_actions,
+  // including deleting the SproutletWrapper itself.  However, process_actions
+  // can be re-entered - it sends messages, which can fail and call back into
+  // the SproutletWrapper synchronously.  This counter counts how many times
+  // the method has currently been entered - if it is non-zero, the
+  // SproutletWrapper must not be destroyed.
+  int _process_actions_entered;
+
   /// Vector keeping track of the status of each fork.  The state field can
   /// only ever take a subset of the values defined by PJSIP - NULL, CALLING,
   /// PROCEEDING and TERMINATED.


### PR DESCRIPTION
Andy,

Please can you review this (which fixes #1124)?  See the issue for details of the problem, but the fix is to count the number of times we've re-entered SproutletWrapper::process_actions and not delete the SproutletWrapper if so.

I've run the UTs, but not enhanced them because they don't have support for failing transports (and it looks quite fiddly to add).  I've also run long stress runs, both at full load and at light load under valgrind, and neither seen the crash nor seen the signature from valgrind.

Thanks,

Matt