### PR TITLE
Revert "[Reviewer AMC] If a route header is present, only route to a sproutlet if this is NOT a SUBSCRIBE"

### DIFF
--- a/src/sproutletproxy.cpp
+++ b/src/sproutletproxy.cpp
@@ -123,9 +123,7 @@ Sproutlet* SproutletProxy::target_sproutlet(pjsip_msg* req,
   }
   else
   {
-    // TODO: Again, needs to change once the subscription manager is a sproutlet.
-    if ((pjsip_method_cmp(&req->line.req.method, pjsip_get_subscribe_method()) != 0) &&
-        PJSIP_URI_SCHEME_IS_SIP(route->name_addr.uri))
+    if (PJSIP_URI_SCHEME_IS_SIP(route->name_addr.uri))
     {
       uri = (pjsip_sip_uri*)route->name_addr.uri;
     }


### PR DESCRIPTION
Reverts Metaswitch/sprout#1286