### PR TITLE
[No reviewer] Fix a compiler warning about incrementing a bool

### DIFF
--- a/src/ut/sproutletproxy_test.cpp
+++ b/src/ut/sproutletproxy_test.cpp
@@ -573,7 +573,7 @@ class FakeSproutletTsxDelayAfterFwd : public SproutletTsx
   }
 
   TimerID _tid;
-  bool _response;
+  int _response;
   pjsip_msg* _second_request;
 };
 


### PR DESCRIPTION
Discussed with @mbt-msw , who wrote this test - he agrees that the intention is to only set a timer on the first response received, so I've changed the type of `_response` to int.

UTs pass, and this is test code only.