### PR TITLE
[Reviewer: Ellie] Add a config flag to always behave as though the HSS had sent Include…

### DIFF
--- a/include/cfgoptions.h
+++ b/include/cfgoptions.h
@@ -141,6 +141,7 @@ struct options
   std::string                          pbxes;
   std::string                          pbx_service_route;
   NonRegisterAuthentication            non_register_auth_mode;
+  bool                                 force_third_party_register_body;
 };
 
 // Objects that must be shared with dynamically linked sproutlets must be

--- a/include/registrar.h
+++ b/include/registrar.h
@@ -60,6 +60,7 @@ extern pj_status_t init_registrar(RegStore* registrar_store,
                                   AnalyticsLogger* analytics_logger,
                                   ACRFactory* rfacr_factory,
                                   int cfg_max_expires,
+                                  bool force_third_party_register_body,
                                   SNMP::RegistrationStatsTables* reg_stats_tbls,
                                   SNMP::RegistrationStatsTables* third_party_reg_stats_tbls);
 

--- a/include/registration_utils.h
+++ b/include/registration_utils.h
@@ -52,6 +52,9 @@ extern "C" {
 
 namespace RegistrationUtils {
 
+void init(SNMP::RegistrationStatsTables* _third_party_reg_stats_tables,
+          bool _force_third_party_register_body);
+
 void remove_bindings(RegStore* store,
                      HSSConnection* hss,
                      const std::string& aor,
@@ -66,13 +69,11 @@ void register_with_application_servers(Ifcs& ifcs,
                                        int expires,
                                        bool is_initial_registration,
                                        const std::string& served_user,
-                                       SNMP::RegistrationStatsTables* third_party_reg_stats_tbls,
                                        SAS::TrailId trail);
 
 void deregister_with_application_servers(Ifcs&,
                                          RegStore* store,
                                          const std::string&,
-                                         SNMP::RegistrationStatsTables* third_party_reg_stats_tbls,
                                          SAS::TrailId trail);
 
 } // namespace RegistrationUtils

--- a/include/registration_utils.h
+++ b/include/registration_utils.h
@@ -52,8 +52,8 @@ extern "C" {
 
 namespace RegistrationUtils {
 
-void init(SNMP::RegistrationStatsTables* _third_party_reg_stats_tables,
-          bool _force_third_party_register_body);
+void init(SNMP::RegistrationStatsTables* third_party_reg_stats_tables_arg,
+          bool force_third_party_register_body_arg);
 
 void remove_bindings(RegStore* store,
                      HSSConnection* hss,

--- a/sprout-base.root/etc/init.d/sprout
+++ b/sprout-base.root/etc/init.d/sprout
@@ -165,6 +165,7 @@ get_daemon_args()
         [ "$enforce_user_phone" != "Y" ] || user_phone_arg="--enforce-user-phone"
         [ "$enforce_global_only_lookups" != "Y" ] || global_only_lookups_arg="--enforce-global-only-lookups"
         [ "$override_npdi" != "Y" ] || override_npdi_arg="--override-npdi"
+        [ "$force_third_party_reg_body" != "Y" ] || force_3pr_body_arg="--force-3pr-body"
 
         # Enable SNMP alarms if informsink(s) are configured
         if [ ! -z "$snmp_ip" ]
@@ -212,6 +213,7 @@ get_daemon_args()
                      $override_npdi_arg
                      $alarms_enabled_arg
                      $exception_max_ttl_arg
+                     $force_3pr_body_arg
                      --http-address=$local_ip
                      --http-port=9888
                      --analytics=$log_directory

--- a/sprout/handlers.cpp
+++ b/sprout/handlers.cpp
@@ -535,7 +535,6 @@ RegStore::AoR* DeregistrationTask::set_aor_data(RegStore* current_store,
       RegistrationUtils::deregister_with_application_servers(ifc_map[aor_id],
                                                              current_store,
                                                              aor_id,
-                                                             NULL,
                                                              trail());
     }
   }

--- a/sprout/registrar.cpp
+++ b/sprout/registrar.cpp
@@ -1061,7 +1061,6 @@ void process_register_request(pjsip_rx_data* rdata)
                                                          expiry,
                                                          is_initial_registration,
                                                          public_id,
-                                                         third_party_reg_stats_tables,
                                                          trail);
   }
 
@@ -1115,6 +1114,7 @@ pj_status_t init_registrar(RegStore* registrar_store,
                            AnalyticsLogger* analytics_logger,
                            ACRFactory* rfacr_factory,
                            int cfg_max_expires,
+                           bool force_original_register_inclusion, 
                            SNMP::RegistrationStatsTables* reg_stats_tbls,
                            SNMP::RegistrationStatsTables* third_party_reg_stats_tbls)
 {
@@ -1128,6 +1128,8 @@ pj_status_t init_registrar(RegStore* registrar_store,
   acr_factory = rfacr_factory;
   reg_stats_tables = reg_stats_tbls;
   third_party_reg_stats_tables = third_party_reg_stats_tbls;
+
+  RegistrationUtils::init(third_party_reg_stats_tbls, force_original_register_inclusion);
 
   // Construct a Service-Route header pointing at the S-CSCF ready to be added
   // to REGISTER 200 OK response.

--- a/sprout/registration_utils.cpp
+++ b/sprout/registration_utils.cpp
@@ -60,6 +60,10 @@ extern "C" {
 
 static SNMP::RegistrationStatsTables* third_party_reg_stats_tables;
 
+// Should we always send the access-side REGISTER and 200 OK in the body of third-party REGISTER
+// messages to application servers, even if the iFCs don't tell us to?
+static bool force_third_party_register_body;
+
 /// Temporary data structure maintained while transmitting a third-party
 /// REGISTER to an application server.
 struct ThirdPartyRegData
@@ -79,10 +83,16 @@ void send_register_to_as(pjsip_rx_data* received_register,
                          const std::string&,
                          SAS::TrailId);
 
+void RegistrationUtils::init(SNMP::RegistrationStatsTables* _third_party_reg_stats_tables,
+                             bool _force_third_party_register_body)
+{
+  third_party_reg_stats_tables = _third_party_reg_stats_tables;
+  force_third_party_register_body = _force_third_party_register_body;
+}
+
 void RegistrationUtils::deregister_with_application_servers(Ifcs& ifcs,
                                                             RegStore* store,
                                                             const std::string& served_user,
-                                                            SNMP::RegistrationStatsTables* third_party_reg_stats_tables,
                                                             SAS::TrailId trail)
 {
   RegistrationUtils::register_with_application_servers(ifcs,
@@ -92,7 +102,6 @@ void RegistrationUtils::deregister_with_application_servers(Ifcs& ifcs,
                                                        0,
                                                        false,
                                                        served_user,
-                                                       third_party_reg_stats_tables,
                                                        trail);
 }
 
@@ -103,7 +112,6 @@ void RegistrationUtils::register_with_application_servers(Ifcs& ifcs,
                                                           int expires,
                                                           bool is_initial_registration,
                                                           const std::string& served_user,
-                                                          SNMP::RegistrationStatsTables* third_party_reg_stats_tbls,
                                                           SAS::TrailId trail)
 {
   // Function preconditions
@@ -116,11 +124,6 @@ void RegistrationUtils::register_with_application_servers(Ifcs& ifcs,
   {
     // We should have both messages or neither
     assert(ok_response != NULL);
-  }
-
-  if (third_party_reg_stats_tbls != NULL)
-  {
-    third_party_reg_stats_tables = third_party_reg_stats_tbls;
   }
 
   std::vector<AsInvocation> as_list;
@@ -189,7 +192,7 @@ void RegistrationUtils::register_with_application_servers(Ifcs& ifcs,
        as_iter != as_list.end();
        as_iter++)
   {
-    if (third_party_reg_stats_tbls != NULL)
+    if (third_party_reg_stats_tables != NULL)
     {
       if (expires == 0)
       {
@@ -350,7 +353,7 @@ void send_register_to_as(pjsip_rx_data *received_register,
                                xml_part);
     }
 
-    if (as.include_register_request)
+    if (as.include_register_request || force_third_party_register_body)
     {
       pjsip_multipart_part *request_part = pjsip_multipart_create_part(tdata->pool);
       pjsip_msg_print(received_register->msg_info.msg, buf, sizeof(buf));
@@ -363,7 +366,7 @@ void send_register_to_as(pjsip_rx_data *received_register,
                                request_part);
     }
 
-    if (as.include_register_response)
+    if (as.include_register_response || force_third_party_register_body)
     {
       pjsip_multipart_part *response_part = pjsip_multipart_create_part(tdata->pool);
       pjsip_msg_print(ok_response->msg, buf, sizeof(buf));
@@ -487,7 +490,7 @@ void RegistrationUtils::remove_bindings(RegStore* store,
     {
       // Note that 3GPP TS 24.229 V12.0.0 (2013-03) 5.4.1.7 doesn't specify that any binding information
       // should be passed on the REGISTER message, so we don't need the binding ID.
-      deregister_with_application_servers(ifc_map[aor], store, aor, third_party_reg_stats_tables, trail);
+      deregister_with_application_servers(ifc_map[aor], store, aor, trail);
       notify_application_servers();
     }
   }

--- a/sprout/registration_utils.cpp
+++ b/sprout/registration_utils.cpp
@@ -83,11 +83,11 @@ void send_register_to_as(pjsip_rx_data* received_register,
                          const std::string&,
                          SAS::TrailId);
 
-void RegistrationUtils::init(SNMP::RegistrationStatsTables* _third_party_reg_stats_tables,
-                             bool _force_third_party_register_body)
+void RegistrationUtils::init(SNMP::RegistrationStatsTables* third_party_reg_stats_tables_arg,
+                             bool force_third_party_register_body_arg)
 {
-  third_party_reg_stats_tables = _third_party_reg_stats_tables;
-  force_third_party_register_body = _force_third_party_register_body;
+  third_party_reg_stats_tables = third_party_reg_stats_tables_arg;
+  force_third_party_register_body = force_third_party_register_body_arg;
 }
 
 void RegistrationUtils::deregister_with_application_servers(Ifcs& ifcs,

--- a/sprout/ut/registrar_test.cpp
+++ b/sprout/ut/registrar_test.cpp
@@ -79,6 +79,7 @@ public:
                                      _analytics,
                                      _acr_factory,
                                      300,
+                                     false,
                                      &SNMP::FAKE_REGISTRATION_STATS_TABLES,
                                      &SNMP::FAKE_THIRD_PARTY_REGISTRATION_STATS_TABLES);
     ASSERT_EQ(PJ_SUCCESS, ret);
@@ -2247,6 +2248,7 @@ public:
                                      _analytics,
                                      _acr_factory,
                                      300,
+                                     false,
                                      &SNMP::FAKE_REGISTRATION_STATS_TABLES,
                                      &SNMP::FAKE_REGISTRATION_STATS_TABLES);
     ASSERT_EQ(PJ_SUCCESS, ret);


### PR DESCRIPTION
…RegisterRequest and IncludeRegisterResponse in the XML

Some HSSes don't allow you to set these fields, but some TASes require them. This pull request allows you to set `force_third_party_reg_body=Y` in the config, which always behaves as if the HSS had set it.

This makes Clearwater a useful bridge for interoperating between these sort of HSSes and these sort of TASes.