### PR TITLE
Reviewer Matt - Don't clean FV tests when doing top-level clean

### DIFF
--- a/mk/sprout.mk
+++ b/mk/sprout.mk
@@ -9,7 +9,6 @@ ifndef LIBMEM_DIR
 endif
 
 SPROUT_DIR := ${ROOT}/src
-SPROUT_TEST_DIR := ${ROOT}/tests
 
 sprout: pjsip libmemcached
 	${MAKE} -C ${SPROUT_DIR}
@@ -22,7 +21,6 @@ sprout_full_test:
 
 sprout_clean:
 	${MAKE} -C ${SPROUT_DIR} clean
-	-${MAKE} -C ${SPROUT_TEST_DIR} clean
 
 sprout_distclean: sprout_clean
 


### PR DESCRIPTION
This is a holding pattern fix (while I determine what we do with the code in `tests`).  Prevents errors when running `make clean` at the top level of Sprout's codebase.