### PR TITLE
[Reviewer: Andy] Fix authentication crash

### DIFF
--- a/src/authentication.cpp
+++ b/src/authentication.cpp
@@ -710,20 +710,22 @@ pj_bool_t authenticate_rx_request(pjsip_rx_data* rdata)
       {
         auth_stats_table = auth_stats_tables->ims_aka_auth_tbl;
       }
-    }
-    if (auth_stats_table == NULL)
-    {
-      // Authorization header did not specify an algorithm, so check the av for
-      // this information instead.
-      if (av->HasMember("digest"))
+      else
       {
-        auth_stats_table = auth_stats_tables->sip_digest_auth_tbl;
-      }
-      else if (av->HasMember("aka"))
-      {
-        auth_stats_table = auth_stats_tables->ims_aka_auth_tbl;
+        // Authorization header did not specify an algorithm, so check the av for
+        // this information instead.
+        if ((av != NULL) && (av->HasMember("aka")))
+        {
+          auth_stats_table = auth_stats_tables->ims_aka_auth_tbl;
+        }
+        else
+        {
+          // Use the digest table if the AV specified digest, or as a fallback if there was no AV
+          auth_stats_table = auth_stats_tables->sip_digest_auth_tbl;
+        }
       }
     }
+
     if (auth_stats_table != NULL)
     {
       auth_stats_table->increment_attempts();


### PR DESCRIPTION
A Sprout node got a re-REGISTER with the following Authorization header:

`Authorization: Digest username="6510803201@great-lakes2.datcon.co.uk",realm="great-lakes2.datcon.co.uk",nonce="1ecf59a675a7162d",uri="sip:great-lakes2.datcon.co.uk",response="5e279ba845e1a866d8fc87080165091d",cnonce="44448888",opaque="222481f80f449504",qop=auth,nc=00000002`

This crashed Sprout, because:

- there was a response, so we tried to challenge it
- there was an expired nonce, so we got NULL as our AV
- there was no explicit algorithm, so we tried to call `av->HasMember("digest")`

This fixes that up (defaulting to Digest in that case). I confirmed my UT reproduces the crash.