### PR TITLE
[Reviewer: Alex] Fix running without clearwater-cluster-manager

### DIFF
--- a/sprout-base.root/etc/init.d/sprout
+++ b/sprout-base.root/etc/init.d/sprout
@@ -103,23 +103,6 @@ get_settings()
         signaling_dns_server=127.0.0.1
         chronos_hostname=127.0.0.1:7253
 
-        # Set up a default cluster_settings file if it does not exist.  The local
-        # IP address needs to be surrounded by square brackets if it is IPv6.
-        if [ ! -f /etc/clearwater/cluster_settings ]
-        then
-          cluster_ip=$(python /usr/share/clearwater/bin/bracket_ipv6_address.py $local_ip)
-          echo "servers=$cluster_ip:11211" > /etc/clearwater/cluster_settings
-        fi
-
-        remote_memstore_arg="--remote-memstore=/etc/clearwater/remote_cluster_settings"
-
-        # Create /etc/clearwater/remote_cluster_settings if it doesn't exist
-        # This means 'service sprout reload' will pick up changes
-        if [ ! -f /etc/clearwater/remote_cluster_settings ]
-        then
-          echo "servers=" > /etc/clearwater/remote_cluster_settings
-        fi
-
         # Set up defaults for user settings then pull in any overrides.
         # Sprout uses blocking look-up services, so must run multi-threaded.
         num_pjsip_threads=1
@@ -142,6 +125,21 @@ get_settings()
           do
             [ -r $file ] && . $file
           done
+        fi
+
+        # Set up a default cluster_settings file if it does not exist.  The local
+        # IP address needs to be surrounded by square brackets if it is IPv6.
+        if [ ! -f /etc/clearwater/cluster_settings ]
+        then
+          cluster_ip=$(python /usr/share/clearwater/bin/bracket_ipv6_address.py $local_ip)
+          echo "servers=$cluster_ip:11211" > /etc/clearwater/cluster_settings
+        fi
+
+        # Create /etc/clearwater/remote_cluster_settings if it doesn't exist
+        # This means 'service sprout reload' will pick up changes
+        if [ ! -f /etc/clearwater/remote_cluster_settings ]
+        then
+          echo "servers=" > /etc/clearwater/remote_cluster_settings
         fi
 }
 
@@ -184,7 +182,7 @@ get_daemon_args()
                      --localhost=$local_ip
                      --realm=$home_domain
                      --memstore=/etc/clearwater/cluster_settings
-                     $remote_memstore_arg
+                     --remote-memstore=/etc/clearwater/remote_cluster_settings
                      --hss=$hs_hostname
                      --chronos=$chronos_hostname
                      $xdms_hostname_arg


### PR DESCRIPTION
Alex,

Please can you review this fix to https://github.com/Metaswitch/sprout/commit/b3eb91d98e6cb517b83478fcdec1e9eeff0a24ad (which you reviewed yesterday)?

Basically, by moving dotting in `/etc/clearwater/config` down, we had no longer set up `local_ip` before we tried to use it - this meant that our `/etc/clearwater/cluster_settings` file was broken if we were running without `clearwater-cluster-manager` (which would otherwise set up this file).

Not yet live-tested - will do so on Docker once the build completes.

Matt