### PR TITLE
[Reviewer: Alex] When creating a new AS chain after a retarget, reuse the SAS trail ID

### DIFF
--- a/include/scscfsproutlet.h
+++ b/include/scscfsproutlet.h
@@ -233,7 +233,7 @@ private:
   AsChainLink create_as_chain(Ifcs ifcs,
                               std::string served_user,
                               ACR*& acr,
-                              SAS::TrailId old_chain_trail = 0);
+                              SAS::TrailId chain_trail);
 
   /// Apply originating services for this request.
   void apply_originating_services(pjsip_msg* req);

--- a/include/scscfsproutlet.h
+++ b/include/scscfsproutlet.h
@@ -230,7 +230,10 @@ private:
 
   /// Creates an AS chain for this service role and links this service hop to
   /// it.
-  AsChainLink create_as_chain(Ifcs ifcs, std::string served_user, ACR*& acr);
+  AsChainLink create_as_chain(Ifcs ifcs,
+                              std::string served_user,
+                              ACR*& acr,
+                              SAS::TrailId old_chain_trail = 0);
 
   /// Apply originating services for this request.
   void apply_originating_services(pjsip_msg* req);

--- a/sprout/scscfsproutlet.cpp
+++ b/sprout/scscfsproutlet.cpp
@@ -871,7 +871,7 @@ pjsip_status_code SCSCFSproutletTsx::determine_served_user(pjsip_msg* req)
       if (lookup_ifcs(served_user, ifcs))
       {
         TRC_DEBUG("Successfully looked up iFCs");
-        _as_chain_link = create_as_chain(ifcs, served_user, acr);
+        _as_chain_link = create_as_chain(ifcs, served_user, acr, trail());
       }
       else
       {
@@ -989,7 +989,7 @@ std::string SCSCFSproutletTsx::served_user_from_msg(pjsip_msg* msg)
 AsChainLink SCSCFSproutletTsx::create_as_chain(Ifcs ifcs,
                                                std::string served_user,
                                                ACR*& acr,
-                                               SAS::TrailId old_chain_trail)
+                                               SAS::TrailId chain_trail)
 {
   if (served_user.empty())
   {
@@ -1001,7 +1001,7 @@ AsChainLink SCSCFSproutletTsx::create_as_chain(Ifcs ifcs,
                                                  *_session_case,
                                                  served_user,
                                                  is_registered,
-                                                 old_chain_trail ? old_chain_trail : trail(),
+                                                 chain_trail,
                                                  ifcs,
                                                  acr);
   acr = NULL;


### PR DESCRIPTION
Speculative fix to https://github.com/Metaswitch/sprout/issues/1202.

It compiles, but I haven't live-tested - I've reproed https://github.com/Metaswitch/sprout/issues/1202 on the VMware rig, though, so I can live test once it goes into the 'latest' repo.