### PR TITLE
[Reviewer: Alex] Default the initial token rate to 250 * num cores

### DIFF
--- a/sprout-base.root/etc/init.d/sprout
+++ b/sprout-base.root/etc/init.d/sprout
@@ -102,7 +102,6 @@ get_settings()
         default_session_expires=600
         signaling_dns_server=127.0.0.1
         chronos_hostname=127.0.0.1:7253
-        . /etc/clearwater/config
 
         # Set up a default cluster_settings file if it does not exist.  The local
         # IP address needs to be surrounded by square brackets if it is IPv6.
@@ -133,7 +132,7 @@ get_settings()
         
         log_level=2
         authentication=Y
-        [ -r /etc/clearwater/user_settings ] && . /etc/clearwater/user_settings
+        . /etc/clearwater/config
 
         # Work out which features are enabled.
         MMTEL_SERVICES_ENABLED=Y

--- a/sprout-base.root/etc/init.d/sprout
+++ b/sprout-base.root/etc/init.d/sprout
@@ -126,6 +126,11 @@ get_settings()
         num_pjsip_threads=1
         num_worker_threads=$(($(grep processor /proc/cpuinfo | wc -l) * 50))
         num_http_threads=$(($(grep processor /proc/cpuinfo | wc -l) * 50))
+
+        # Testing has shown that we can handle at least 250 requests per second per core - this is
+        # probably an underestimate, but is a reasonable start.
+        init_token_rate=$(($(grep processor /proc/cpuinfo | wc -l) * 250))
+        
         log_level=2
         authentication=Y
         [ -r /etc/clearwater/user_settings ] && . /etc/clearwater/user_settings


### PR DESCRIPTION
In https://github.com/Metaswitch/cpp-common/pull/397, we discussed that our initial token rate was probably too low.

I've now taken measurements suggesting 250 req/sec/core is sensible (and an underestimate, if anything) - see https://github.com/Metaswitch/sprout/issues/1251#issuecomment-157803199. This sets it to that.