### PR TITLE
Pass memento notify URL to memento

### DIFF
--- a/include/cfgoptions.h
+++ b/include/cfgoptions.h
@@ -141,6 +141,7 @@ struct options
   std::string                          pbx_service_route;
   NonRegisterAuthentication            non_register_auth_mode;
   bool                                 force_third_party_register_body;
+  std::string                          memento_notify_url;
 };
 
 // Objects that must be shared with dynamically linked sproutlets must be

--- a/sprout-base.root/etc/init.d/sprout
+++ b/sprout-base.root/etc/init.d/sprout
@@ -234,6 +234,11 @@ get_daemon_args()
           DAEMON_ARGS="$DAEMON_ARGS --max-call-list-length=$max_call_list_length"
         fi
 
+        if [ -n "$memento_notify_url" ]
+        then
+          DAEMON_ARGS="$DAEMON_ARGS --memento-notify-url=$memento_notify_ur"
+        fi
+
         if [ -n "$call_list_ttl" ]
         then
           DAEMON_ARGS="$DAEMON_ARGS --call-list-ttl=$call_list_ttl"

--- a/sprout/main.cpp
+++ b/sprout/main.cpp
@@ -140,6 +140,7 @@ enum OptionTypes
   OPT_PBX_SERVICE_ROUTE,
   OPT_NON_REGISTER_AUTHENTICATION,
   OPT_FORCE_THIRD_PARTY_REGISTER_BODY,
+  OPT_MEMENTO_NOTIFY_URL,
 };
 
 
@@ -190,6 +191,7 @@ const static struct pj_getopt_option long_opt[] =
   { "max-call-list-length",         required_argument, 0, OPT_MAX_CALL_LIST_LENGTH},
   { "memento-threads",              required_argument, 0, OPT_MEMENTO_THREADS},
   { "call-list-ttl",                required_argument, 0, OPT_CALL_LIST_TTL},
+  { "memento-notify-url",           required_argument, 0, OPT_MEMENTO_NOTIFY_URL},
   { "log-level",                    required_argument, 0, 'L'},
   { "daemon",                       no_argument,       0, 'd'},
   { "interactive",                  no_argument,       0, 't'},
@@ -339,6 +341,8 @@ static void usage(void)
        "                            then there is no limit (default: 0)\n"
        "     --memento-threads N    Number of Memento threads (default: 25)\n"
        "     --call-list-ttl N      Time to store call lists entries (default: 604800)\n"
+       "     --memento-notify-url <url>\n"
+       "                            URL Memento should notify when call lists change.\n"
        "     --alarms-enabled       Whether SNMP alarms are enabled (default: false)\n"
        "     --memcached-write-format\n"
        "                            The data format to use when writing registration and subscription data\n"
@@ -1028,6 +1032,13 @@ static pj_status_t init_options(int argc, char* argv[], struct options* options)
       }
       break;
 
+    case OPT_MEMENTO_NOTIFY_URL:
+      {
+        options->memento_notify_url = std::string(pj_optarg);
+        TRC_INFO("Memento notify URL set to: '%s'",
+                 options->memento_notify_url.c_str());
+      }
+      break;
 
     case 'h':
       usage();

--- a/sprout/memento_as.mk
+++ b/sprout/memento_as.mk
@@ -14,6 +14,7 @@ TARGET_SOURCES := sproutletappserver.cpp \
                   call_list_store.cpp \
                   mementosaslogger.cpp \
                   call_list_store_processor.cpp \
+                  httpnotifier.cpp \
                   mementoappserver.cpp
 
 CPPFLAGS += -Wno-write-strings \

--- a/sprout/mementoasplugin.cpp
+++ b/sprout/mementoasplugin.cpp
@@ -117,7 +117,9 @@ bool MementoPlugin::load(struct options& opt, std::list<Sproutlet*>& sproutlets)
                                     opt.max_tokens,
                                     opt.init_token_rate,
                                     opt.min_token_rate,
-                                    exception_handler);
+                                    exception_handler,
+                                    http_resolver,
+                                    opt.memento_notify_url);
 
     _memento_sproutlet = new SproutletAppServerShim(_memento, incoming_sip_transactions_tbl, outgoing_sip_transactions_tbl);
     sproutlets.push_back(_memento_sproutlet);


### PR DESCRIPTION
Implements configuration of https://github.com/Metaswitch/memento/pull/105

The URL to notify is configured in the `memento_notify_url` setting in shared config.