### PR TITLE
Reviewer: Rob] Strip Proxy-Authorization headers

### DIFF
--- a/sprout/authentication.cpp
+++ b/sprout/authentication.cpp
@@ -831,7 +831,13 @@ pj_bool_t authenticate_rx_request(pjsip_rx_data* rdata)
       if (status == PJ_SUCCESS)
       {
         // Request authentication completed, so let the message through to
-        // other modules.
+        // other modules. Remove any authorization headers first.
+        while (pjsip_msg_find_remove_hdr(rdata->msg_info.msg,
+                                         PJSIP_H_AUTHORIZATION,
+                                         NULL) != NULL);
+        while (pjsip_msg_find_remove_hdr(rdata->msg_info.msg,
+                                         PJSIP_H_PROXY_AUTHORIZATION,
+                                         NULL) != NULL);
         delete av;
         return PJ_FALSE;
       }

--- a/sprout/authentication.cpp
+++ b/sprout/authentication.cpp
@@ -830,11 +830,11 @@ pj_bool_t authenticate_rx_request(pjsip_rx_data* rdata)
 
       if (status == PJ_SUCCESS)
       {
-        // Request authentication completed, so let the message through to
-        // other modules. Remove any authorization headers first.
-        while (pjsip_msg_find_remove_hdr(rdata->msg_info.msg,
-                                         PJSIP_H_AUTHORIZATION,
-                                         NULL) != NULL);
+        // Request authentication completed, so let the message through to other
+        // modules. Remove any Proxy-Authorization headers first so they are not
+        // passed to downstream devices. We can't do this for Authorization
+        // headers, as these may need to be included in 3rd party REGISTER
+        // messages.
         while (pjsip_msg_find_remove_hdr(rdata->msg_info.msg,
                                          PJSIP_H_PROXY_AUTHORIZATION,
                                          NULL) != NULL);

--- a/sprout/ut/authentication_test.cpp
+++ b/sprout/ut/authentication_test.cpp
@@ -601,7 +601,14 @@ TEST_F(AuthenticationTest, DigestAuthSuccess)
   msg2._cnonce = "8765432187654321";
   msg2._qop = "auth";
   msg2._integ_prot = "ip-assoc-pending";
-  inject_msg(msg2.get());
+
+  // Inject the request into the auth module. Check that it passes the request
+  // through, and strips the Authorization header.
+  pjsip_rx_data* rdata = build_rxdata(msg2.get());
+  parse_rxdata(rdata);
+  pj_bool_t ret = _module->on_rx_request(rdata);
+  ASSERT_EQ(ret, PJ_FALSE);
+  EXPECT_EQ(get_headers(rdata->msg_info.msg, "Authorization"), "");
 
   // Expect no response, as the authentication module has let the request through.
   ASSERT_EQ(0, txdata_count());
@@ -1407,7 +1414,14 @@ TEST_F(AuthenticationPxyAuthHdrTest, ProxyAuthorizationSuccess)
   msg2._cnonce = "8765432187654321";
   msg2._qop = "auth";
   msg2._integ_prot = "ip-assoc-pending";
-  inject_msg(msg2.get());
+
+  // Inject the request into the auth module. Check that it passes the request
+  // through, and strips the Proxy-Authorization header.
+  pjsip_rx_data* rdata = build_rxdata(msg2.get());
+  parse_rxdata(rdata);
+  pj_bool_t ret = _module->on_rx_request(rdata);
+  ASSERT_EQ(ret, PJ_FALSE);
+  EXPECT_EQ(get_headers(rdata->msg_info.msg, "Proxy-Authorization"), "");
 
   // Expect no response, as the authentication module has let the request through.
   ASSERT_EQ(0, txdata_count());

--- a/sprout/ut/authentication_test.cpp
+++ b/sprout/ut/authentication_test.cpp
@@ -601,14 +601,7 @@ TEST_F(AuthenticationTest, DigestAuthSuccess)
   msg2._cnonce = "8765432187654321";
   msg2._qop = "auth";
   msg2._integ_prot = "ip-assoc-pending";
-
-  // Inject the request into the auth module. Check that it passes the request
-  // through, and strips the Authorization header.
-  pjsip_rx_data* rdata = build_rxdata(msg2.get());
-  parse_rxdata(rdata);
-  pj_bool_t ret = _module->on_rx_request(rdata);
-  ASSERT_EQ(ret, PJ_FALSE);
-  EXPECT_EQ(get_headers(rdata->msg_info.msg, "Authorization"), "");
+  inject_msg(msg2.get());
 
   // Expect no response, as the authentication module has let the request through.
   ASSERT_EQ(0, txdata_count());


### PR DESCRIPTION
Rob, please could you review this change to strip any Proxy-Authorization headers out of the message before passing the request up out of the auth module. 

I've not done this for Authorization headers as 3rd party REGISTERs may need to include the entire received REGISTER request :-0.

Tested in UT. Fixes #1213. 