### PR TITLE
[Reviewer AMC] If a route header is present, only route to a sproutlet if this is NOT a SUBSCRIBE

### DIFF
--- a/src/sproutletproxy.cpp
+++ b/src/sproutletproxy.cpp
@@ -123,7 +123,9 @@ Sproutlet* SproutletProxy::target_sproutlet(pjsip_msg* req,
   }
   else
   {
-    if (PJSIP_URI_SCHEME_IS_SIP(route->name_addr.uri))
+    // TODO: Again, needs to change once the subscription manager is a sproutlet.
+    if ((pjsip_method_cmp(&req->line.req.method, pjsip_get_subscribe_method()) != 0) &&
+        PJSIP_URI_SCHEME_IS_SIP(route->name_addr.uri))
     {
       uri = (pjsip_sip_uri*)route->name_addr.uri;
     }


### PR DESCRIPTION
This fixes a SUBSCRIBE routing issue whereby, if I-CSCF identifies the target S-CSCF for a SUBSCRIBE as the local Sprout, it routes the request to the S-CSCF Sproutlet, thereby bypassing the subscription module and causing the SUBSCRIBE to be routed (erroneously) to the subscribee instead of being processed on the local Sprout

This fix stops the I-CSCF from attempting to use sproutlets, instead sending it to the local S-CSCF the long way round (so that it is sent to the subscription module correctly by PJSIP).

Tested live using a P-CSCF configuration that sent re-event SUBSCRIBEs to the I-CSCF and sending in reg-event subscribes for local subscribers.