### PR TITLE
Reviewer Alex - Remove CDIV-triggered ACRs

### DIFF
--- a/include/acr.h
+++ b/include/acr.h
@@ -149,7 +149,8 @@ public:
 
   /// Returns the JSON encoded message in string form.
   ///
-  /// See comments for `_cancelled`.
+  /// If the ACR has been cancelled, this function's behaviour is unspecified
+  /// (though the UTs expect it to return "Cancelled ACR").
   ///
   /// @param   timestamp      Timestamp to be used as Event-Timestamp AVP.
   virtual std::string get_message(pj_time_val timestamp=unspec);
@@ -167,7 +168,8 @@ public:
   /// cancelled.  In general this will be when the relevant transaction or AS
   /// chain has ended.
   /// @param   timestamp      Timestamp to be used as Event-Timestamp AVP.
-  inline void send(pj_time_val timestamp=unspec) {
+  inline void send(pj_time_val timestamp=unspec)
+  {
     if (!_cancelled)
     {
       send_message(timestamp);
@@ -182,13 +184,13 @@ protected:
   /// Tracks if the ACR has been cancelled.
   ///
   /// `send_message()` will not be called if this is true.
-  /// `get_message()` should return an appropriate error string if this is true
+  /// `get_message()` is undefined if this is true
   bool _cancelled;
 
 private:
   /// Called when the ACR message should be triggered.
   ///
-  /// See comments for `_cancelled`.
+  /// This will never be called on a cancelled ACR.
   ///
   /// @param   timestamp      Timestamp to be used as Event-Timestamp AVP.
   virtual void send_message(pj_time_val timestamp=unspec);

--- a/include/acr.h
+++ b/include/acr.h
@@ -147,12 +147,10 @@ public:
   /// @param   caps           Capabiliies as received from I-CSCF.
   virtual void server_capabilities(const ServerCapabilities& caps);
 
-  /// Called when the ACR message should be triggered.  In general this will
-  /// be when the relevant transaction or AS chain has ended.
-  /// @param   timestamp      Timestamp to be used as Event-Timestamp AVP.
-  virtual void send_message(pj_time_val timestamp=unspec);
-
   /// Returns the JSON encoded message in string form.
+  ///
+  /// See comments for `_cancelled`.
+  ///
   /// @param   timestamp      Timestamp to be used as Event-Timestamp AVP.
   virtual std::string get_message(pj_time_val timestamp=unspec);
 
@@ -164,6 +162,37 @@ public:
 
   /// Set the default CCF for this ACR.
   virtual void set_default_ccf(const std::string& default_ccf);
+
+  /// Called when the ACR message should be sent if it's not yet been
+  /// cancelled.  In general this will be when the relevant transaction or AS
+  /// chain has ended.
+  /// @param   timestamp      Timestamp to be used as Event-Timestamp AVP.
+  inline void send(pj_time_val timestamp=unspec) {
+    if (!_cancelled)
+    {
+      send_message(timestamp);
+    }
+  }
+
+  /// Cancel this ACR, preventing it from being sent.  Used if a call leg
+  /// should no longer be considered for billing.
+  inline void cancel() { _cancelled = true; }
+
+protected:
+  /// Tracks if the ACR has been cancelled.
+  ///
+  /// `send_message()` will not be called if this is true.
+  /// `get_message()` should return an appropriate error string if this is true
+  bool _cancelled;
+
+private:
+  /// Called when the ACR message should be triggered.
+  ///
+  /// See comments for `_cancelled`.
+  ///
+  /// @param   timestamp      Timestamp to be used as Event-Timestamp AVP.
+  virtual void send_message(pj_time_val timestamp=unspec);
+
 };
 
 
@@ -247,11 +276,6 @@ public:
   /// @param   caps           Capabiliies as received from I-CSCF.
   virtual void server_capabilities(const ServerCapabilities& caps);
 
-  /// Called when the Rf message should be triggered.  In general this will
-  /// be when the relevant transaction or AS chain has ended.
-  /// @param   timestamp      Timestamp to be used as Event-Timestamp AVP.
-  virtual void send_message(pj_time_val timestamp=unspec);
-
   /// Returns the JSON encoded message in string form.
   /// @param   timestamp      Timestamp to be used as Event-Timestamp AVP.
   virtual std::string get_message(pj_time_val timestamp=unspec);
@@ -260,6 +284,11 @@ public:
   virtual void set_default_ccf(const std::string& default_ccf);
 
 private:
+
+  /// Called when the Rf message should be triggered.  In general this will
+  /// be when the relevant transaction or AS chain has ended.
+  /// @param   timestamp      Timestamp to be used as Event-Timestamp AVP.
+  virtual void send_message(pj_time_val timestamp=unspec);
 
   typedef enum { EVENT_RECORD=1,
                  START_RECORD=2,

--- a/include/scscfsproutlet.h
+++ b/include/scscfsproutlet.h
@@ -284,10 +284,10 @@ private:
   bool lookup_ifcs(std::string public_id,
                    Ifcs& ifcs);
 
-  /// Record-Route the S-CSCF sproutlet into a dialog.  The parameter passed
-  /// will be attached to the Record-Route and can be used to recover the
+  /// Record-Route the S-CSCF sproutlet into a dialog.  The third parameter
+  /// passed may be attached to the Record-Route and can be used to recover the
   /// billing role that is in use on subsequent in-dialog messages.
-  void add_record_route(pjsip_msg* msg, NodeRole);
+  void add_record_route(pjsip_msg* msg, bool, NodeRole);
 
   /// Retrieve the billing role for the incoming message.  This should have been
   /// set during session initiation.

--- a/include/scscfsproutlet.h
+++ b/include/scscfsproutlet.h
@@ -287,7 +287,12 @@ private:
   /// Record-Route the S-CSCF sproutlet into a dialog.  The third parameter
   /// passed may be attached to the Record-Route and can be used to recover the
   /// billing role that is in use on subsequent in-dialog messages.
-  void add_record_route(pjsip_msg* msg, bool, NodeRole);
+  ///
+  /// @param msg          - The message to modify
+  /// @param billing_rr   - Whether to add a `billing-role` parameter to the RR
+  /// @param billing_role - The contents of the `billing-role` (ignored if
+  ///                       `billing_rr` is false)
+  void add_record_route(pjsip_msg* msg, bool billing_rr, NodeRole billing_role);
 
   /// Retrieve the billing role for the incoming message.  This should have been
   /// set during session initiation.

--- a/sprout/aschain.cpp
+++ b/sprout/aschain.cpp
@@ -95,7 +95,7 @@ AsChain::~AsChain()
 
     // Send the ACR for this chain and destroy the ACR.
     TRC_DEBUG("Sending ACR (%p) from AS chain", _acr);
-    _acr->send_message();
+    _acr->send();
     delete _acr;
   }
 

--- a/sprout/authentication.cpp
+++ b/sprout/authentication.cpp
@@ -959,7 +959,7 @@ pj_bool_t authenticate_rx_request(pjsip_rx_data* rdata)
   }
 
   // Send the ACR.
-  acr->send_message();
+  acr->send();
   delete acr;
   delete av;
   return PJ_TRUE;

--- a/sprout/bgcfsproutlet.cpp
+++ b/sprout/bgcfsproutlet.cpp
@@ -125,7 +125,7 @@ BGCFSproutletTsx::~BGCFSproutletTsx()
 {
   if (_acr != NULL)
   {
-    _acr->send_message();
+    _acr->send();
   }
 
   delete _acr;
@@ -263,7 +263,7 @@ void BGCFSproutletTsx::on_cancel(int status_code, pjsip_msg* cancel_req)
 
     // @TODO - timestamp from request.
     acr->rx_request(cancel_req);
-    acr->send_message();
+    acr->send();
 
     delete acr;
   }

--- a/sprout/bono.cpp
+++ b/sprout/bono.cpp
@@ -536,12 +536,12 @@ void process_tsx_request(pjsip_rx_data* rdata)
     }
 
     // Send Rf messages and clean up the ACRs.
-    acr->send_message();
+    acr->send();
     delete acr; acr = NULL;
 
     if (downstream_acr)
     {
-      downstream_acr->send_message();
+      downstream_acr->send();
       delete downstream_acr; downstream_acr = NULL;
     }
 
@@ -638,7 +638,7 @@ void process_cancel_request(pjsip_rx_data* rdata)
                                        acr_node_role(rdata->msg_info.msg));
   acr->set_default_ccf(PJUtils::pj_str_to_string(&stack_data.cdf_domain));
   acr->rx_request(rdata->msg_info.msg, rdata->pkt_info.timestamp);
-  acr->send_message();
+  acr->send();
   delete acr;
 
   // Unlock UAS tsx because it is locked in find_tsx()
@@ -752,7 +752,7 @@ static void reject_request(pjsip_rx_data* rdata, int status_code)
   }
 
   // Send the ACR and delete it.
-  acr->send_message();
+  acr->send();
   delete acr;
 }
 
@@ -1818,7 +1818,7 @@ UASTransaction::~UASTransaction()
     // I-CSCF ACR has been created for this transaction, so send the message
     // and delete the ACR.
     TRC_DEBUG("I-CSCF ACR = %p", _icscf_acr);
-    _icscf_acr->send_message();
+    _icscf_acr->send();
 
     if (_downstream_acr == _icscf_acr)
     {
@@ -1836,7 +1836,7 @@ UASTransaction::~UASTransaction()
     // BGCF ACR has been created for this transaction, so send the message
     // and delete the ACR.
     TRC_DEBUG("BGCF ACR = %p", _bgcf_acr);
-    _bgcf_acr->send_message();
+    _bgcf_acr->send();
 
     if (_downstream_acr == _bgcf_acr)
     {
@@ -1856,12 +1856,12 @@ UASTransaction::~UASTransaction()
   {
     // The downstream ACR is not the same as the upstream one, so send the
     // message and destroy the object.
-    _downstream_acr->send_message();
+    _downstream_acr->send();
     delete _downstream_acr;
   }
 
   // Send the ACR for the upstream side.
-  _upstream_acr->send_message();
+  _upstream_acr->send();
   delete _upstream_acr;
   _upstream_acr = NULL;
   _downstream_acr = NULL;
@@ -2041,7 +2041,7 @@ void UASTransaction::on_new_client_response(UACTransaction* uac_data, pjsip_rx_d
       {
         // This is a provisional response to a mid-dialog message, so we
         // should send an ACR now.
-        _downstream_acr->send_message();
+        _downstream_acr->send();
 
         // Don't delete the ACR as we will send another on any subsequent
         // provisional responses, and also when the transaction completes.
@@ -2065,7 +2065,7 @@ void UASTransaction::on_new_client_response(UACTransaction* uac_data, pjsip_rx_d
         {
           // This is a provisional response to a mid-dialog message, so we
           // should send an ACR now.
-          _upstream_acr->send_message();
+          _upstream_acr->send();
 
           // Don't delete the ACR as we will send another on any subsequent
           // provisional responses, and also when the transaction completes.

--- a/sprout/icscfrouter.cpp
+++ b/sprout/icscfrouter.cpp
@@ -100,7 +100,7 @@ int ICSCFRouter::get_scscf(pj_pool_t* pool, pjsip_sip_uri*& scscf_sip_uri)
     // should be generated if the Cx Query fails - we are sending on both
     // success and failure, but that could be wrong.  Also, in the failure
     // case we will not include a Server-Capabilities AVP.)
-    _acr->send_message();
+    _acr->send();
   }
 
   if (status_code == PJSIP_SC_OK)

--- a/sprout/icscfsproutlet.cpp
+++ b/sprout/icscfsproutlet.cpp
@@ -168,7 +168,7 @@ ICSCFSproutletRegTsx::~ICSCFSproutletRegTsx()
   if (_acr != NULL)
   {
     // Send the ACR for this transaction.
-    _acr->send_message();
+    _acr->send();
   }
 
   delete _acr;
@@ -406,7 +406,7 @@ void ICSCFSproutletRegTsx::on_cancel(int status_code, pjsip_msg* cancel_req)
 
     // @TODO - timestamp from request.
     acr->rx_request(cancel_req);
-    acr->send_message();
+    acr->send();
 
     delete acr;
   }
@@ -433,7 +433,7 @@ ICSCFSproutletTsx::~ICSCFSproutletTsx()
 {
   if (_acr != NULL)
   {
-    _acr->send_message();
+    _acr->send();
     delete _acr;
   }
 
@@ -783,7 +783,7 @@ void ICSCFSproutletTsx::on_cancel(int status_code, pjsip_msg* cancel_req)
 
     // @TODO - timestamp from request.
     acr->rx_request(cancel_req);
-    acr->send_message();
+    acr->send();
 
     delete acr;
   }

--- a/sprout/registrar.cpp
+++ b/sprout/registrar.cpp
@@ -1042,7 +1042,7 @@ void process_register_request(pjsip_rx_data* rdata)
   status = pjsip_endpt_send_response2(stack_data.endpt, rdata, tdata, NULL, NULL);
 
   // Send the ACR and delete it.
-  acr->send_message();
+  acr->send();
   delete acr;
 
   // TODO in sto397: we should do third-party registration once per

--- a/sprout/scscfsproutlet.cpp
+++ b/sprout/scscfsproutlet.cpp
@@ -1545,25 +1545,28 @@ void SCSCFSproutletTsx::add_record_route(pjsip_msg* msg,
 {
   pj_pool_t* pool = get_pool(msg);
 
+  pjsip_route_hdr* rr = NULL;
   if (!_record_routed)
   {
     pjsip_sip_uri* uri = get_reflexive_uri(pool);
 
-    pjsip_route_hdr* rr = pjsip_rr_hdr_create(pool);
+    rr = pjsip_rr_hdr_create(pool);
     rr->name_addr.uri = (pjsip_uri*)uri;
 
     pjsip_msg_insert_first_hdr(msg, (pjsip_hdr*)rr);
 
     _record_routed = true;
   }
+  else
+  {
+    rr = (pjsip_route_hdr*)pjsip_msg_find_hdr(msg,
+                                              PJSIP_H_RECORD_ROUTE,
+                                              NULL);
+  }
 
   // Ensure the billing scope flag is set on the RR header.
   if (billing_rr)
   {
-    pjsip_route_hdr* rr = (pjsip_route_hdr*)pjsip_msg_find_hdr(msg,
-                                                               PJSIP_H_RECORD_ROUTE,
-                                                               NULL);
-
     // We've records routed before (either earlier in this function or in a
     // previous call to this function within this transaction).  Therefore the
     // Record-Route header we added then must be present (and must be the top

--- a/sprout/scscfsproutlet.cpp
+++ b/sprout/scscfsproutlet.cpp
@@ -347,7 +347,7 @@ SCSCFSproutletTsx::~SCSCFSproutletTsx()
     ACR* acr = get_acr();
     if (acr)
     {
-      acr->send_message();
+      acr->send();
     }
   }
 
@@ -648,7 +648,7 @@ void SCSCFSproutletTsx::on_rx_cancel(int status_code, pjsip_msg* cancel_req)
 
     // @TODO - timestamp from request.
     cancel_acr->rx_request(cancel_req);
-    cancel_acr->send_message();
+    cancel_acr->send();
 
     delete cancel_acr;
   }

--- a/sprout/subscription.cpp
+++ b/sprout/subscription.cpp
@@ -595,7 +595,7 @@ void process_subscription_request(pjsip_rx_data* rdata)
   status = pjsip_endpt_send_response2(stack_data.endpt, rdata, tdata, NULL, NULL);
 
   // Send the ACR and delete it.
-  acr->send_message();
+  acr->send();
   delete acr;
 
   // Send the Notify

--- a/sprout/ut/scscf_test.cpp
+++ b/sprout/ut/scscf_test.cpp
@@ -3949,8 +3949,8 @@ TEST_F(SCSCFTest, RecordRoutingTestStartAndEnd)
   doFourAppServerFlow("Record-Route: <sip:homedomain:5058;lr;service=scscf;billing-role=charge-term>\r\n"
                       "Record-Route: <sip:6.2.3.4>\r\n"
                       "Record-Route: <sip:5.2.3.4>\r\n"
-                      "Record-Route: <sip:homedomain:5058;lr;service=scscf;billing-role=charge-term>\r\n"
-                      "Record-Route: <sip:homedomain:5058;lr;service=scscf;billing-role=charge-orig>\r\n"
+                      "Record-Route: <sip:homedomain:5058;lr;service=scscf>\r\n"
+                      "Record-Route: <sip:homedomain:5058;lr;service=scscf>\r\n"
                       "Record-Route: <sip:4.2.3.4>\r\n"
                       "Record-Route: <sip:1.2.3.4>\r\n"
                       "Record-Route: <sip:homedomain:5058;lr;service=scscf;billing-role=charge-orig>", true);
@@ -3986,12 +3986,12 @@ TEST_F(SCSCFTest, RecordRoutingTestEachHop)
   // split originating and terminating handling like that yet.
   doFourAppServerFlow("Record-Route: <sip:homedomain:5058;lr;service=scscf;billing-role=charge-term>\r\n"
                       "Record-Route: <sip:6.2.3.4>\r\n"
-                      "Record-Route: <sip:homedomain:5058;lr;service=scscf;billing-role=charge-term>\r\n"
+                      "Record-Route: <sip:homedomain:5058;lr;service=scscf>\r\n"
                       "Record-Route: <sip:5.2.3.4>\r\n"
-                      "Record-Route: <sip:homedomain:5058;lr;service=scscf;billing-role=charge-term>\r\n"
-                      "Record-Route: <sip:homedomain:5058;lr;service=scscf;billing-role=charge-orig>\r\n"
+                      "Record-Route: <sip:homedomain:5058;lr;service=scscf>\r\n"
+                      "Record-Route: <sip:homedomain:5058;lr;service=scscf>\r\n"
                       "Record-Route: <sip:4.2.3.4>\r\n"
-                      "Record-Route: <sip:homedomain:5058;lr;service=scscf;billing-role=charge-orig>\r\n"
+                      "Record-Route: <sip:homedomain:5058;lr;service=scscf>\r\n"
                       "Record-Route: <sip:1.2.3.4>\r\n"
                       "Record-Route: <sip:homedomain:5058;lr;service=scscf;billing-role=charge-orig>", true);
 
@@ -4018,9 +4018,9 @@ TEST_F(SCSCFTest, RecordRoutingTestCollapseEveryHop)
   stack_data.record_route_on_every_hop = true;
   // Expect 1 Record-Route
   doFourAppServerFlow("Record-Route: <sip:homedomain:5058;lr;service=scscf;billing-role=charge-term>\r\n"
-                      "Record-Route: <sip:homedomain:5058;lr;service=scscf;billing-role=charge-term>\r\n"
-                      "Record-Route: <sip:homedomain:5058;lr;service=scscf;billing-role=charge-orig>\r\n"
-                      "Record-Route: <sip:homedomain:5058;lr;service=scscf;billing-role=charge-orig>\r\n"
+                      "Record-Route: <sip:homedomain:5058;lr;service=scscf>\r\n"
+                      "Record-Route: <sip:homedomain:5058;lr;service=scscf>\r\n"
+                      "Record-Route: <sip:homedomain:5058;lr;service=scscf>\r\n"
                       "Record-Route: <sip:homedomain:5058;lr;service=scscf;billing-role=charge-orig>", false);
   stack_data.record_route_on_every_hop = false;
 }


### PR DESCRIPTION
As per the discussion in #1199, this change limits the S-CSCF to perform billing at the beginning of originating and at the end of terminating, removing the billing performed on `cdiv` and removing the spurious INTERIM billing if your `Record-Route` settings cause multiple hops per call leg.

Fixes #1199.

I've tested the `billing-role` change and the `ACR::cancel()` function in UT.  I'll confirm the extra START ACR with a SAS trace on a live system once this is merged.