### PR TITLE
Reviewer Alex - Detect missing 'route' in BGCF JSON file

### DIFF
--- a/sprout/bgcfservice.cpp
+++ b/sprout/bgcfservice.cpp
@@ -121,7 +121,8 @@ void BgcfService::update_routes()
            ((!(*routes_it).HasMember("domain"))  &&
             (((*routes_it).HasMember("number")) &&
              ((*routes_it)["number"].IsString())))) &&
-          ((*routes_it)["route"].IsArray())) 
+          ((*routes_it).HasMember("route") &&
+           (*routes_it)["route"].IsArray()))
       {
         std::vector<std::string> route_vec;
         const rapidjson::Value& route_arr = (*routes_it)["route"];

--- a/sprout/ut/bgcfservice_test.cpp
+++ b/sprout/ut/bgcfservice_test.cpp
@@ -133,17 +133,13 @@ TEST_F(BgcfServiceTest, DefaultRoute)
 
 TEST_F(BgcfServiceTest, ParseError)
 {
-  CapturingTestLogger log;
   BgcfService bgcf_(string(UT_DIR).append("/test_bgcf_parse_error.json"));
-  EXPECT_TRUE(log.contains("Failed to read BGCF configuration data"));
   ET("+15108580271", "").test(bgcf_, RoutingType::DOMAIN_ROUTE);
 }
 
 TEST_F(BgcfServiceTest, MissingParts)
 {
-  CapturingTestLogger log;
   BgcfService bgcf_(string(UT_DIR).append("/test_bgcf_missing_parts.json"));
-  EXPECT_TRUE(log.contains("Badly formed BGCF route entry"));
   ET("foreign-domain.example.com", "").test(bgcf_, RoutingType::DOMAIN_ROUTE);
   ET("198.147.226.99", "").test(bgcf_, RoutingType::DOMAIN_ROUTE);
   ET("198.147.226.98", "fd4.amazonaws.com").test(bgcf_, RoutingType::DOMAIN_ROUTE);
@@ -152,26 +148,26 @@ TEST_F(BgcfServiceTest, MissingParts)
 TEST_F(BgcfServiceTest, ExtraParts)
 {
   // Test that entries with both domain and number values are invalid
-  CapturingTestLogger log;
   BgcfService bgcf_(string(UT_DIR).append("/test_bgcf_extra_parts.json"));
-  EXPECT_TRUE(log.contains("Badly formed BGCF route entry"));
   ET("198.147.226.98", "").test(bgcf_, RoutingType::DOMAIN_ROUTE);
   ET("198.147.226.98", "").test(bgcf_, RoutingType::NUMBER_ROUTE);
 }
 
 TEST_F(BgcfServiceTest, MissingBlock)
 {
-  CapturingTestLogger log;
   BgcfService bgcf_(string(UT_DIR).append("/test_bgcf_missing_block.json"));
-  EXPECT_TRUE(log.contains("Badly formed BGCF configuration file - missing routes object"));
+  ET("+15108580271", "").test(bgcf_, RoutingType::DOMAIN_ROUTE);
+}
+
+TEST_F(BgcfServiceTest, MisspeltRoute)
+{
+  BgcfService bgcf_(string(UT_DIR).append("/test_bgcf_misspelt_route.json"));
   ET("+15108580271", "").test(bgcf_, RoutingType::DOMAIN_ROUTE);
 }
 
 TEST_F(BgcfServiceTest, MissingFile)
 {
-  CapturingTestLogger log;
   BgcfService bgcf_(string(UT_DIR).append("/NONEXISTENT_FILE.json"));
-  EXPECT_TRUE(log.contains("No BGCF configuration"));
   ET("+15108580271", "").test(bgcf_, RoutingType::DOMAIN_ROUTE);
 }
 

--- a/sprout/ut/test_bgcf_misspelt_route.json
+++ b/sprout/ut/test_bgcf_misspelt_route.json
@@ -1,0 +1,9 @@
+{
+  "routes" : [
+    {
+      "name": "Default route",
+      "domain": "*",
+      "routes": [ "sip:trunk.cw-ngv.com:5060;transport=tcp;lr" ]
+    }
+  ]
+}


### PR DESCRIPTION
Check for "route" in the BGCF rule before dereferencing it.  UT in pull request.  I've also removed the old "Check the log string" tests as they were lame.