### PR TITLE
Respect standard build environment variables

### DIFF
--- a/include/analyticslogger.h
+++ b/include/analyticslogger.h
@@ -79,7 +79,6 @@ private:
   static const int BUFFER_SIZE = 1000;
 
   Logger* _logger;
-  Logger* _default_logger;
 };
 
 #endif

--- a/include/connection_pool.h
+++ b/include/connection_pool.h
@@ -96,9 +96,6 @@ private:
   pjsip_endpoint* _endpt;
   pjsip_tpfactory* _tpfactory;
 
-  /// The address family to request from the resolver.
-  int _addr_family;
-
   pj_thread_t* _recycler;
   volatile bool _terminated;
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -262,12 +262,12 @@ ${BUILD_DIR}/bin/sprout_test : ${sprout_test_OBJECT_DIR}/md5.o \
 # Build rules for SIPp cryptographic modules
 SIPP_DIR := ../modules/sipp
 $(sprout_test_OBJECT_DIR)/md5.o : $(SIPP_DIR)/md5.c
-	g++ $(sprout_test_CPPFLAGS) -I$(SIPP_DIR) -c $(SIPP_DIR)/md5.c -o $@
+	$(CC) $(CPPFLAGS) $(sprout_test_CPPFLAGS) -I$(SIPP_DIR) -c $(SIPP_DIR)/md5.c -o $@
 CLEANS += ${sprout_test_OBJECT_DIR}/md5.o
 
 # Build rule for our interposer.
 ${sprout_test_OBJECT_DIR}/test_interposer.so : ../modules/cpp-common/test_utils/test_interposer.cpp ../modules/cpp-common/test_utils/test_interposer.hpp
-	g++ $(sprout_test_CPPFLAGS) -shared -fPIC -ldl $< -o $@
+	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(sprout_test_CPPFLAGS) -shared -fPIC -ldl $< -o $@
 CLEANS += ${sprout_test_OBJECT_DIR}/test_interposer.so
 
 # Alarm definition generation rules

--- a/src/connection_pool.cpp
+++ b/src/connection_pool.cpp
@@ -423,10 +423,7 @@ void ConnectionPool::recycle_connections()
 
   while (!_terminated)
   {
-#ifdef UNIT_TEST
-    // A smaller pause here is much faster
-    sleep(0.1);
-#else
+#ifndef UNIT_TEST
     sleep(1);
 #endif
 


### PR DESCRIPTION
So that eg we can build under clang.

Also make fixes so that a clang build actually succeeds:
- unused private variables
- sleep(0.1) is truncated to sleep(0), which is pointless anyway