### PR TITLE
[Reviewer: Ellie] Reinstate Bono logging

### DIFF
--- a/debian/bono.init.d
+++ b/debian/bono.init.d
@@ -162,9 +162,9 @@ get_daemon_args()
                      --dns-server=$signaling_dns_server
                      --pjsip-threads=$num_pjsip_threads
                      --worker-threads=$num_worker_threads
-                     -a=$log_directory
-                     -F=$log_directory
-                     -L=$log_level
+                     --analytics=$log_directory
+                     --log-file=$log_directory
+                     --log-level=$log_level
                      $target_latency_us_arg
                      $max_tokens_arg
                      $init_token_rate_arg


### PR DESCRIPTION
I noticed that no Bono nodes have been logging for a while - this is because short arguments like `-a` are incompatible with using `=` for arguments. This switches all the short-form arguments to long-form ones.