### PR TITLE
[Reviewer: Alex] Just talk to the memcached proxy on localhost, and let that handle GR

### DIFF
--- a/include/bono.h
+++ b/include/bono.h
@@ -355,9 +355,7 @@ private:
   static const int LIVENESS_TIMER = 1;
 };
 
-pj_status_t init_stateful_proxy(RegStore* registrar_store,
-                                RegStore* remote_reg_store,
-                                IfcHandler* ifc_handler,
+pj_status_t init_stateful_proxy(IfcHandler* ifc_handler,
                                 pj_bool_t enable_access_proxy,
                                 const std::string& upstream_proxy,
                                 int upstream_proxy_port,

--- a/include/cfgoptions.h
+++ b/include/cfgoptions.h
@@ -94,8 +94,6 @@ struct options
   std::string                          hss_server;
   std::string                          xdm_server;
   std::string                          chronos_service;
-  std::string                          store_servers;
-  std::string                          remote_store_servers;
   std::string                          ralf_server;
   int                                  ralf_threads;
   std::vector<std::string>             dns_servers;

--- a/include/handlers.h
+++ b/include/handlers.h
@@ -68,11 +68,10 @@ class RegSubTimeoutTask : public HttpStackUtils::Task
 public:
   struct Config
   {
-    Config(RegStore* store, RegStore* remote_store, HSSConnection* hss) :
-      _store(store), _remote_store(remote_store), _hss(hss)
+    Config(RegStore* store, HSSConnection* hss) :
+      _store(store), _hss(hss)
       {}
     RegStore* _store;
-    RegStore* _remote_store;
     HSSConnection* _hss;
   };
 
@@ -89,8 +88,6 @@ protected:
   HTTPCode parse_response(std::string body);
   RegStore::AoR* set_aor_data(RegStore* current_store,
                               std::string aor_id,
-                              RegStore::AoR* previous_aor_data,
-                              RegStore* remote_store,
                               bool is_primary,  //do we update chronos and send NOTIFYs
                               bool& all_bindings_expired);
 
@@ -104,11 +101,10 @@ class DeregistrationTask : public HttpStackUtils::Task
 public:
   struct Config
   {
-    Config(RegStore* store, RegStore* remote_store, HSSConnection* hss, SIPResolver* sipresolver) :
-      _store(store), _remote_store(remote_store), _hss(hss), _sipresolver(sipresolver)
+    Config(RegStore* store, HSSConnection* hss, SIPResolver* sipresolver) :
+      _store(store), _hss(hss), _sipresolver(sipresolver)
       {}
     RegStore* _store;
-    RegStore* _remote_store;
     HSSConnection* _hss;
     SIPResolver* _sipresolver;
   };
@@ -126,8 +122,6 @@ public:
   RegStore::AoR* set_aor_data(RegStore* current_store,
                               std::string aor_id,
                               std::string private_id,
-                              RegStore::AoR* previous_aor_data,
-                              RegStore* remote_store,
                               bool is_primary);
 
 protected:

--- a/include/registrar.h
+++ b/include/registrar.h
@@ -55,7 +55,6 @@ void third_party_register_failed(const std::string& public_id,
                                  SAS::TrailId trail);
 
 extern pj_status_t init_registrar(RegStore* registrar_store,
-                                  RegStore* remote_reg_store,
                                   HSSConnection* hss_connection,
                                   AnalyticsLogger* analytics_logger,
                                   ACRFactory* rfacr_factory,

--- a/include/scscfsproutlet.h
+++ b/include/scscfsproutlet.h
@@ -81,7 +81,6 @@ public:
                  const std::string& bgcf_uri,
                  int port,
                  RegStore* store,
-                 RegStore* remote_store,
                  HSSConnection* hss,
                  EnumService* enum_service,
                  ACRFactory* acr_factory,
@@ -123,14 +122,14 @@ private:
   /// Returns the configured BGCF URI for this system.
   const pjsip_uri* bgcf_uri() const;
 
-  /// Gets all bindings for the specified Address of Record from the local or
-  /// remote registration stores.
+  /// Gets all bindings for the specified Address of Record from the 
+  /// registration store.
   void get_bindings(const std::string& aor,
                     RegStore::AoR** aor_data,
                     SAS::TrailId trail);
 
   /// Removes the specified binding for the specified Address of Record from
-  /// the local or remote registration stores.
+  /// the registration store.
   void remove_binding(const std::string& aor,
                       const std::string& binding_id,
                       SAS::TrailId trail);
@@ -174,7 +173,6 @@ private:
   pjsip_uri* _bgcf_uri;
 
   RegStore* _store;
-  RegStore* _remote_store;
 
   HSSConnection* _hss;
 

--- a/include/subscription.h
+++ b/include/subscription.h
@@ -50,7 +50,6 @@ extern "C" {
 extern pjsip_module mod_subscription;
 
 extern pj_status_t init_subscription(RegStore* registrar_store,
-                                     RegStore* remote_reg_store,
                                      HSSConnection* hss_connection,
                                      ACRFactory* rfacr_factory,
                                      AnalyticsLogger* analytics_logger,

--- a/sprout-base.root/etc/init.d/sprout
+++ b/sprout-base.root/etc/init.d/sprout
@@ -104,23 +104,6 @@ get_settings()
         chronos_hostname=127.0.0.1:7253
         . /etc/clearwater/config
 
-        # Set up a default cluster_settings file if it does not exist.  The local
-        # IP address needs to be surrounded by square brackets if it is IPv6.
-        if [ ! -f /etc/clearwater/cluster_settings ]
-        then
-          cluster_ip=$(python /usr/share/clearwater/bin/bracket_ipv6_address.py $local_ip)
-          echo "servers=$cluster_ip:11211" > /etc/clearwater/cluster_settings
-        fi
-
-        remote_memstore_arg="--remote-memstore=/etc/clearwater/remote_cluster_settings"
-
-        # Create /etc/clearwater/remote_cluster_settings if it doesn't exist
-        # This means 'service sprout reload' will pick up changes
-        if [ ! -f /etc/clearwater/remote_cluster_settings ]
-        then
-          echo "servers=" > /etc/clearwater/remote_cluster_settings
-        fi
-
         # Set up defaults for user settings then pull in any overrides.
         # Sprout uses blocking look-up services, so must run multi-threaded.
         num_pjsip_threads=1
@@ -179,8 +162,6 @@ get_daemon_args()
                      --domain=$home_domain
                      --localhost=$local_ip
                      --realm=$home_domain
-                     --memstore=/etc/clearwater/cluster_settings
-                     $remote_memstore_arg
                      --hss=$hs_hostname
                      --chronos=$chronos_hostname
                      $xdms_hostname_arg

--- a/sprout/bono.cpp
+++ b/sprout/bono.cpp
@@ -133,9 +133,6 @@ extern "C" {
 #include "contact_filtering.h"
 #include "uri_classifier.h"
 
-static RegStore* store;
-static RegStore* remote_store;
-
 static IfcHandler* ifc_handler;
 
 static AnalyticsLogger* analytics_logger;
@@ -3209,9 +3206,7 @@ void UACTransaction::exit_context()
 ///@{
 // MODULE LIFECYCLE
 
-pj_status_t init_stateful_proxy(RegStore* registrar_store,
-                                RegStore* remote_reg_store,
-                                IfcHandler* ifc_handler_in,
+pj_status_t init_stateful_proxy(IfcHandler* ifc_handler_in,
                                 pj_bool_t enable_edge_proxy,
                                 const std::string& upstream_proxy_arg,
                                 int upstream_proxy_port,
@@ -3238,8 +3233,6 @@ pj_status_t init_stateful_proxy(RegStore* registrar_store,
   pj_status_t status;
 
   analytics_logger = analytics;
-  store = registrar_store;
-  remote_store = remote_reg_store;
 
   ifc_handler = ifc_handler_in;
 

--- a/sprout/main.cpp
+++ b/sprout/main.cpp
@@ -1496,8 +1496,7 @@ int main(int argc, char* argv[])
     TRC_WARNING("XDM server configured on P-CSCF, ignoring");
   }
 
-  if ((opt.store_servers != "") &&
-      (opt.auth_enabled) &&
+  if ((opt.auth_enabled) &&
       (opt.worker_threads == 1))
   {
     TRC_WARNING("Use multiple threads for good performance when using memstore and/or authentication");
@@ -1813,8 +1812,6 @@ int main(int argc, char* argv[])
 
     // Launch stateful proxy as P-CSCF.
     status = init_stateful_proxy(NULL,
-                                 NULL,
-                                 NULL,
                                  true,
                                  opt.upstream_proxy,
                                  opt.upstream_proxy_port,
@@ -1863,19 +1860,10 @@ int main(int argc, char* argv[])
                       (ACRFactory*)new RalfACRFactory(ralf_processor, SCSCF) :
                       new ACRFactory();
 
-    if (opt.store_servers != "")
-    {
-      // Use memcached store.
-      TRC_STATUS("Using memcached compatible store");
+    // Use memcached store.
+    TRC_STATUS("Using memcached compatible store");
 
-      local_data_store = (Store*)new MemcachedStore(memcached_comm_monitor);
-    }
-    else
-    {
-      // Use local store.
-      TRC_STATUS("Using local store");
-      local_data_store = (Store*)new LocalStore();
-    }
+    local_data_store = (Store*)new MemcachedStore(memcached_comm_monitor);
 
     if (local_data_store == NULL)
     {

--- a/sprout/scscfplugin.cpp
+++ b/sprout/scscfplugin.cpp
@@ -121,7 +121,6 @@ bool SCSCFPlugin::load(struct options& opt, std::list<Sproutlet*>& sproutlets)
                                           bgcf_uri,
                                           opt.scscf_port,
                                           local_reg_store,
-                                          remote_reg_store,
                                           hss_connection,
                                           enum_service,
                                           scscf_acr_factory,

--- a/sprout/scscfsproutlet.cpp
+++ b/sprout/scscfsproutlet.cpp
@@ -60,7 +60,6 @@ SCSCFSproutlet::SCSCFSproutlet(const std::string& scscf_cluster_uri,
                                const std::string& bgcf_uri,
                                int port,
                                RegStore* store,
-                               RegStore* remote_store,
                                HSSConnection* hss,
                                EnumService* enum_service,
                                ACRFactory* acr_factory,
@@ -73,7 +72,6 @@ SCSCFSproutlet::SCSCFSproutlet(const std::string& scscf_cluster_uri,
   _icscf_uri(NULL),
   _bgcf_uri(NULL),
   _store(store),
-  _remote_store(remote_store),
   _hss(hss),
   _enum_service(enum_service),
   _acr_factory(acr_factory),
@@ -210,8 +208,8 @@ AsChainTable* SCSCFSproutlet::as_chain_table() const
 }
 
 
-/// Gets all bindings for the specified Address of Record from the local or
-/// remote registration stores.
+/// Gets all bindings for the specified Address of Record from the registration
+/// store.
 void SCSCFSproutlet::get_bindings(const std::string& aor,
                                   RegStore::AoR** aor_data,
                                   SAS::TrailId trail)
@@ -220,23 +218,12 @@ void SCSCFSproutlet::get_bindings(const std::string& aor,
   TRC_INFO("Look up targets in registration store: %s", aor.c_str());
   *aor_data = _store->get_aor_data(aor, trail);
 
-  // If we didn't get bindings from the local store and we have a remote
-  // store, try the remote.
-  if ((_remote_store != NULL) &&
-      (_remote_store->has_servers()) &&
-      ((*aor_data == NULL) ||
-       ((*aor_data)->bindings().empty())))
-  {
-    delete *aor_data;
-    *aor_data = _remote_store->get_aor_data(aor, trail);
-  }
-
   // TODO - Log bindings to SAS
 }
 
 
 /// Removes the specified binding for the specified Address of Record from
-/// the local or remote registration stores.
+/// the registration store.
 void SCSCFSproutlet::remove_binding(const std::string& aor,
                                     const std::string& binding_id,
                                     SAS::TrailId trail)

--- a/sprout/subscription.cpp
+++ b/sprout/subscription.cpp
@@ -59,7 +59,6 @@ extern "C" {
 #include "uri_classifier.h"
 
 static RegStore* store;
-static RegStore* remote_store;
 
 // Connection to the HSS service for retrieving associated public URIs.
 static HSSConnection* hss;

--- a/sprout/ut/bono_test.cpp
+++ b/sprout/ut/bono_test.cpp
@@ -338,8 +338,6 @@ public:
     SipTest::SetUpTestCase(false);
 
     _chronos_connection = new FakeChronosConnection();
-    _local_data_store = new LocalStore();
-    _store = new RegStore((Store*)_local_data_store, _chronos_connection);
     _analytics = new AnalyticsLogger(&PrintingTestLogger::DEFAULT);
     _hss_connection = new FakeHSSConnection();
     if (ifcs)
@@ -360,9 +358,7 @@ public:
     _scscf = scscf_enabled;
     _emerg_reg = emerg_reg_enabled;
     _acr_factory = new ACRFactory();
-    pj_status_t ret = init_stateful_proxy(_store,
-                                          NULL,
-                                          _ifc_handler,
+    pj_status_t ret = init_stateful_proxy(_ifc_handler,
                                           !_edge_upstream_proxy.empty(),
                                           _edge_upstream_proxy.c_str(),
                                           stack_data.pcscf_trusted_port,
@@ -398,9 +394,7 @@ public:
     pjsip_tsx_layer_destroy();
     destroy_stateful_proxy();
     delete _acr_factory; _acr_factory = NULL;
-    delete _store; _store = NULL;
     delete _chronos_connection; _chronos_connection = NULL;
-    delete _local_data_store; _local_data_store = NULL;
     delete _analytics; _analytics = NULL;
     delete _ifc_handler; _ifc_handler = NULL;
     delete _hss_connection; _hss_connection = NULL;
@@ -414,7 +408,6 @@ public:
   StatefulProxyTestBase()
   {
     _log_traffic = PrintingTestLogger::DEFAULT.isPrinting(); // true to see all traffic
-    _local_data_store->flush_all();  // start from a clean slate on each test
     if (_hss_connection)
     {
       _hss_connection->flush_all();
@@ -461,9 +454,7 @@ public:
   }
 
 protected:
-  static LocalStore* _local_data_store;
   static FakeChronosConnection* _chronos_connection;
-  static RegStore* _store;
   static AnalyticsLogger* _analytics;
   static FakeHSSConnection* _hss_connection;
   static FakeXDMConnection* _xdm_connection;
@@ -492,9 +483,7 @@ protected:
                      bool pcpi);
 };
 
-LocalStore* StatefulProxyTestBase::_local_data_store;
 FakeChronosConnection* StatefulProxyTestBase::_chronos_connection;
-RegStore* StatefulProxyTestBase::_store;
 AnalyticsLogger* StatefulProxyTestBase::_analytics;
 FakeHSSConnection* StatefulProxyTestBase::_hss_connection;
 FakeXDMConnection* StatefulProxyTestBase::_xdm_connection;

--- a/sprout/ut/registrar_test.cpp
+++ b/sprout/ut/registrar_test.cpp
@@ -67,14 +67,11 @@ public:
 
     _chronos_connection = new FakeChronosConnection();
     _local_data_store = new LocalStore();
-    _remote_data_store = new LocalStore();
     _store = new RegStore((Store*)_local_data_store, _chronos_connection);
-    _remote_store = new RegStore((Store*)_remote_data_store, _chronos_connection);
     _analytics = new AnalyticsLogger(&PrintingTestLogger::DEFAULT);
     _hss_connection = new FakeHSSConnection();
     _acr_factory = new ACRFactory();
     pj_status_t ret = init_registrar(_store,
-                                     _remote_store,
                                      _hss_connection,
                                      _analytics,
                                      _acr_factory,
@@ -97,9 +94,7 @@ public:
     delete _acr_factory; _acr_factory = NULL;
     delete _hss_connection; _hss_connection = NULL;
     delete _analytics;
-    delete _remote_store; _remote_store = NULL;
     delete _store; _store = NULL;
-    delete _remote_data_store; _remote_data_store = NULL;
     delete _local_data_store; _local_data_store = NULL;
     delete _chronos_connection; _chronos_connection = NULL;
     SipTest::TearDownTestCase();
@@ -108,7 +103,6 @@ public:
   RegistrarTest() : SipTest(&mod_registrar)
   {
     _local_data_store->flush_all();  // start from a clean slate on each test
-    _remote_data_store->flush_all();
   }
 
   ~RegistrarTest()
@@ -135,9 +129,7 @@ public:
 
 protected:
   static LocalStore* _local_data_store;
-  static LocalStore* _remote_data_store;
   static RegStore* _store;
-  static RegStore* _remote_store;
   static AnalyticsLogger* _analytics;
   static IfcHandler* _ifc_handler;
   static ACRFactory* _acr_factory;
@@ -146,9 +138,7 @@ protected:
 };
 
 LocalStore* RegistrarTest::_local_data_store;
-LocalStore* RegistrarTest::_remote_data_store;
 RegStore* RegistrarTest::_store;
-RegStore* RegistrarTest::_remote_store;
 AnalyticsLogger* RegistrarTest::_analytics;
 IfcHandler* RegistrarTest::_ifc_handler;
 ACRFactory* RegistrarTest::_acr_factory;
@@ -2243,7 +2233,6 @@ public:
     _hss_connection = new FakeHSSConnection();
     _acr_factory = new ACRFactory();
     pj_status_t ret = init_registrar(_store,
-                                     NULL,
                                      _hss_connection,
                                      _analytics,
                                      _acr_factory,

--- a/sprout/ut/scscf_test.cpp
+++ b/sprout/ut/scscf_test.cpp
@@ -355,7 +355,6 @@ public:
                                           "sip:bgcf@homedomain:5058",
                                           5058,
                                           _store,
-                                          NULL,
                                           _hss_connection,
                                           _enum_service,
                                           _acr_factory,

--- a/sprout/ut/subscription_test.cpp
+++ b/sprout/ut/subscription_test.cpp
@@ -65,13 +65,11 @@ public:
 
     _chronos_connection = new FakeChronosConnection();
     _local_data_store = new LocalStore();
-    _remote_data_store = new LocalStore();
     _store = new RegStore((Store*)_local_data_store, _chronos_connection);
-    _remote_store = new RegStore((Store*)_remote_data_store, _chronos_connection);
     _analytics = new AnalyticsLogger(&PrintingTestLogger::DEFAULT);
     _hss_connection = new FakeHSSConnection();
     _acr_factory = new ACRFactory();
-    pj_status_t ret = init_subscription(_store, _remote_store, _hss_connection, _acr_factory, _analytics, 300);
+    pj_status_t ret = init_subscription(_store, _hss_connection, _acr_factory, _analytics, 300);
     ASSERT_EQ(PJ_SUCCESS, ret);
     stack_data.scscf_uri = pj_str("sip:all.the.sprout.nodes:5058;transport=TCP");
 
@@ -85,9 +83,7 @@ public:
     delete _acr_factory; _acr_factory = NULL;
     delete _hss_connection; _hss_connection = NULL;
     delete _analytics; _analytics = NULL;
-    delete _remote_store; _remote_store = NULL;
     delete _store; _store = NULL;
-    delete _remote_data_store; _remote_data_store = NULL;
     delete _local_data_store; _local_data_store = NULL;
     delete _chronos_connection; _chronos_connection = NULL;
     SipTest::TearDownTestCase();
@@ -96,7 +92,6 @@ public:
   SubscriptionTest() : SipTest(&mod_subscription)
   {
     _local_data_store->flush_all();  // start from a clean slate on each test
-    _remote_data_store->flush_all();
 
     _log_traffic = PrintingTestLogger::DEFAULT.isPrinting();
   }
@@ -107,9 +102,7 @@ public:
 
 protected:
   static LocalStore* _local_data_store;
-  static LocalStore* _remote_data_store;
   static RegStore* _store;
-  static RegStore* _remote_store;
   static AnalyticsLogger* _analytics;
   static ACRFactory* _acr_factory;
   static FakeHSSConnection* _hss_connection;
@@ -120,9 +113,7 @@ protected:
 };
 
 LocalStore* SubscriptionTest::_local_data_store;
-LocalStore* SubscriptionTest::_remote_data_store;
 RegStore* SubscriptionTest::_store;
-RegStore* SubscriptionTest::_remote_store;
 AnalyticsLogger* SubscriptionTest::_analytics;
 ACRFactory* SubscriptionTest::_acr_factory;
 FakeHSSConnection* SubscriptionTest::_hss_connection;
@@ -645,7 +636,7 @@ public:
     _analytics = new AnalyticsLogger(&PrintingTestLogger::DEFAULT);
     _hss_connection = new FakeHSSConnection();
     _acr_factory = new ACRFactory();
-    pj_status_t ret = init_subscription(_store, NULL, _hss_connection, _acr_factory, _analytics, 300);
+    pj_status_t ret = init_subscription(_store, _hss_connection, _acr_factory, _analytics, 300);
     ASSERT_EQ(PJ_SUCCESS, ret);
     stack_data.scscf_uri = pj_str("sip:all.the.sprout.nodes:5058;transport=TCP");
 


### PR DESCRIPTION
This:

* sets up a single Memcached connection to the proxy on localhost
* removes the whole idea of a "remote store" or a "backup store"

I've tested live - I can successfully register a subscriber (using a normal memcached instance on 127.0.0.1 - which should have the same interface as the proxy).
Passes UT and code coverage. (Some of the UTs for remote store code also hit necessary code coverage paths, so I've repurposed them for code coverage.)