### PR TITLE
[Reviewer: Andy] Fixes #1209 - Reload enum json on sighup

### DIFF
--- a/include/bgcfservice.h
+++ b/include/bgcfservice.h
@@ -43,6 +43,7 @@
 #include <map>
 #include <string>
 #include <boost/regex.hpp>
+#include <boost/thread.hpp>
 
 #include <functional>
 #include "updater.h"
@@ -57,9 +58,9 @@ public:
   /// Updates the bgcf routes
   void update_routes();
 
-  std::vector<std::string> get_route_from_domain(const std::string &domain, 
+  std::vector<std::string> get_route_from_domain(const std::string &domain,
                                                  SAS::TrailId trail) const;
-  std::vector<std::string> get_route_from_number(const std::string &number, 
+  std::vector<std::string> get_route_from_number(const std::string &number,
                                                  SAS::TrailId trail) const;
 
 private:
@@ -68,6 +69,9 @@ private:
   std::string _configuration;
   Updater<void, BgcfService>* _updater;
 
+  // Mark as mutable to flag that this can be modified without affecting the
+  // external behaviour of the class, allowing for locking in 'const' methods.
+  mutable boost::shared_mutex _routes_rw_lock;
 };
 
 #endif

--- a/include/enumservice.h
+++ b/include/enumservice.h
@@ -45,10 +45,12 @@
 #include <boost/regex.hpp>
 #include <netinet/in.h>
 #include <ares.h>
+#include <pthread.h>
 #include "sas.h"
 #include "baseresolver.h"
 #include "dnsresolver.h"
 #include "communicationmonitor.h"
+#include "updater.h"
 
 /// @class EnumService
 ///
@@ -88,9 +90,14 @@ public:
   JSONEnumService(std::string configuration = "./enum.json");
   ~JSONEnumService();
 
+  // Updates the enum configuration
+  void update_enum();
+
   std::string lookup_uri_from_user(const std::string& user, SAS::TrailId trail) const;
 
 private:
+  void destroy_prefixes();
+
   struct NumberPrefix
   {
     std::string prefix;
@@ -100,8 +107,10 @@ private:
 
   std::list<struct NumberPrefix*> _number_prefixes;
 
+  std::string _configuration;
   NumberPrefix* prefix_match(const std::string& number) const;
-
+  Updater<void, JSONEnumService>* _updater;
+  mutable pthread_mutex_t _number_prefixes_rw_lock;
 };
 
 /// @class DNSEnumService

--- a/include/scscfselector.h
+++ b/include/scscfselector.h
@@ -41,6 +41,7 @@
 #include <vector>
 #include <map>
 #include <functional>
+#include <boost/thread.hpp>
 #include "updater.h"
 #include "sas.h"
 
@@ -70,6 +71,7 @@ private:
   std::string _configuration;
   std::vector<scscf> _scscfs;
   Updater<void, SCSCFSelector>* _updater;
+  boost::shared_mutex _scscfs_rw_lock;
 };
 
 #endif

--- a/sprout/bgcfservice.cpp
+++ b/sprout/bgcfservice.cpp
@@ -80,13 +80,13 @@ void BgcfService::update_routes()
   if (bgcf_str == "")
   {
     // LCOV_EXCL_START
-    TRC_ERROR("Failed to read BGCF configuration data from %s", 
+    TRC_ERROR("Failed to read BGCF configuration data from %s",
               _configuration.c_str());
     CL_SPROUT_BGCF_FILE_EMPTY.log();
     return;
     // LCOV_EXCL_STOP
   }
- 
+
   // Now parse the document
   rapidjson::Document doc;
   doc.Parse<0>(bgcf_str.c_str());
@@ -162,6 +162,8 @@ void BgcfService::update_routes()
       }
     }
 
+    // Take a write lock on the mutex in RAII style
+    boost::lock_guard<boost::shared_mutex> write_lock(_routes_rw_lock);
     _domain_routes = new_domain_routes;
     _number_routes = new_number_routes;
   }
@@ -185,8 +187,11 @@ std::vector<std::string> BgcfService::get_route_from_domain(
 {
   TRC_DEBUG("Getting route for URI domain %s via BGCF lookup", domain.c_str());
 
+  // Take a read lock on the mutex in RAII style
+  boost::shared_lock<boost::shared_mutex> read_lock(_routes_rw_lock);
+
   // First try the specified domain.
-  std::map<std::string, std::vector<std::string>>::const_iterator i = 
+  std::map<std::string, std::vector<std::string>>::const_iterator i =
                                                     _domain_routes.find(domain);
   if (i != _domain_routes.end())
   {
@@ -239,8 +244,11 @@ std::vector<std::string> BgcfService::get_route_from_number(
                                                 const std::string &number,
                                                 SAS::TrailId trail) const
 {
-  // The number routes map is ordered by length of key. Start from the end of 
-  // the map to get the longest prefixes first. 
+  // Take a read lock on the mutex in RAII style
+  boost::shared_lock<boost::shared_mutex> read_lock(_routes_rw_lock);
+
+  // The number routes map is ordered by length of key. Start from the end of
+  // the map to get the longest prefixes first.
   for (std::map<std::string, std::vector<std::string>>::const_reverse_iterator it =
         _number_routes.rbegin();
        it != _number_routes.rend();
@@ -262,8 +270,8 @@ std::vector<std::string> BgcfService::get_route_from_number(
       event.add_var_param(number);
       std::string route_string;
 
-      for (std::vector<std::string>::const_iterator ii = (*it).second.begin(); 
-                                                    ii != (*it).second.end(); 
+      for (std::vector<std::string>::const_iterator ii = (*it).second.begin();
+                                                    ii != (*it).second.end();
                                                     ++ii)
       {
         route_string = route_string + *ii + ";";

--- a/sprout/enumservice.cpp
+++ b/sprout/enumservice.cpp
@@ -217,13 +217,14 @@ void JSONEnumService::destroy_prefixes()
 
 JSONEnumService::~JSONEnumService()
 {
-  // Destroy the updater
   delete _updater;
   _updater = NULL;
 
   // Lock not required here as nothing should be using the object when it is
   // destroyed.
   destroy_prefixes();
+
+  pthread_mutex_destroy(&_number_prefixes_rw_lock);
 }
 
 
@@ -269,9 +270,9 @@ std::string JSONEnumService::lookup_uri_from_user(const std::string &user, SAS::
 
 JSONEnumService::NumberPrefix* JSONEnumService::prefix_match(const std::string& number) const
 {
-  pthread_mutex_lock(&_number_prefixes_rw_lock);
-
   JSONEnumService::NumberPrefix* xoPrefix = NULL;
+
+  pthread_mutex_lock(&_number_prefixes_rw_lock);
 
   // For simplicity this uses a linear scan since we don't expect too many
   // entries.  Should shift to a radix tree at some point.

--- a/sprout/enumservice.cpp
+++ b/sprout/enumservice.cpp
@@ -252,6 +252,10 @@ std::string JSONEnumService::lookup_uri_from_user(const std::string &user, SAS::
 }
 
 
+// This function returns a pointer to a struct that may be destroyed by the
+// updater. Callers must therefore ensure that they have the read lock before
+// calling this function and only release the lock once they no longer need
+// the object.
 const JSONEnumService::NumberPrefix* JSONEnumService::prefix_match(const std::string& number) const
 {
   // For simplicity this uses a linear scan since we don't expect too many

--- a/sprout/enumservice.cpp
+++ b/sprout/enumservice.cpp
@@ -92,23 +92,34 @@ bool EnumService::parse_regex_replace(const std::string& regex_replace, boost::r
 }
 
 
-JSONEnumService::JSONEnumService(std::string configuration)
+JSONEnumService::JSONEnumService(std::string configuration):
+  _configuration(configuration),
+  _updater(NULL)
+{
+  pthread_mutex_init(&_number_prefixes_rw_lock, NULL);
+
+  // create and updater which, by default, runs the function when initialized
+  _updater = new Updater<void, JSONEnumService>(this,
+                                  std::mem_fun(&JSONEnumService::update_enum));
+}
+
+void JSONEnumService::update_enum()
 {
   // Check whether the file exists.
   struct stat s;
-  if ((stat(configuration.c_str(), &s) != 0) &&
+  if ((stat(_configuration.c_str(), &s) != 0) &&
       (errno == ENOENT))
   {
     TRC_STATUS("No ENUM configuration (file %s does not exist)",
-               configuration.c_str());
-    CL_SPROUT_ENUM_FILE_MISSING.log(configuration.c_str());
+               _configuration.c_str());
+    CL_SPROUT_ENUM_FILE_MISSING.log(_configuration.c_str());
     return;
   }
 
-  TRC_STATUS("Loading ENUM configuration from %s", configuration.c_str());
+  TRC_STATUS("Loading ENUM configuration from %s", _configuration.c_str());
 
   // Read from the file
-  std::ifstream fs(configuration.c_str());
+  std::ifstream fs(_configuration.c_str());
   std::string enum_str((std::istreambuf_iterator<char>(fs)),
                         std::istreambuf_iterator<char>());
 
@@ -116,8 +127,8 @@ JSONEnumService::JSONEnumService(std::string configuration)
   {
     // LCOV_EXCL_START
     TRC_ERROR("Failed to read ENUM configuration data from %s",
-              configuration.c_str());
-    CL_SPROUT_ENUM_FILE_EMPTY.log(configuration.c_str());
+              _configuration.c_str());
+    CL_SPROUT_ENUM_FILE_EMPTY.log(_configuration.c_str());
     return;
     // LCOV_EXCL_STOP
   }
@@ -131,12 +142,14 @@ JSONEnumService::JSONEnumService(std::string configuration)
     TRC_ERROR("Failed to read ENUM configuration data: %s\nError: %s",
               enum_str.c_str(),
               rapidjson::GetParseError_En(doc.GetParseError()));
-    CL_SPROUT_ENUM_FILE_INVALID.log(configuration.c_str());
+    CL_SPROUT_ENUM_FILE_INVALID.log(_configuration.c_str());
     return;
   }
 
   try
   {
+    std::list<struct NumberPrefix*> new_number_prefixes;
+
     JSON_ASSERT_CONTAINS(doc, "number_blocks");
     JSON_ASSERT_ARRAY(doc["number_blocks"]);
     const rapidjson::Value& nb_arr = doc["number_blocks"];
@@ -147,7 +160,7 @@ JSONEnumService::JSONEnumService(std::string configuration)
     {
       try
       {
-        std::string prefix; 
+        std::string prefix;
         JSON_GET_STRING_MEMBER(*nb_it, "prefix", prefix);
         std::string regex;
         JSON_GET_STRING_MEMBER(*nb_it, "regex", regex);
@@ -175,19 +188,24 @@ JSONEnumService::JSONEnumService(std::string configuration)
         // Badly formed number block.
         TRC_WARNING("Badly formed ENUM number block (hit error at %s:%d)",
                     err._file, err._line);
-        CL_SPROUT_ENUM_FILE_INVALID.log(configuration.c_str());
+        CL_SPROUT_ENUM_FILE_INVALID.log(_configuration.c_str());
       }
     }
+
+    // Delete the old prefixes and store the new ones under mutex protection.
+    pthread_mutex_lock(&_number_prefixes_rw_lock);
+    destroy_prefixes();
+    _number_prefixes = new_number_prefixes;
+    pthread_mutex_unlock(&_number_prefixes_rw_lock);
   }
   catch (JsonFormatError err)
   {
     TRC_ERROR("Badly formed ENUM configuration data - missing number_blocks object");
-    CL_SPROUT_ENUM_FILE_INVALID.log(configuration.c_str());
+    CL_SPROUT_ENUM_FILE_INVALID.log(_configuration.c_str());
   }
 }
 
-
-JSONEnumService::~JSONEnumService()
+void JSONEnumService::destroy_prefixes()
 {
   for (std::list<struct NumberPrefix*>::iterator it = _number_prefixes.begin();
        it != _number_prefixes.end();
@@ -195,6 +213,17 @@ JSONEnumService::~JSONEnumService()
   {
     delete *it;
   }
+}
+
+JSONEnumService::~JSONEnumService()
+{
+  // Destroy the updater
+  delete _updater;
+  _updater = NULL;
+
+  // Lock not required here as nothing should be using the object when it is
+  // destroyed.
+  destroy_prefixes();
 }
 
 
@@ -240,6 +269,10 @@ std::string JSONEnumService::lookup_uri_from_user(const std::string &user, SAS::
 
 JSONEnumService::NumberPrefix* JSONEnumService::prefix_match(const std::string& number) const
 {
+  pthread_mutex_lock(&_number_prefixes_rw_lock);
+
+  JSONEnumService::NumberPrefix* xoPrefix = NULL;
+
   // For simplicity this uses a linear scan since we don't expect too many
   // entries.  Should shift to a radix tree at some point.
   for (std::list<struct NumberPrefix*>::const_iterator it = _number_prefixes.begin();
@@ -257,11 +290,14 @@ JSONEnumService::NumberPrefix* JSONEnumService::prefix_match(const std::string& 
       // ordered with most specific matches first so we can stop as soon as we
       // have one match).
       TRC_DEBUG("Match found");
-      return *it;
+      xoPrefix = *it;
+      break;
     }
   }
 
-  return NULL;
+  pthread_mutex_unlock(&_number_prefixes_rw_lock);
+
+  return xoPrefix;
 }
 
 DNSEnumService::DNSEnumService(const std::vector<std::string>& dns_servers,
@@ -296,7 +332,7 @@ DNSEnumService::DNSEnumService(const std::vector<std::string>& dns_servers,
       dns_server_addr.af = res->ai_family;
       if (dns_server_addr.af == AF_INET)
       {
-        dns_server_addr.addr.ipv4 = ((struct sockaddr_in*)res->ai_addr)->sin_addr;   
+        dns_server_addr.addr.ipv4 = ((struct sockaddr_in*)res->ai_addr)->sin_addr;
       }
       else if (dns_server_addr.af == AF_INET6)
       {
@@ -450,7 +486,7 @@ std::string DNSEnumService::lookup_uri_from_user(const std::string& user, SAS::T
   }
 
   // Report state of last communication attempt (which may potentially set/clear
-  // an associated alarm). 
+  // an associated alarm).
   if (_comm_monitor)
   {
     if (server_failed)
@@ -509,7 +545,7 @@ void DNSEnumService::parse_naptr_reply(const struct ares_naptr_reply* naptr_repl
   {
     TRC_DEBUG("Got NAPTR record: %u %u \"%s\" \"%s\" \"%s\" %s", record->order, record->preference, record->service, record->flags, record->regexp, record->replacement);
     if ((strcasecmp((char*)record->service, "e2u+sip") == 0) ||
-        (strcasecmp((char*)record->service, "e2u+pstn:sip") == 0) || 
+        (strcasecmp((char*)record->service, "e2u+pstn:sip") == 0) ||
         (strcasecmp((char*)record->service, "e2u+pstn:tel") == 0))
     {
       boost::regex regex;


### PR DESCRIPTION
Andy

Would you mind reviewing these changes to allow Sprout to pickup changes to enum.json.
A couple of areas I'm less confident on are:
* The locking using pthread mutexes.
* Memory management - Looking at [scscfselector](https://github.com/Metaswitch/sprout/blob/dev/sprout/scscfselector.cpp) line 151, we don't seem to destroy the old list (_scscfs) in the way I have done in my change. I think this might mean that scscfselector leaks the memory storing the config whenever it is reloaded, although if I'm misunderstanding something then my changes may be wrong instead.

Fixes #1209 

I tested this on our system with both good and broken enum.json files and it behaved as expected.

Thanks,
Tom