### PR TITLE
[Reviewer: Ellie] Fix subscriptions for expired users

### DIFF
--- a/src/subscriber_data_manager.cpp
+++ b/src/subscriber_data_manager.cpp
@@ -1494,7 +1494,7 @@ void SubscriberDataManager::NotifySender::send_notifys_for_expired_subscriptions
       pj_status_t status = NotifyUtils::create_subscription_notify(
                                           &tdata_notify,
                                           s,
-                                          "aor",
+                                          aor_id,
                                           aor_pair->get_orig(),
                                           binding_notify,
                                           reg_state,
@@ -1624,7 +1624,7 @@ void SubscriberDataManager::NotifySender::send_notifys_for_current_subscriptions
     pj_status_t status = NotifyUtils::create_subscription_notify(
                                           &tdata_notify,
                                           aor_current->second,
-                                          "aor",
+                                          aor_id,
                                           aor_pair->get_orig(),
                                           binding_notify,
                                           NotifyUtils::RegistrationState::ACTIVE,

--- a/src/subscriber_data_manager.cpp
+++ b/src/subscriber_data_manager.cpp
@@ -1420,6 +1420,28 @@ void SubscriberDataManager::NotifySender::send_notifys_for_expired_subscriptions
                                int now,
                                SAS::TrailId trail)
 {
+  // Work out which bindings have expired - we no longer have a valid connection to these endpoints,
+  // so shouldn't send a NOTIFY to them (even to say that their subscription is terminated).
+  //
+  // Note that we can't just check whether a binding exists before sending a NOTIFY - a SUBSCRIBE
+  // may have come from a P-CSCF or AS, which wouldn't match a binding.
+  std::vector<std::string> expired_bindings;
+
+  for (SubscriberDataManager::AoR::Bindings::const_iterator aor_orig =
+         aor_pair->get_orig()->bindings().begin();
+       aor_orig != aor_pair->get_orig()->bindings().end();
+       ++aor_orig)
+  {
+    SubscriberDataManager::AoR::Binding* b = aor_orig->second;
+    std::string b_id = aor_orig->first;
+
+    // Compare the original and current lists to see whether this binding has expired.
+    if (aor_pair->get_current()->bindings().find(b_id) == aor_pair->get_current()->bindings().end())
+    {
+      expired_bindings.push_back(b->_uri);
+    }
+  }
+
   // Iterate over the subscriptions in the original AoR, and send NOTIFYs for
   // any subscriptions that aren't in the current AoR
   for (SubscriberDataManager::AoR::Subscriptions::const_iterator aor_orig_s =
@@ -1429,6 +1451,12 @@ void SubscriberDataManager::NotifySender::send_notifys_for_expired_subscriptions
   {
     SubscriberDataManager::AoR::Subscription* s = aor_orig_s->second;
     std::string s_id = aor_orig_s->first;
+
+    if (std::find(expired_bindings.begin(), expired_bindings.end(), s->_req_uri) != expired_bindings.end())
+    {
+      // This NOTIFY would go to a binding which no longer exists - skip it.
+      continue;
+    }
 
     // Is this subscription present in the new AoR?
     SubscriberDataManager::AoR::Subscriptions::const_iterator aor_current =

--- a/src/ut/registrar_test.cpp
+++ b/src/ut/registrar_test.cpp
@@ -2202,6 +2202,66 @@ TEST_F(RegistrarTest, RegistrationWithSubscription)
   free_txdata();
 }
 
+
+// Make registers with a subscription and check the correct NOTIFYs
+// are sent. Specifically, check that a NOTIFY is not sent to a UE to tell it that it no longer
+// exists.
+TEST_F(RegistrarTest, NoNotifyToUnregisteredUser)
+{
+  std::string aor = "sip:6505550231@homedomain";
+  std::string aor_brackets = "<" + aor + ">";
+  // We have a private ID in this test, so set up the expect response
+  // to the query.
+  _hss_connection->set_impu_result(aor, "reg", HSSConnection::STATE_REGISTERED, "", "?private_id=Alice");
+
+  // Register a binding
+  Message msg;
+  msg._contact_params = ";+sip.ice;reg-id=1";
+  msg._expires = "Expires: 200";
+  msg._auth = "Authorization: Digest username=\"Alice\", realm=\"atlanta.com\", nonce=\"84a4cc6f3082121f32b42a2187831a9e\", response=\"7587245234b3434cc3412213e5f113a5432\"";
+  inject_msg(msg.get());
+  ASSERT_EQ(1, txdata_count());
+  pjsip_msg* out = current_txdata()->msg;
+  EXPECT_EQ(200, out->line.status.code);
+  EXPECT_EQ("OK", str_pj(out->line.status.reason));
+  free_txdata();
+
+  // Now add a subscription to the store
+  SubscriberDataManager::AoRPair* aor_pair = _sdm->get_aor_data(aor, 0);
+  SubscriberDataManager::AoR::Subscription* s1 = aor_pair->get_current()->get_subscription("1234");
+  s1->_req_uri = msg._contact;
+  s1->_from_uri = aor_brackets;
+  s1->_from_tag = std::string("4321");
+  s1->_to_uri = aor_brackets;
+  s1->_to_tag = std::string("1234");
+  s1->_cid = std::string("xyzabc@192.91.191.29");
+  s1->_route_uris.push_back(std::string("sip:abcdefgh@bono1.homedomain;lr"));
+  int now = time(NULL);
+  s1->_expires = now + 300;
+
+  pj_status_t rc = _sdm->set_aor_data(aor, aor_pair, 0);
+  EXPECT_TRUE(rc);
+  delete aor_pair; aor_pair = NULL;
+
+  ASSERT_EQ(1, txdata_count());
+  out = current_txdata()->msg;
+  EXPECT_EQ("NOTIFY", str_pj(out->line.status.reason));
+
+  check_notify(out, aor, "active", std::make_pair("active", "registered"));
+  inject_msg(respond_to_current_txdata(200));
+  free_txdata();
+
+  // Delete the registration. We shouldn't get a NOTIFY - it's coming over the unregistered binding.
+  msg._expires = "Expires: 0";
+  msg._cseq = "16570";
+  inject_msg(msg.get());
+  ASSERT_EQ(1, txdata_count());
+  out = current_txdata()->msg;
+  EXPECT_EQ(200, out->line.status.code);
+  EXPECT_EQ("OK", str_pj(out->line.status.reason));
+  free_txdata();
+}
+
 TEST_F(RegistrarTest, MultipleRegistrationsWithSubscription)
 {
   std::string aor = "sip:6505550231@homedomain";


### PR DESCRIPTION
This fixes the two issues reported in #1274:

* Use the actual AoR instead of the literal string 'aor'
* When binding A expires, don't send a NOTIFY to binding A announcing the subscription is terminated - that's pointless

I think the UTs cover all the right behaviour here - I don't think there's much value in testing live.
