### PR TITLE
[Reviewer: Andy] Make the S-CSCF override the session ID when deciding to record-route

### DIFF
--- a/include/acr.h
+++ b/include/acr.h
@@ -164,6 +164,16 @@ public:
   /// Set the default CCF for this ACR.
   virtual void set_default_ccf(const std::string& default_ccf);
 
+  /// Sets the session ID for this ACR.
+  ///
+  /// This allows the caller to override the default session ID (which is the
+  /// call ID of the first request passed to the ACR).  This is useful if there
+  /// are B2BUAs involved in the call and the caller needs more control about
+  /// what call ID is reported to Ralf.
+  ///
+  /// @param session_id       The session ID to use.
+  virtual void override_session_id(const std::string& session_id);
+
   /// Called when the ACR message should be sent if it's not yet been
   /// cancelled.  In general this will be when the relevant transaction or AS
   /// chain has ended.
@@ -285,6 +295,15 @@ public:
   /// Set the default CCF for this ACR.
   virtual void set_default_ccf(const std::string& default_ccf);
 
+  /// Sets the session ID for this ACR.
+  ///
+  /// This allows the caller to override the default session ID (which is the
+  /// call ID of the first request passed to the ACR).  This is useful if there
+  /// are B2BUAs involved in the call and the caller needs more control about
+  /// what call ID is reported to Ralf.
+  ///
+  /// @param session_id       The session ID to use.
+  virtual void override_session_id(const std::string& session_id);
 private:
 
   /// Called when the Rf message should be triggered.  In general this will

--- a/sprout/acr.cpp
+++ b/sprout/acr.cpp
@@ -92,6 +92,10 @@ void ACR::set_default_ccf(const std::string& default_ccf)
 {
 }
 
+void ACR::override_session_id(const std::string& session_id)
+{
+}
+
 std::string ACR::node_name(Node node_functionality)
 {
   switch (node_functionality)
@@ -282,12 +286,15 @@ void RalfACR::rx_request(pjsip_msg* req, pj_time_val timestamp)
       _expires = -1;
     }
 
-    // Store the call ID.
-    pjsip_cid_hdr* cid_hdr = (pjsip_cid_hdr*)
-                                pjsip_msg_find_hdr(req, PJSIP_H_CALL_ID, NULL);
-    if (cid_hdr != NULL)
+    // Store the call ID but only if the session ID has not already been set.
+    if (_user_session_id.empty())
     {
-      _user_session_id = PJUtils::pj_str_to_string(&cid_hdr->id);
+      pjsip_cid_hdr* cid_hdr = (pjsip_cid_hdr*)
+                                  pjsip_msg_find_hdr(req, PJSIP_H_CALL_ID, NULL);
+      if (cid_hdr != NULL)
+      {
+        _user_session_id = PJUtils::pj_str_to_string(&cid_hdr->id);
+      }
     }
 
     // Store contents of From header.
@@ -639,7 +646,7 @@ void RalfACR::send_message(pj_time_val timestamp)
     rr->path = path;
     rr->message = get_message(timestamp);
     rr->trail = _trail;
-   
+
     _ralf->send_request_to_ralf(rr);
   }
   else
@@ -1265,6 +1272,11 @@ void RalfACR::set_default_ccf(const std::string& default_ccf)
   {
     _ccfs.push_back(default_ccf);
   }
+}
+
+void RalfACR::override_session_id(const std::string& session_id)
+{
+  _user_session_id = session_id;
 }
 
 void RalfACR::encode_sdp_description(

--- a/sprout/ut/acr_scscftermcall_start_changed_call_id.json
+++ b/sprout/ut/acr_scscftermcall_start_changed_call_id.json
@@ -1,0 +1,102 @@
+{
+  "event": {
+    "Accounting-Record-Type": 2,
+    "Acct-Interim-Interval": 600,
+    "Event-Timestamp": 1,
+    "Service-Information": {
+      "IMS-Information": {
+        "Application-Server-Information": [
+          {
+            "Application-Provided-Called-Party-Address": [
+              "sip:6505559999@homedomain"
+            ],
+            "Application-Server": "sip:as1.homedomain:5060;transport=TCP"
+          }
+        ],
+        "Called-Asserted-Identity": [
+          "sip:6505550001@homedomain",
+          "tel:6505550001"
+        ],
+        "Called-Party-Address": "sip:6505550001@homedomain",
+        "Calling-Party-Address": [
+          "sip:6505550000@homedomain",
+          "tel:6505550000"
+        ],
+        "Event-Type": {
+          "SIP-Method": "INVITE"
+        },
+        "From-Address": "\"6505550000\" <sip:6505550000@homedomain>;tag=12345678",
+        "IMS-Charging-Identifier": "1234bc9876e",
+        "Inter-Operator-Identifier": [
+          {
+            "Originating-IOI": "homedomain",
+            "Terminating-IOI": "homedomain"
+          }
+        ],
+        "Node-Functionality": 0,
+        "Role-Of-Node": 1,
+        "Route-Header-Received": "<sip:sprout.homedomain:5054;transport=TCP;lr>",
+        "Route-Header-Transmitted": "<sip:abcdefgh@pcscf1.homedomain:5058;transport=TCP;lr>",
+        "SDP-Media-Component": [
+          {
+            "IP-Realm-Default-Indication": 1,
+            "Local-GW-Inserted-Indication": 0,
+            "Media-Initiator-Flag": 1,
+            "Media-Initiator-Party": "sip:6505550000@homedomain",
+            "SDP-Media-Description": [
+              "c=IN IP4 10.83.18.38"
+            ],
+            "SDP-Media-Name": "m=audio 1988 RTP\/SAVPF 0 8",
+            "SDP-Type": 0,
+            "Transcoder-Inserted-Indication": 0
+          },
+          {
+            "IP-Realm-Default-Indication": 1,
+            "Local-GW-Inserted-Indication": 0,
+            "Media-Initiator-Flag": 0,
+            "Media-Initiator-Party": "sip:6505550001@homedomain",
+            "SDP-Media-Description": [
+              "c=IN IP4 10.83.18.50"
+            ],
+            "SDP-Media-Name": "m=audio 1988 RTP/SAVPF 0 8",
+            "SDP-Type": 1,
+            "Transcoder-Inserted-Indication": 0
+          }
+        ],
+        "SDP-Session-Description": [
+          "v=0",
+          "o=- 2728502836004741600 2 IN IP4 127.0.0.1",
+          "s=Doubango Telecom - chrome",
+          "t=0 0"
+        ],
+        "Time-Stamps": {
+          "SIP-Request-Timestamp": 1,
+          "SIP-Request-Timestamp-Fraction": 0,
+          "SIP-Response-Timestamp": 1,
+          "SIP-Response-Timestamp-Fraction": 70
+        },
+        "User-Session-Id": "differentfromapreviouscallid@10.83.18.38"
+      },
+      "Subscription-Id": [
+        {
+          "Subscription-Id-Data": "sip:6505550001@homedomain",
+          "Subscription-Id-Type": 2
+        },
+        {
+          "Subscription-Id-Data": "6505550001",
+          "Subscription-Id-Type": 0
+        }
+      ]
+    }
+  },
+  "peers": {
+    "ccf": [
+      "192.1.1.1",
+      "192.1.1.2"
+    ],
+    "ecf": [
+      "192.1.1.3",
+      "192.1.1.4"
+    ]
+  }
+}


### PR DESCRIPTION
Andy, please can you review this PR that fixes #1222. As discussed, I've added a new method to allow the S-CSCF to override the default session ID for an ACR, and made the S-CSCF sproutlet call this whenever it record-routes itself into a dialog to do billing. 

I tested the ACR code in UT. I tested the entire change (including the S-CSCF part) live, by using mangelwurzel to change the call ID and checking in SAS that the correct session IDs were used on INTERIMs and STOPs send by sprout.