### PR TITLE
[Reviewer: Rob] Copy URI setting as well

### DIFF
--- a/sprout/regstore.cpp
+++ b/sprout/regstore.cpp
@@ -499,6 +499,7 @@ void RegStore::AoR::common_constructor(const AoR& other)
 
   _notify_cseq = other._notify_cseq;
   _cas = other._cas;
+  _uri = other._uri;
 }
 
 

--- a/sprout/ut/regstore_test.cpp
+++ b/sprout/ut/regstore_test.cpp
@@ -375,6 +375,9 @@ TYPED_TEST(BasicRegStoreTest, CopyTests)
   RegStore::AoR* copy = new RegStore::AoR(*aor_data1);
   EXPECT_EQ(1u, copy->bindings().size());
   EXPECT_EQ(1u, copy->subscriptions().size());
+  EXPECT_EQ(1, copy->_notify_cseq);
+  EXPECT_EQ(0, copy->_cas);
+  EXPECT_EQ("5102175698@cw-ngv.com", copy->_uri);
   delete copy; copy = NULL;
 
   // Test AoR assignment.
@@ -382,6 +385,9 @@ TYPED_TEST(BasicRegStoreTest, CopyTests)
   *copy = *aor_data1;
   EXPECT_EQ(1u, copy->bindings().size());
   EXPECT_EQ(1u, copy->subscriptions().size());
+  EXPECT_EQ(1, copy->_notify_cseq);
+  EXPECT_EQ(0, copy->_cas);
+  EXPECT_EQ("5102175698@cw-ngv.com", copy->_uri);
   delete copy; copy = NULL;
   delete aor_data1; aor_data1 = NULL;
 }


### PR DESCRIPTION
Fix to copy the _uri as well when copying an AoR

Tested in UTs