### PR TITLE
Correct Reason parameter in History-Info header

### DIFF
--- a/sprout/basicproxy.cpp
+++ b/sprout/basicproxy.cpp
@@ -1733,6 +1733,8 @@ void BasicProxy::UACTsx::cancel_pending_tsx(int st_code)
       if (_tdata->msg->line.req.method.id == PJSIP_INVITE_METHOD)
       {
         TRC_DEBUG("Sending CANCEL request");
+
+        // See issue 1232.
         pjsip_tx_data *cancel = PJUtils::create_cancel(stack_data.endpt,
                                                        _tsx->last_tx,
                                                        st_code);

--- a/sprout/bono.cpp
+++ b/sprout/bono.cpp
@@ -2863,7 +2863,7 @@ void UACTransaction::cancel_pending_tsx(int st_code)
       // See issue 1232.
       pjsip_tx_data* cancel = PJUtils::create_cancel(stack_data.endpt,
                                                      _tsx->last_tx,
-                                                     _tsx->status_code)
+                                                     _tsx->status_code);
 
       if (trail() == 0)
       {

--- a/sprout/bono.cpp
+++ b/sprout/bono.cpp
@@ -2860,18 +2860,11 @@ void UACTransaction::cancel_pending_tsx(int st_code)
     TRC_DEBUG("Found transaction %s status=%d", name(), _tsx->status_code);
     if (_tsx->status_code < 200)
     {
-      pjsip_tx_data *cancel;
-      pjsip_endpt_create_cancel(stack_data.endpt, _tsx->last_tx, &cancel);
-      if (st_code != 0)
-      {
-        char reason_val_str[96];
-        const pj_str_t* st_text = pjsip_get_status_text(st_code);
-        sprintf(reason_val_str, "SIP ;cause=%d ;text=\"%.*s\"", st_code, (int)st_text->slen, st_text->ptr);
-        pj_str_t reason_name = pj_str("Reason");
-        pj_str_t reason_val = pj_str(reason_val_str);
-        pjsip_hdr* reason_hdr = (pjsip_hdr*)pjsip_generic_string_hdr_create(cancel->pool, &reason_name, &reason_val);
-        pjsip_msg_add_hdr(cancel->msg, reason_hdr);
-      }
+      // See issue 1232.
+      pjsip_tx_data* cancel = PJUtils::create_cancel(stack_data.endpt,
+                                                     _tsx->last_tx,
+                                                     _tsx->status_code)
+
       if (trail() == 0)
       {
         TRC_ERROR("Sending CANCEL request with no SAS trail");

--- a/sprout/pjutils.cpp
+++ b/sprout/pjutils.cpp
@@ -59,10 +59,6 @@ extern "C" {
 #include "enumservice.h"
 #include "uri_classifier.h"
 
-/// Definitions of static functions.
-namespace PJUtils {
-static std::string build_reason_value(int code);
-}
 
 static const int DEFAULT_RETRIES = 5;
 
@@ -1563,10 +1559,10 @@ void PJUtils::remove_top_via(pjsip_tx_data* tdata)
   }
 }
 
-static std::string PJUtils::build_reason_value(int code)
+static std::string build_reason_value(int code)
 {
   std::stringstream value_builder;
-  std::string reason_text = pj_str_to_string(pjsip_get_status_text(code));
+  std::string reason_text = PJUtils::pj_str_to_string(pjsip_get_status_text(code));
 
   value_builder << "SIP;cause=" << code << ";text=\"" << reason_text << "\"";
 

--- a/sprout/pjutils.cpp
+++ b/sprout/pjutils.cpp
@@ -1826,19 +1826,19 @@ void PJUtils::update_history_info_reason(pjsip_uri* history_info_uri, pj_pool_t*
       // so that it can be manipulated using C++ utility functions.
       std::stringstream value_builder;
       std::string reason_value_string;
-      pj_str_t* reason_value;
+      pj_str_t reason_value;
 
       const pj_str_t* reason_text = pjsip_get_status_text(code);
 
       value_builder << "SIP;cause=";
       value_builder << code;
       value_builder << ";text=\"";
-      value_builder << pj_str_to_string(reason_text)
+      value_builder << pj_str_to_string(reason_text);
       value_builder << "\"";
 
       // As per RFC 3261, the contents of a parameter must contain a limited
       // set of characters.
-      reason_value_string = Utils::url_escape(value_builder.str())
+      reason_value_string = Utils::url_escape(value_builder.str());
 
       pj_strdup2(pool,
                  &reason_value,
@@ -1847,7 +1847,7 @@ void PJUtils::update_history_info_reason(pjsip_uri* history_info_uri, pj_pool_t*
       // Create a parameter and copy in the details we've created.
       pjsip_param *param = PJ_POOL_ALLOC_T(pool, pjsip_param);
       param->name = STR_REASON;
-      param->value = reason_val;
+      param->value = reason_value;
 
       pj_list_insert_after(&history_info_sip_uri->other_param,
                            (pj_list_type*)param);

--- a/sprout/pjutils.cpp
+++ b/sprout/pjutils.cpp
@@ -1822,23 +1822,26 @@ void PJUtils::update_history_info_reason(pjsip_uri* history_info_uri, pj_pool_t*
     pjsip_sip_uri* history_info_sip_uri = (pjsip_sip_uri*)history_info_uri;
     if (pj_list_empty(&history_info_sip_uri->other_param))
     {
-      pj_str_t* null_terminated_text;
+      // Need to build up a std::string containing the parameter value
+      // so that it can be manipulated using C++ utility functions.
       std::stringstream value_builder;
       std::string reason_value_string;
       pj_str_t* reason_value;
 
       const pj_str_t* reason_text = pjsip_get_status_text(code);
-      pj_strdup2_with_null(pool, null_terminated_text, reason_text);
 
-      value_builder << "SIP;cause=" << code;
-      value_builder << ";text=\"" << null_terminated_text << "\"";
-      
+      value_builder << "SIP;cause=";
+      value_builder << code;
+      value_builder << ";text=\"";
+      value_builder << pj_str_to_string(reason_text)
+      value_builder << "\"";
+
       // As per RFC 3261, the contents of a parameter must contain a limited
       // set of characters.
       reason_value_string = Utils::url_escape(value_builder.str())
-        
-      pj_strdup2(pool, 
-                 &reason_value, 
+
+      pj_strdup2(pool,
+                 &reason_value,
                  reason_value_string.c_str());
 
       // Create a parameter and copy in the details we've created.

--- a/sprout/pjutils.cpp
+++ b/sprout/pjutils.cpp
@@ -1815,9 +1815,6 @@ pjsip_history_info_hdr* PJUtils::create_history_info_hdr(pjsip_uri* target, pj_p
 void PJUtils::update_history_info_reason(pjsip_uri* history_info_uri, pj_pool_t* pool, int code)
 {
   static const pj_str_t STR_REASON = pj_str("Reason");
-  static const pj_str_t STR_SIP = pj_str("SIP");
-  static const pj_str_t STR_CAUSE = pj_str("cause");
-  static const pj_str_t STR_TEXT = pj_str("text");
 
   if (PJSIP_URI_SCHEME_IS_SIP(history_info_uri))
   {
@@ -1825,25 +1822,32 @@ void PJUtils::update_history_info_reason(pjsip_uri* history_info_uri, pj_pool_t*
     pjsip_sip_uri* history_info_sip_uri = (pjsip_sip_uri*)history_info_uri;
     if (pj_list_empty(&history_info_sip_uri->other_param))
     {
+      pj_str_t* null_terminated_text;
+      std::stringstream value_builder;
+      std::string reason_value_string;
+      pj_str_t* reason_value;
+
+      const pj_str_t* reason_text = pjsip_get_status_text(code);
+      pj_strdup2_with_null(pool, null_terminated_text, reason_text);
+
+      value_builder << "SIP;cause=" << code;
+      value_builder << ";text=\"" << null_terminated_text << "\"";
+      
+      // As per RFC 3261, the contents of a parameter must contain a limited
+      // set of characters.
+      reason_value_string = Utils::url_escape(value_builder.str())
+        
+      pj_strdup2(pool, 
+                 &reason_value, 
+                 reason_value_string.c_str());
+
+      // Create a parameter and copy in the details we've created.
       pjsip_param *param = PJ_POOL_ALLOC_T(pool, pjsip_param);
       param->name = STR_REASON;
-      param->value = STR_SIP;
+      param->value = reason_val;
 
-      pj_list_insert_after(&history_info_sip_uri->other_param, (pj_list_type*)param);
-
-      // Now add the cause parameter.
-      param = PJ_POOL_ALLOC_T(pool, pjsip_param);
-      param->name = STR_CAUSE;
-      char cause_text[4];
-      sprintf(cause_text, "%u", code);
-      pj_strdup2(pool, &param->value, cause_text);
-      pj_list_insert_after(&history_info_sip_uri->other_param, param);
-
-      // Finally add the text parameter.
-      param = PJ_POOL_ALLOC_T(pool, pjsip_param);
-      param->name = STR_TEXT;
-      param->value = *pjsip_get_status_text(code);
-      pj_list_insert_after(&history_info_sip_uri->other_param, param);
+      pj_list_insert_after(&history_info_sip_uri->other_param,
+                           (pj_list_type*)param);
     }
   }
 }

--- a/sprout/sproutletproxy.cpp
+++ b/sprout/sproutletproxy.cpp
@@ -1866,6 +1866,7 @@ void SproutletWrapper::tx_response(pjsip_tx_data* rsp)
 void SproutletWrapper::tx_cancel(int fork_id)
 {
   // Build a CANCEL request from the original request sent on this fork.
+  // See issue 1232.
   pjsip_tx_data* cancel = PJUtils::create_cancel(stack_data.endpt,
                                                  _forks[fork_id].req,
                                                  _forks[fork_id].cancel_reason);

--- a/sprout/ut/scscf_test.cpp
+++ b/sprout/ut/scscf_test.cpp
@@ -4779,7 +4779,7 @@ TEST_F(SCSCFTest, MmtelCdiv)
   EXPECT_THAT(get_headers(out, "P-Served-User"),
               testing::MatchesRegex("P-Served-User: <sip:6505551234@homedomain>;sescase=orig-cdiv"));
   EXPECT_THAT(get_headers(out, "History-Info"),
-              testing::MatchesRegex("History-Info: <sip:6505551234@homedomain;text=Temporarily%20Unavailable;cause=480;Reason=SIP>;index=1\r\nHistory-Info: <sip:6505555678@homedomain>;index=1.1"));
+              testing::MatchesRegex("History-Info: <sip:6505551234@homedomain;Reason=SIP%3[bB]cause%3[dD]480%3[bB]text%3[dD]%22Temporarily%20Unavailable%22>;index=1\r\nHistory-Info: <sip:6505555678@homedomain>;index=1.1"));
 
   // ---------- AS2 turns it around (acting as proxy)
   hdr = (pjsip_hdr*)pjsip_msg_find_hdr_by_name(out, &STR_ROUTE, NULL);
@@ -4806,7 +4806,7 @@ TEST_F(SCSCFTest, MmtelCdiv)
   EXPECT_EQ("sip:andunnuvvawun@10.114.61.214:5061;transport=tcp;ob", r1.uri());
   EXPECT_EQ("", get_headers(out, "Route"));
   EXPECT_THAT(get_headers(out, "History-Info"),
-              testing::MatchesRegex("History-Info: <sip:6505551234@homedomain;text=Temporarily%20Unavailable;cause=480;Reason=SIP>;index=1\r\nHistory-Info: <sip:6505555678@homedomain>;index=1.1"));
+              testing::MatchesRegex("History-Info: <sip:6505551234@homedomain;Reason=SIP%3[bB]cause%3[dD]480%3[bB]text%3[dD]%22Temporarily%20Unavailable%22>;index=1\r\nHistory-Info: <sip:6505555678@homedomain>;index=1.1"));
 
   free_txdata();
 }
@@ -4987,7 +4987,7 @@ TEST_F(SCSCFTest, MmtelDoubleCdiv)
   EXPECT_THAT(get_headers(out, "P-Served-User"),
               testing::MatchesRegex("P-Served-User: <sip:6505555678@homedomain>;sescase=orig-cdiv"));
   EXPECT_THAT(get_headers(out, "History-Info"),
-              testing::MatchesRegex("History-Info: <sip:6505551234@homedomain;text=Temporarily%20Unavailable;cause=480;Reason=SIP>;index=1\r\nHistory-Info: <sip:6505555678@homedomain;text=Temporarily%20Unavailable;cause=480;Reason=SIP>;index=1.1\r\nHistory-Info: <sip:6505559012@homedomain>;index=1.1.1"));
+              testing::MatchesRegex("History-Info: <sip:6505551234@homedomain;Reason=SIP%3[bB]cause%3[dD]480%3[bB]text%3[dD]%22Temporarily%20Unavailable%22>;index=1\r\nHistory-Info: <sip:6505555678@homedomain;Reason=SIP%3[bB]cause%3[dD]480%3[bB]text%3[dD]%22Temporarily%20Unavailable%22>;index=1.1\r\nHistory-Info: <sip:6505559012@homedomain>;index=1.1.1"));
 
   // ---------- AS2 turns it around (acting as proxy)
   hdr = (pjsip_hdr*)pjsip_msg_find_hdr_by_name(out, &STR_ROUTE, NULL);


### PR DESCRIPTION
This pull request fixes #873 by correcting the Reason field in the History-Info header. The old behavior was to include each part of the Reason field as a separate parameter in the URI. The fixed behavior is to URL escape the values into a single parameter as per RFC 7044.

I've checked the RFC and confirmed that I agree with the interpretation in the issue. I've run the live tests against my code with no errors.