### PR TITLE
[Reviewer: Chris] Stats api update

### DIFF
--- a/include/handlers.h
+++ b/include/handlers.h
@@ -63,7 +63,7 @@ public:
   }
 };
 
-class RegSubTimeoutTask : public HttpStackUtils::Task
+class AoRTimeoutTask : public HttpStackUtils::Task
 {
 public:
   struct Config
@@ -80,9 +80,9 @@ public:
     HSSConnection* _hss;
   };
 
-  RegSubTimeoutTask(HttpStack::Request& req,
-                          const Config* cfg,
-                          SAS::TrailId trail) :
+  AoRTimeoutTask(HttpStack::Request& req,
+                       const Config* cfg,
+                       SAS::TrailId trail) :
     HttpStackUtils::Task(req, trail), _cfg(cfg)
   {};
 

--- a/include/subscriber_data_manager.h
+++ b/include/subscriber_data_manager.h
@@ -202,10 +202,10 @@ public:
     inline const Subscriptions& subscriptions() const { return _subscriptions; }
 
     // Return the number of bindings in the AoR.
-    uint32_t get_bindings_count() { return _bindings.size(); }
+    inline uint32_t get_bindings_count() const { return _bindings.size(); }
 
     // Return the number of subscriptions in the AoR.
-    uint32_t get_subscriptions_count() { return _subscriptions.size(); }
+    inline uint32_t get_subscriptions_count() const { return _subscriptions.size(); }
 
     // Return the expiry time of the binding or subscription due to expire next.
     int get_next_expires();

--- a/include/subscriber_data_manager.h
+++ b/include/subscriber_data_manager.h
@@ -201,6 +201,15 @@ public:
     /// Retrieve all the subscriptions.
     inline const Subscriptions& subscriptions() const { return _subscriptions; }
 
+    // Return the number of bindings in the AoR.
+    uint32_t get_bindings_count() { return _bindings.size(); }
+
+    // Return the number of subscriptions in the AoR.
+    uint32_t get_subscriptions_count() { return _subscriptions.size(); }
+
+    // Return the expiry time of the binding or subscription due to expire next.
+    int get_next_expires();
+
     /// CSeq value for event notifications for this AoR.  This is initialised
     /// to one when the AoR record is first set up and incremented every time
     /// the record is updated while there are active subscriptions.  (It is
@@ -209,6 +218,9 @@ public:
     /// CSeq=1, and once a subscription dialog is established it should
     /// receive every NOTIFY for the AoR.)
     int _notify_cseq;
+
+    // Chronos Timer ID
+    std::string _timer_id;
 
   private:
     /// Map holding the bindings for a particular AoR indexed by binding ID.
@@ -383,44 +395,22 @@ public:
   private:
     ChronosConnection* _chronos_conn;
 
+    /// Build the tag info map from an AoR
+    virtual void build_tag_info(AoR* aor,
+                                std::map<std::string, uint32_t>& tag_map);
+
     /// Create the Chronos Timer request
     ///
     /// @param aor_id       The AoR ID
-    /// @param object_id    What the JSON ID should be
     /// @param timer_id     The Timer ID
     /// @param expiry       Timer length
-    /// @param id_type      Binding/subscription ID
     /// @param tags         Any tags to add to the Chronos timer
     /// @param trail        SAS trail
     virtual void set_timer(const std::string& aor_id,
-                           std::string object_id,
                            std::string& timer_id,
                            int expiry,
-                           std::string id_type,
-                           std::vector<std::string> tags,
+                           std::map<std::string, uint32_t> tags,
                            SAS::TrailId trail);
-
-    /// Create and send any Chronos requests for bindings
-    ///
-    /// @param aor_id       The AoR ID
-    /// @param aor_pair     The AoR pair to send requests for
-    /// @param now          The current time
-    /// @param trail        SAS trail
-    virtual void send_binding_timers(const std::string& aor_id,
-                                     AoRPair* aor_pair,
-                                     int now,
-                                     SAS::TrailId trail);
-
-    /// Create and send any Chronos requests for subscriptions
-    ///
-    /// @param aor_id       The AoR ID
-    /// @param aor_pair     The AoR pair to send requests for
-    /// @param now          The current time
-    /// @param trail        SAS trail
-    virtual void send_subscription_timers(const std::string& aor_id,
-                                          AoRPair* aor_pair,
-                                          int now,
-                                          SAS::TrailId trail);
   };
 
   /// @class SubscriberDataManager::NotifySender

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -150,7 +150,7 @@ static void report_sip_all_register_marker(SAS::TrailId trail, std::string uri_s
 }
 
 //LCOV_EXCL_START - don't want to actually run the handlers in the UT
-void RegSubTimeoutTask::run()
+void AoRTimeoutTask::run()
 {
   if (_req.method() != htp_method_POST)
   {
@@ -251,7 +251,7 @@ void DeregistrationTask::run()
   delete this;
 }
 
-void RegSubTimeoutTask::handle_response()
+void AoRTimeoutTask::handle_response()
 {
   bool all_bindings_expired = false;
   SubscriberDataManager::AoRPair* aor_pair = set_aor_data(_cfg->_sdm,
@@ -296,7 +296,7 @@ void RegSubTimeoutTask::handle_response()
   report_sip_all_register_marker(trail(), _aor_id);
 }
 
-SubscriberDataManager::AoRPair* RegSubTimeoutTask::set_aor_data(
+SubscriberDataManager::AoRPair* AoRTimeoutTask::set_aor_data(
                           SubscriberDataManager* current_sdm,
                           std::string aor_id,
                           SubscriberDataManager::AoRPair* previous_aor_pair,
@@ -343,7 +343,7 @@ SubscriberDataManager::AoRPair* RegSubTimeoutTask::set_aor_data(
 }
 
 // Retrieve the aor and binding ID from the opaque data
-HTTPCode RegSubTimeoutTask::parse_response(std::string body)
+HTTPCode AoRTimeoutTask::parse_response(std::string body)
 {
   rapidjson::Document doc;
   std::string json_str = body;
@@ -366,33 +366,7 @@ HTTPCode RegSubTimeoutTask::parse_response(std::string body)
     TRC_DEBUG("Badly formed opaque data (missing aor_id)");
     return HTTP_BAD_REQUEST;
   }
-
-  std::string _binding_id = (((doc.HasMember("binding_id"))   &&
-                            ((doc["binding_id"]).IsString())) ?
-                            (doc["binding_id"].GetString()) : "");
-
-  std::string _subscription_id = (((doc.HasMember("subscription_id")) &&
-                                 ((doc["subscription_id"]).IsString())) ?
-                                 (doc["subscription_id"].GetString()) : "");
-
-  if (_binding_id == "" && _subscription_id == "")
-  {
-    TRC_DEBUG("No binding id or subscription id found");
-  }
-  else if (_binding_id != "" && _subscription_id != "")
-  {
-    TRC_DEBUG("Found both binding id: %s and subscription id: %s", _binding_id.c_str(),
-                                                                   _subscription_id.c_str());
-  }
-  else if (_binding_id != "")
-  {
-    TRC_DEBUG("Handling timer pop for binding id: %s", _binding_id.c_str());
-  }
-  else if (_subscription_id != "")
-  {
-    TRC_DEBUG("Handling timer pop for subscription id: %s", _subscription_id.c_str());
-  }
-
+  TRC_DEBUG("Handling timer pop for AoR id: %s", _aor_id.c_str());
   return HTTP_OK;
 }
 

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -342,7 +342,7 @@ SubscriberDataManager::AoRPair* AoRTimeoutTask::set_aor_data(
   return aor_pair;
 }
 
-// Retrieve the aor and binding ID from the opaque data
+// Retrieve the aor ID from the opaque data
 HTTPCode AoRTimeoutTask::parse_response(std::string body)
 {
   rapidjson::Document doc;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2185,13 +2185,13 @@ int main(int argc, char* argv[])
     return 1;
   }
 
-  RegSubTimeoutTask::Config reg_sub_timeout_config(local_sdm, remote_sdm, hss_connection);
+  AoRTimeoutTask::Config aor_timeout_config(local_sdm, remote_sdm, hss_connection);
   AuthTimeoutTask::Config auth_timeout_config(av_store, hss_connection);
   DeregistrationTask::Config deregistration_config(local_sdm, remote_sdm, hss_connection, sip_resolver);
 
-  // The RegSubTimeoutTask and AuthTimeoutTask both handle
+  // The AoRTimeoutTask and AuthTimeoutTask both handle
   // chronos requests, so use the ChronosHandler.
-  ChronosHandler<RegSubTimeoutTask, RegSubTimeoutTask::Config> reg_timeout_handler(&reg_sub_timeout_config);
+  ChronosHandler<AoRTimeoutTask, AoRTimeoutTask::Config> aor_timeout_handler(&aor_timeout_config);
   ChronosHandler<AuthTimeoutTask, AuthTimeoutTask::Config> auth_timeout_handler(&auth_timeout_config);
   HttpStackUtils::SpawningHandler<DeregistrationTask, DeregistrationTask::Config> deregistration_handler(&deregistration_config);
   HttpStackUtils::PingHandler ping_handler;
@@ -2203,7 +2203,7 @@ int main(int argc, char* argv[])
       http_stack->register_handler("^/ping$",
                                    &ping_handler);
       http_stack->register_handler("^/timers$",
-                                   &reg_timeout_handler);
+                                   &aor_timeout_handler);
       http_stack->register_handler("^/authentication-timeout$",
                                    &auth_timeout_handler);
       http_stack->register_handler("^/registrations?*$",

--- a/src/registrar.cpp
+++ b/src/registrar.cpp
@@ -113,7 +113,7 @@ pjsip_module mod_registrar =
 void log_bindings(const std::string& aor_name,
                   SubscriberDataManager::AoR* aor_data)
 {
-  TRC_DEBUG("Bindings for %s", aor_name.c_str());
+  TRC_DEBUG("Bindings for %s, timer ID %s", aor_name.c_str(), aor_data->_timer_id.c_str());
   for (SubscriberDataManager::AoR::Bindings::const_iterator i =
          aor_data->bindings().begin();
        i != aor_data->bindings().end();

--- a/src/scscfsproutlet.cpp
+++ b/src/scscfsproutlet.cpp
@@ -1233,8 +1233,8 @@ void SCSCFSproutletTsx::route_to_as(pjsip_msg* req, const std::string& server_na
     {
       // If the session case is "Originating_CDIV" we include the
       // "orig-div" header field parameter with just a name and no value.
-      // As per 3GPP TS 24.229 this creates a header that looks like: 
-      // P-Served-User: <sip:6505551234@homedomain>;orig-cdiv 
+      // As per 3GPP TS 24.229 this creates a header that looks like:
+      // P-Served-User: <sip:6505551234@homedomain>;orig-cdiv
       pj_strdup2(pool, &p->name, _session_case->to_string().c_str());
       pj_strdup2(pool, &p->value, "");
       pj_list_insert_before(&psu_hdr->other_param, p);
@@ -1242,7 +1242,7 @@ void SCSCFSproutletTsx::route_to_as(pjsip_msg* req, const std::string& server_na
     else
     {
       // If the session case is not "Originating_CDIV" we include the
-      // sescase header field parameter and the regstate header field 
+      // sescase header field parameter and the regstate header field
       // parameter both set to their corresponding values, for example:
       // P-Served-User: <sip:6505551234@homedomain>;sescase=term;regstate=reg
       pj_strdup2(pool, &p->name, "sescase");

--- a/src/subscriber_data_manager.cpp
+++ b/src/subscriber_data_manager.cpp
@@ -1187,7 +1187,7 @@ std::string SubscriberDataManager::JsonSerializerDeserializer::serialize_aor(AoR
           }
           writer.EndArray();
 
-          writer.String(JSON_TIMER_ID); writer.String("Deprecated"); // b->_timer_id.c_str());
+          writer.String(JSON_TIMER_ID); writer.String("Deprecated");
           writer.String(JSON_PRIVATE_ID); writer.String(b->_private_id.c_str());
           writer.String(JSON_EMERGENCY_REG); writer.Bool(b->_emergency_registration);
         }
@@ -1230,7 +1230,7 @@ std::string SubscriberDataManager::JsonSerializerDeserializer::serialize_aor(AoR
           writer.EndArray();
 
           writer.String(JSON_EXPIRES); writer.Int(s->_expires);
-          writer.String(JSON_TIMER_ID); writer.String("Deprecated"); // s->_timer_id.c_str());
+          writer.String(JSON_TIMER_ID); writer.String("Deprecated");
 
         }
         writer.EndObject();

--- a/src/subscriber_data_manager.cpp
+++ b/src/subscriber_data_manager.cpp
@@ -67,10 +67,6 @@ extern "C" {
 #include "json_parse_utils.h"
 #include "rapidjson/error/en.h"
 
-const std::vector<std::string> SubscriberDataManager::TAGS_NONE = {};
-const std::vector<std::string> SubscriberDataManager::TAGS_REG = {"REG"};
-const std::vector<std::string> SubscriberDataManager::TAGS_SUB = {"SUB"};
-
 /// SubscriberDataManager Methods
 
 SubscriberDataManager::SubscriberDataManager(Store* data_store,

--- a/src/subscriber_data_manager.cpp
+++ b/src/subscriber_data_manager.cpp
@@ -1306,9 +1306,12 @@ void SubscriberDataManager::ChronosTimerRequestSender::send_timers(
       (new_next_expires != old_next_expires) ||
       (timer_id == ""))
   {
+    // Set the expiry time to be relative to now
+    int expiry = new_next_expires - now;
+
     set_timer(aor_id,
               timer_id,
-              new_next_expires,
+              expiry,
               new_tags,
               trail);
   }

--- a/src/ut/chronosconnection_test.cpp
+++ b/src/ut/chronosconnection_test.cpp
@@ -101,7 +101,7 @@ TEST_F(ChronosConnectionTest, SendPostWithTags)
   fakecurl_responses["http://10.42.42.42:80/timers"] = Response(headers);
 
   std::string opaque = "{\"aor_id\": \"aor_id\", \"binding_id\": \"binding_id\"}";
-  std::map<std::string, uint32_t> tags; tags["TAG1"]++; tags["TAG2"]++;
+  std::map<std::string, uint32_t> tags = { {"TAG1", 1}, {"TAG2", 1} };
   std::string post_identity = "";
   HTTPCode status = _chronos.send_post(post_identity, 300, "/timers", opaque,  0, tags);
   EXPECT_EQ(status, 200);
@@ -154,7 +154,7 @@ TEST_F(ChronosConnectionTest, SendPutWithTags)
   // We expect Chronos to change the put identity to the value in the Location
   // header.
   std::string opaque = "{\"aor_id\": \"aor_id\", \"binding_id\": \"binding_id\"}";
-  std::map<std::string, uint32_t> tags; tags["TAG1"]++; tags["TAG2"]++;
+  std::map<std::string, uint32_t> tags = { {"TAG1", 1}, {"TAG2", 1} };
   std::string put_identity = "abcd";
   HTTPCode status = _chronos.send_put(put_identity, 300, "/timers", opaque,  0, tags);
   EXPECT_EQ(status, 200);

--- a/src/ut/chronosconnection_test.cpp
+++ b/src/ut/chronosconnection_test.cpp
@@ -101,7 +101,7 @@ TEST_F(ChronosConnectionTest, SendPostWithTags)
   fakecurl_responses["http://10.42.42.42:80/timers"] = Response(headers);
 
   std::string opaque = "{\"aor_id\": \"aor_id\", \"binding_id\": \"binding_id\"}";
-  std::vector<std::string> tags {"TAG1", "TAG2"};
+  std::map<std::string, uint32_t> tags; tags["TAG1"]++; tags["TAG2"]++;
   std::string post_identity = "";
   HTTPCode status = _chronos.send_post(post_identity, 300, "/timers", opaque,  0, tags);
   EXPECT_EQ(status, 200);
@@ -154,7 +154,7 @@ TEST_F(ChronosConnectionTest, SendPutWithTags)
   // We expect Chronos to change the put identity to the value in the Location
   // header.
   std::string opaque = "{\"aor_id\": \"aor_id\", \"binding_id\": \"binding_id\"}";
-  std::vector<std::string> tags = {"TAG1", "TAG2"};
+  std::map<std::string, uint32_t> tags; tags["TAG1"]++; tags["TAG2"]++;
   std::string put_identity = "abcd";
   HTTPCode status = _chronos.send_put(put_identity, 300, "/timers", opaque,  0, tags);
   EXPECT_EQ(status, 200);

--- a/src/ut/fakechronosconnection.cpp
+++ b/src/ut/fakechronosconnection.cpp
@@ -78,7 +78,7 @@ HTTPCode FakeChronosConnection::send_post(std::string& post_identity,
                                           const std::string& callback_uri,
                                           const std::string& opaque_data,
                                           SAS::TrailId trail,
-                                          const std::vector<std::string>& tags)
+                                          const std::map<std::string, uint32_t>& tags)
 {
   HTTPCode status = get_result(post_identity);
 
@@ -91,7 +91,7 @@ HTTPCode FakeChronosConnection::send_put(std::string& put_identity,
                                          const std::string& callback_uri,
                                          const std::string& opaque_data,
                                          SAS::TrailId trail,
-                                         const std::vector<std::string>& tags)
+                                         const std::map<std::string, uint32_t>& tags)
 {
   HTTPCode status = get_result(put_identity);
 

--- a/src/ut/fakechronosconnection.hpp
+++ b/src/ut/fakechronosconnection.hpp
@@ -61,12 +61,12 @@ private:
                      const std::string& callback_uri,
                      const std::string& opaque_data,
                      SAS::TrailId trail,
-                     const std::vector<std::string>& tags);
+                     const std::map<std::string, uint32_t>& tags);
   HTTPCode send_put(std::string& put_identity,
                     uint32_t timer_interval,
                     const std::string& callback_uri,
                     const std::string& opaque_data,
                     SAS::TrailId trail,
-                    const std::vector<std::string>& tags);
+                    const std::map<std::string, uint32_t>& tags);
   HTTPCode get_result(std::string identity);
 };

--- a/src/ut/scscf_test.cpp
+++ b/src/ut/scscf_test.cpp
@@ -4435,7 +4435,7 @@ TEST_F(SCSCFTest, Cdiv)
   EXPECT_EQ("sip:6505555678@homedomain", r1.uri());
   EXPECT_THAT(get_headers(out, "Route"),
               testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;orig>"));
-  
+
   // As the session case is "Originating_CDIV" we want to include the
   // "orig-div" header field parameter with just a name and no value
   // as specified in 3GPP TS 24.229.

--- a/src/ut/subscriber_data_manager_test.cpp
+++ b/src/ut/subscriber_data_manager_test.cpp
@@ -145,13 +145,14 @@ TYPED_TEST(BasicSubscriberDataManagerTest, BindingTests)
   now = time(NULL);
   aor_data1 = this->_store->get_aor_data(std::string("5102175698@cw-ngv.com"), 0);
   ASSERT_TRUE(aor_data1 != NULL);
+  aor_data1->get_current()->_timer_id = "AoRtimer";
   EXPECT_EQ(0u, aor_data1->get_current()->bindings().size());
   b1 = aor_data1->get_current()->get_binding(std::string("urn:uuid:00000000-0000-0000-0000-b4dd32817622:1"));
   b1->_uri = std::string("<sip:5102175698@192.91.191.29:59934;transport=tcp;ob>");
   b1->_cid = std::string("gfYHoZGaFaRNxhlV0WIwoS-f91NoJ2gq");
   b1->_cseq = 17038;
   b1->_expires = now + 300;
-  b1->_timer_id = "00000000000";
+  b1->_timer_id = "shouldbecomeDeprecated";
   b1->_priority = 0;
   b1->_path_headers.push_back(std::string("<sip:abcdefgh@bono-1.cw-ngv.com;lr>"));
   b1->_params["+sip.instance"] = "\"<urn:uuid:00000000-0000-0000-0000-b4dd32817622>\"";
@@ -168,6 +169,7 @@ TYPED_TEST(BasicSubscriberDataManagerTest, BindingTests)
   // Get the AoR record from the store.
   aor_data1 = this->_store->get_aor_data(std::string("5102175698@cw-ngv.com"), 0);
   ASSERT_TRUE(aor_data1 != NULL);
+  EXPECT_EQ("AoRtimer", aor_data1->get_current()->_timer_id);
   EXPECT_EQ(1u, aor_data1->get_current()->bindings().size());
   EXPECT_EQ(std::string("urn:uuid:00000000-0000-0000-0000-b4dd32817622:1"), aor_data1->get_current()->bindings().begin()->first);
   b1 = aor_data1->get_current()->bindings().begin()->second;
@@ -176,7 +178,7 @@ TYPED_TEST(BasicSubscriberDataManagerTest, BindingTests)
   EXPECT_EQ(17038, b1->_cseq);
   EXPECT_EQ(now + 300, b1->_expires);
   EXPECT_EQ(0, b1->_priority);
-  EXPECT_EQ(std::string("00000000000"), b1->_timer_id);
+  EXPECT_EQ(std::string("Deprecated"), b1->_timer_id);
   EXPECT_EQ(1u, b1->_path_headers.size());
   EXPECT_EQ(std::string("<sip:abcdefgh@bono-1.cw-ngv.com;lr>"), b1->_path_headers.front());
   EXPECT_EQ(3u, b1->_params.size());
@@ -194,6 +196,7 @@ TYPED_TEST(BasicSubscriberDataManagerTest, BindingTests)
 
   aor_data1 = this->_store->get_aor_data(std::string("5102175698@cw-ngv.com"), 0);
   ASSERT_TRUE(aor_data1 != NULL);
+  EXPECT_EQ("AoRtimer", aor_data1->get_current()->_timer_id);
   EXPECT_EQ(1u, aor_data1->get_current()->bindings().size());
   EXPECT_EQ(std::string("urn:uuid:00000000-0000-0000-0000-b4dd32817622:1"), aor_data1->get_current()->bindings().begin()->first);
   b1 = aor_data1->get_current()->bindings().begin()->second;
@@ -211,6 +214,7 @@ TYPED_TEST(BasicSubscriberDataManagerTest, BindingTests)
 
   aor_data1 = this->_store->get_aor_data(std::string("5102175698@cw-ngv.com"), 0);
   ASSERT_TRUE(aor_data1 != NULL);
+  EXPECT_EQ("AoRtimer", aor_data1->get_current()->_timer_id);
   EXPECT_EQ(1u, aor_data1->get_current()->bindings().size());
   b1 = aor_data1->get_current()->get_binding(std::string("urn:uuid:00000000-0000-0000-0000-b4dd32817622:1"));
   EXPECT_EQ(std::string("<sip:5102175698@192.91.191.29:59934;transport=tcp;ob>"), b1->_uri);
@@ -250,13 +254,14 @@ TYPED_TEST(BasicSubscriberDataManagerTest, SubscriptionTests)
   now = time(NULL);
   aor_data1 = this->_store->get_aor_data(std::string("5102175698@cw-ngv.com"), 0);
   ASSERT_TRUE(aor_data1 != NULL);
+  aor_data1->get_current()->_timer_id = "AoRtimer";
   EXPECT_EQ(0u, aor_data1->get_current()->bindings().size());
   b1 = aor_data1->get_current()->get_binding(std::string("urn:uuid:00000000-0000-0000-0000-b4dd32817622:1"));
   b1->_uri = std::string("<sip:5102175698@192.91.191.29:59934;transport=tcp;ob>");
   b1->_cid = std::string("gfYHoZGaFaRNxhlV0WIwoS-f91NoJ2gq");
   b1->_cseq = 17038;
   b1->_expires = now + 300;
-  b1->_timer_id = "00000000000";
+  b1->_timer_id = "shouldbecomeDeprecated";
   b1->_priority = 0;
   b1->_path_headers.push_back(std::string("<sip:abcdefgh@bono-1.cw-ngv.com;lr>"));
   b1->_params["+sip.instance"] = "\"<urn:uuid:00000000-0000-0000-0000-b4dd32817622>\"";
@@ -273,6 +278,7 @@ TYPED_TEST(BasicSubscriberDataManagerTest, SubscriptionTests)
   // Get the AoR record from the store.
   aor_data1 = this->_store->get_aor_data(std::string("5102175698@cw-ngv.com"), 0);
   ASSERT_TRUE(aor_data1 != NULL);
+  EXPECT_EQ("AoRtimer", aor_data1->get_current()->_timer_id);
   EXPECT_EQ(1u, aor_data1->get_current()->bindings().size());
   EXPECT_EQ(std::string("urn:uuid:00000000-0000-0000-0000-b4dd32817622:1"), aor_data1->get_current()->bindings().begin()->first);
   b1 = aor_data1->get_current()->bindings().begin()->second;
@@ -292,7 +298,7 @@ TYPED_TEST(BasicSubscriberDataManagerTest, SubscriptionTests)
   s1->_cid = std::string("xyzabc@192.91.191.29");
   s1->_route_uris.push_back(std::string("<sip:abcdefgh@bono-1.cw-ngv.com;lr>"));
   s1->_expires = now + 300;
-  s1->_timer_id = "11111111111";
+  s1->_timer_id = "shouldbecomeDeprecated";
 
   // Write the record back to the store.
   rc = this->_store->set_aor_data(std::string("5102175698@cw-ngv.com"), aor_data1, 0);
@@ -302,6 +308,7 @@ TYPED_TEST(BasicSubscriberDataManagerTest, SubscriptionTests)
   // Read the record back in and check the subscription is still in place.
   aor_data1 = this->_store->get_aor_data(std::string("5102175698@cw-ngv.com"), 0);
   ASSERT_TRUE(aor_data1 != NULL);
+  EXPECT_EQ("AoRtimer", aor_data1->get_current()->_timer_id);
   EXPECT_EQ(1u, aor_data1->get_current()->subscriptions().size());
   EXPECT_EQ(std::string("1234"), aor_data1->get_current()->subscriptions().begin()->first);
   s1 = aor_data1->get_current()->get_subscription(std::string("1234"));
@@ -315,6 +322,7 @@ TYPED_TEST(BasicSubscriberDataManagerTest, SubscriptionTests)
   EXPECT_EQ(std::string("<sip:abcdefgh@bono-1.cw-ngv.com;lr>"), s1->_route_uris.front());
   EXPECT_EQ(now + 300, s1->_expires);
   EXPECT_EQ(3, aor_data1->get_current()->_notify_cseq);
+  EXPECT_EQ("Deprecated", s1->_timer_id);
 
   // Remove the subscription.
   aor_data1->get_current()->remove_subscription(std::string("1234"));
@@ -334,6 +342,7 @@ TYPED_TEST(BasicSubscriberDataManagerTest, CopyTests)
   now = time(NULL);
   aor_data1 = this->_store->get_aor_data(std::string("5102175698@cw-ngv.com"), 0);
   ASSERT_TRUE(aor_data1 != NULL);
+  aor_data1->get_current()->_timer_id = "AoRtimer";
   EXPECT_EQ(0u, aor_data1->get_current()->bindings().size());
   EXPECT_EQ(0u, aor_data1->get_current()->subscriptions().size());
 
@@ -344,7 +353,7 @@ TYPED_TEST(BasicSubscriberDataManagerTest, CopyTests)
   b1->_cid = std::string("gfYHoZGaFaRNxhlV0WIwoS-f91NoJ2gq");
   b1->_cseq = 17038;
   b1->_expires = now + 300;
-  b1->_timer_id = "00000000000";
+  b1->_timer_id = "shouldbecomeDeprecated";
   b1->_priority = 0;
   b1->_path_headers.push_back(std::string("<sip:abcdefgh@bono1.homedomain;lr>"));
   b1->_params["+sip.instance"] = "\"<urn:uuid:00000000-0000-0000-0000-b4dd32817622>\"";
@@ -370,6 +379,7 @@ TYPED_TEST(BasicSubscriberDataManagerTest, CopyTests)
 
   // Test AoR copy constructor.
   SubscriberDataManager::AoR* copy = new SubscriberDataManager::AoR(*aor_data1->get_current());
+  EXPECT_EQ("AoRtimer", copy->_timer_id);
   EXPECT_EQ(1u, copy->bindings().size());
   EXPECT_EQ(1u, copy->subscriptions().size());
   EXPECT_EQ(1, copy->_notify_cseq);
@@ -380,6 +390,7 @@ TYPED_TEST(BasicSubscriberDataManagerTest, CopyTests)
   // Test AoR assignment.
   copy = new SubscriberDataManager::AoR("sip:name@example.com");
   *copy = *aor_data1->get_current();
+  EXPECT_EQ("AoRtimer", copy->_timer_id);
   EXPECT_EQ(1u, copy->bindings().size());
   EXPECT_EQ(1u, copy->subscriptions().size());
   EXPECT_EQ(1, copy->_notify_cseq);
@@ -405,6 +416,7 @@ TYPED_TEST(BasicSubscriberDataManagerTest, ExpiryTests)
   now = time(NULL);
   aor_data1 = this->_store->get_aor_data(std::string("5102175698@cw-ngv.com"), 0);
   ASSERT_TRUE(aor_data1 != NULL);
+  aor_data1->get_current()->_timer_id = "AoRtimer";
   EXPECT_EQ(0u, aor_data1->get_current()->bindings().size());
   EXPECT_EQ(0u, aor_data1->get_current()->subscriptions().size());
 
@@ -416,7 +428,7 @@ TYPED_TEST(BasicSubscriberDataManagerTest, ExpiryTests)
   b1->_cid = std::string("gfYHoZGaFaRNxhlV0WIwoS-f91NoJ2gq");
   b1->_cseq = 17038;
   b1->_expires = now + 100;
-  b1->_timer_id = "00000000000";
+  b1->_timer_id = "shouldbecomeDeprecated";
   b1->_priority = 0;
   b1->_params["+sip.instance"] = "\"<urn:uuid:00000000-0000-0000-0000-b4dd32817622>\"";
   b1->_params["reg-id"] = "1";
@@ -429,7 +441,7 @@ TYPED_TEST(BasicSubscriberDataManagerTest, ExpiryTests)
   b2->_cid = std::string("gfYHoZGaFaRNxhlV0WIwoS-f91NoJ2gq");
   b2->_cseq = 17038;
   b2->_expires = now + 200;
-  b2->_timer_id = "00000000000";
+  b2->_timer_id = "shouldbecomeDeprecated";
   b2->_priority = 0;
   b2->_params["+sip.instance"] = "\"<urn:uuid:00000000-0000-0000-0000-b4dd32817622>\"";
   b2->_params["reg-id"] = "2";
@@ -449,7 +461,7 @@ TYPED_TEST(BasicSubscriberDataManagerTest, ExpiryTests)
   s1->_cid = std::string("xyzabc@192.91.191.29");
   s1->_route_uris.push_back(std::string("sip:abcdefgh@bono-1.cw-ngv.com;lr"));
   s1->_expires = now + 150;
-  s1->_timer_id = "00000000000";
+  s1->_timer_id = "shouldbecomeDeprecated";
   s2 = aor_data1->get_current()->get_subscription("5678");
   EXPECT_EQ(2u, aor_data1->get_current()->subscriptions().size());
   s2->_req_uri = std::string("sip:5102175698@192.91.191.29:59934;transport=tcp");
@@ -460,7 +472,7 @@ TYPED_TEST(BasicSubscriberDataManagerTest, ExpiryTests)
   s2->_cid = std::string("xyzabc@192.91.191.29");
   s2->_route_uris.push_back(std::string("sip:abcdefgh@bono-1.cw-ngv.com;lr"));
   s2->_expires = now + 300;
-  s2->_timer_id = "00000000000";
+  s2->_timer_id = "shouldbecomeDeprecated";
 
   // Write the record to the store.
   rc = this->_store->set_aor_data(std::string("5102175698@cw-ngv.com"), aor_data1, 0);
@@ -573,7 +585,7 @@ TYPED_TEST(MultiFormatSubscriberDataManagerTest, AllFormatsCanBeRead)
   b1->_cid = std::string("cid1");
   b1->_cseq = 1000;
   b1->_expires = now + 300;
-  b1->_timer_id = "00000000001";
+  b1->_timer_id = "shouldbecomeDeprecated";
   b1->_priority = 0;
   b1->_path_headers.push_back(std::string("<sip:abcdefgh@bono-1.cw-ngv.com;lr>"));
   b1->_params["+sip.instance"] = "\"<urn:uuid:00000000-0000-0000-0000-b4dd32817621>\"";
@@ -727,9 +739,9 @@ class SubscriberDataManagerChronosRequestsTest : public SipTest
   SubscriberDataManager* _store;
 };
 
-// Test that deleting a subscription when it doesn't have a timer set doesn't generate a
-// Chronos request
-TEST_F(SubscriberDataManagerChronosRequestsTest, SubscriptionTestsDeleteWithoutChronosTimer)
+// Test that adding an AoR to the store generates a chronos POST request, and that
+// voiding the AoR (removing all bindings) sends a DELETE request.
+TEST_F(SubscriberDataManagerChronosRequestsTest, BasicAoRTimerTest)
 {
   SubscriberDataManager::AoRPair* aor_data1;
   SubscriberDataManager::AoR::Binding* b1;
@@ -747,7 +759,7 @@ TEST_F(SubscriberDataManagerChronosRequestsTest, SubscriptionTestsDeleteWithoutC
   b1->_cid = std::string("gfYHoZGaFaRNxhlV0WIwoS-f91NoJ2gq");
   b1->_cseq = 17038;
   b1->_expires = now + 300;
-  b1->_timer_id = "00000000000";
+  b1->_timer_id = "shouldbecomeDeprecated";
   b1->_priority = 0;
   b1->_path_headers.push_back(std::string("<sip:abcdefgh@bono-1.cw-ngv.com;lr>"));
   b1->_params["+sip.instance"] = "\"<urn:uuid:00000000-0000-0000-0000-b4dd32817622>\"";
@@ -767,10 +779,10 @@ TEST_F(SubscriberDataManagerChronosRequestsTest, SubscriptionTestsDeleteWithoutC
   s1->_route_uris.push_back(std::string("<sip:abcdefgh@bono-1.cw-ngv.com;lr>"));
   s1->_expires = now + 300;
 
-  // Write the record back to the store. Have the Chronos request fail
-  EXPECT_CALL(*(this->_chronos_connection), send_put(_, _, _, _, _, _));
-  EXPECT_CALL(*(this->_chronos_connection), send_post(s1->_timer_id, _, _, _, _, _)).
-                   WillOnce(Return(503));
+  // Write the record back to the store.
+  EXPECT_CALL(*(this->_chronos_connection), send_post(aor_data1->get_current()->_timer_id, _, _, _, _, _)).
+                   WillOnce(DoAll(SetArgReferee<0>("TIMER_ID"),
+                                  Return(HTTP_OK)));
   rc = this->_store->set_aor_data(std::string("5102175698@cw-ngv.com"), aor_data1, 0);
   EXPECT_TRUE(rc);
   delete aor_data1; aor_data1 = NULL;
@@ -778,28 +790,32 @@ TEST_F(SubscriberDataManagerChronosRequestsTest, SubscriptionTestsDeleteWithoutC
   // Read the record back in and check the timer ID.
   aor_data1 = this->_store->get_aor_data(std::string("5102175698@cw-ngv.com"), 0);
   ASSERT_TRUE(aor_data1 != NULL);
+  EXPECT_EQ("TIMER_ID", aor_data1->get_current()->_timer_id);
+  EXPECT_EQ(1u, aor_data1->get_current()->bindings().size());
+  EXPECT_EQ(std::string("urn:uuid:00000000-0000-0000-0000-b4dd32817622:1"), aor_data1->get_current()->bindings().begin()->first);
   EXPECT_EQ(1u, aor_data1->get_current()->subscriptions().size());
   EXPECT_EQ(std::string("1234"), aor_data1->get_current()->subscriptions().begin()->first);
-  s1 = aor_data1->get_current()->get_subscription(std::string("1234"));
-  EXPECT_EQ("", s1->_timer_id);
 
-  // Remove the subscription.
-  aor_data1->get_current()->remove_subscription(std::string("1234"));
-  EXPECT_EQ(0u, aor_data1->get_current()->subscriptions().size());
+  // Remove the binding.
+  aor_data1->get_current()->remove_binding(std::string("urn:uuid:00000000-0000-0000-0000-b4dd32817622:1"));
+  EXPECT_EQ(0u, aor_data1->get_current()->bindings().size());
 
-  // Write the record back to the store. Check no delete is sent
-  EXPECT_CALL(*(this->_chronos_connection), send_delete(_, _)).Times(0);
+  // Write the record back to the store. Check DELETE request is sent.
+  EXPECT_CALL(*(this->_chronos_connection), send_delete(aor_data1->get_current()->_timer_id, _)).Times(1);
   rc = this->_store->set_aor_data(std::string("5102175698@cw-ngv.com"), aor_data1, 0);
   EXPECT_TRUE(rc);
   delete aor_data1; aor_data1 = NULL;
 }
 
-// Test that adding a subscription generates Chronos Timer requests
-TEST_F(SubscriberDataManagerChronosRequestsTest, SubscriptionTestsChronosRequests)
+// Test that updating an AoR with extra bindings and subscriptions generates a chronos PUT request.
+TEST_F(SubscriberDataManagerChronosRequestsTest, UpdateAoRTimerTest)
 {
   SubscriberDataManager::AoRPair* aor_data1;
   SubscriberDataManager::AoR::Binding* b1;
-  SubscriberDataManager::AoR::Subscription* s1;
+  std::map<std::string, uint32_t> expected_tags;
+  expected_tags["REG"] = 1;
+  expected_tags["BIND"] = 0;
+  expected_tags["SUB"] = 0;
   bool rc;
   int now;
 
@@ -813,7 +829,7 @@ TEST_F(SubscriberDataManagerChronosRequestsTest, SubscriptionTestsChronosRequest
   b1->_cid = std::string("gfYHoZGaFaRNxhlV0WIwoS-f91NoJ2gq");
   b1->_cseq = 17038;
   b1->_expires = now + 300;
-  b1->_timer_id = "00000000000";
+  b1->_timer_id = "shouldbecomeDeprecated";
   b1->_priority = 0;
   b1->_path_headers.push_back(std::string("<sip:abcdefgh@bono-1.cw-ngv.com;lr>"));
   b1->_params["+sip.instance"] = "\"<urn:uuid:00000000-0000-0000-0000-b4dd32817622>\"";
@@ -821,6 +837,107 @@ TEST_F(SubscriberDataManagerChronosRequestsTest, SubscriptionTestsChronosRequest
   b1->_params["+sip.ice"] = "";
   b1->_private_id = "5102175698@cw-ngv.com";
   b1->_emergency_registration = false;
+
+  expected_tags["BIND"]++;
+
+  // Write the record back to the store.
+  EXPECT_CALL(*(this->_chronos_connection), send_post(_, _, _, _, _, expected_tags)).
+                   WillOnce(DoAll(SetArgReferee<0>("TIMER_ID"),
+                                  Return(HTTP_OK)));
+  rc = this->_store->set_aor_data(std::string("5102175698@cw-ngv.com"), aor_data1, 0);
+  EXPECT_TRUE(rc);
+  delete aor_data1; aor_data1 = NULL;
+
+  // Read the record back in and check the timer ID.
+  aor_data1 = this->_store->get_aor_data(std::string("5102175698@cw-ngv.com"), 0);
+  ASSERT_TRUE(aor_data1 != NULL);
+  EXPECT_EQ("TIMER_ID", aor_data1->get_current()->_timer_id);
+
+  // Add a subscription to the record.
+  SubscriberDataManager::AoR::Subscription* s1;
+  s1 = aor_data1->get_current()->get_subscription("1234");
+  s1->_req_uri = std::string("sip:5102175698@192.91.191.29:59934;transport=tcp");
+  s1->_from_uri = std::string("<sip:5102175698@cw-ngv.com>");
+  s1->_from_tag = std::string("4321");
+  s1->_to_uri = std::string("<sip:5102175698@cw-ngv.com>");
+  s1->_to_tag = std::string("1234");
+  s1->_cid = std::string("xyzabc@192.91.191.29");
+  s1->_route_uris.push_back(std::string("<sip:abcdefgh@bono-1.cw-ngv.com;lr>"));
+  s1->_expires = now + 300;
+
+  expected_tags["SUB"]++;
+
+  // Write the record back to the store, expecting a chronos PUT request.
+  EXPECT_CALL(*(this->_chronos_connection), send_put(_, _, _, _, _, expected_tags)).
+                   WillOnce(Return(HTTP_OK));
+  rc = this->_store->set_aor_data(std::string("5102175698@cw-ngv.com"), aor_data1, 0);
+  EXPECT_TRUE(rc);
+  delete aor_data1; aor_data1 = NULL;
+
+  // Read the record back in and check the timer ID.
+  aor_data1 = this->_store->get_aor_data(std::string("5102175698@cw-ngv.com"), 0);
+  ASSERT_TRUE(aor_data1 != NULL);
+
+  // Add another binding to the record.
+  SubscriberDataManager::AoR::Binding* b2;
+  b2 = aor_data1->get_current()->get_binding(std::string("urn:uuid:00000000-0000-0000-0000-b4dd32817622:2"));
+  b2->_uri = std::string("<sip:5102175698@192.91.191.29:59934;transport=tcp;ob>");
+  b2->_cid = std::string("gfYHoZGaFaRNxhlV0WIwoS-f91NoJ2gq");
+  b2->_cseq = 17038;
+  b2->_expires = now + 300;
+  b2->_timer_id = "shouldbecomeDeprecated";
+  b2->_priority = 0;
+  b2->_path_headers.push_back(std::string("<sip:abcdefgh@bono-1.cw-ngv.com;lr>"));
+  b2->_params["+sip.instance"] = "\"<urn:uuid:00000000-0000-0000-0000-b4dd32817622>\"";
+  b2->_params["reg-id"] = "1";
+  b2->_params["+sip.ice"] = "";
+  b2->_private_id = "5102175698@cw-ngv.com";
+  b2->_emergency_registration = false;
+
+  expected_tags["BIND"]++;
+
+  // Write the record back to the store, expecting a chronos PUT request.
+  EXPECT_CALL(*(this->_chronos_connection), send_put(_, _, _, _, _, expected_tags)).
+                   WillOnce(Return(HTTP_OK));
+  rc = this->_store->set_aor_data(std::string("5102175698@cw-ngv.com"), aor_data1, 0);
+  EXPECT_TRUE(rc);
+  delete aor_data1; aor_data1 = NULL;
+}
+
+// Test that adding and removing an equal number of bindings or subscriptions
+// does not generate a chronos request.
+TEST_F(SubscriberDataManagerChronosRequestsTest, AoRChangeNoUpdateTimerTest)
+{
+  SubscriberDataManager::AoRPair* aor_data1;
+  SubscriberDataManager::AoR::Binding* b1;
+  SubscriberDataManager::AoR::Subscription* s1;
+  std::map<std::string, uint32_t> expected_tags;
+  expected_tags["REG"] = 1;
+  expected_tags["BIND"] = 0;
+  expected_tags["SUB"] = 0;
+  bool rc;
+  int now;
+
+  // Get an initial empty AoR record and add a binding.
+  now = time(NULL);
+  aor_data1 = this->_store->get_aor_data(std::string("5102175698@cw-ngv.com"), 0);
+  ASSERT_TRUE(aor_data1 != NULL);
+  EXPECT_EQ(0u, aor_data1->get_current()->bindings().size());
+  b1 = aor_data1->get_current()->get_binding(std::string("urn:uuid:00000000-0000-0000-0000-b4dd32817622:1"));
+  b1->_uri = std::string("<sip:5102175698@192.91.191.29:59934;transport=tcp;ob>");
+  b1->_cid = std::string("gfYHoZGaFaRNxhlV0WIwoS-f91NoJ2gq");
+  b1->_cseq = 17038;
+  b1->_expires = now + 300;
+  b1->_timer_id = "shouldbecomeDeprecated";
+  b1->_priority = 0;
+  b1->_path_headers.push_back(std::string("<sip:abcdefgh@bono-1.cw-ngv.com;lr>"));
+  b1->_params["+sip.instance"] = "\"<urn:uuid:00000000-0000-0000-0000-b4dd32817622>\"";
+  b1->_params["reg-id"] = "1";
+  b1->_params["+sip.ice"] = "";
+  b1->_private_id = "5102175698@cw-ngv.com";
+  b1->_emergency_registration = false;
+
+  expected_tags["BIND"]++;
 
   // Add a subscription to the record.
   s1 = aor_data1->get_current()->get_subscription("1234");
@@ -833,10 +950,12 @@ TEST_F(SubscriberDataManagerChronosRequestsTest, SubscriptionTestsChronosRequest
   s1->_route_uris.push_back(std::string("<sip:abcdefgh@bono-1.cw-ngv.com;lr>"));
   s1->_expires = now + 300;
 
-  // Write the record back to the store. Have the Chronos request fail
-  EXPECT_CALL(*(this->_chronos_connection), send_put(_, _, _, _, _, _));
-  EXPECT_CALL(*(this->_chronos_connection), send_post(s1->_timer_id, _, _, _, _, _)).
-                   WillOnce(Return(503));
+  expected_tags["SUB"]++;
+
+  // Write the record back to the store.
+  EXPECT_CALL(*(this->_chronos_connection), send_post(_, _, _, _, _, expected_tags)).
+                   WillOnce(DoAll(SetArgReferee<0>("TIMER_ID"),
+                                  Return(HTTP_OK)));
   rc = this->_store->set_aor_data(std::string("5102175698@cw-ngv.com"), aor_data1, 0);
   EXPECT_TRUE(rc);
   delete aor_data1; aor_data1 = NULL;
@@ -844,53 +963,201 @@ TEST_F(SubscriberDataManagerChronosRequestsTest, SubscriptionTestsChronosRequest
   // Read the record back in and check the timer ID.
   aor_data1 = this->_store->get_aor_data(std::string("5102175698@cw-ngv.com"), 0);
   ASSERT_TRUE(aor_data1 != NULL);
-  EXPECT_EQ(1u, aor_data1->get_current()->subscriptions().size());
-  EXPECT_EQ(std::string("1234"), aor_data1->get_current()->subscriptions().begin()->first);
-  s1 = aor_data1->get_current()->get_subscription(std::string("1234"));
-  EXPECT_EQ("", s1->_timer_id);
+  EXPECT_EQ("TIMER_ID", aor_data1->get_current()->_timer_id);
 
-  // Write the record back. This time let the Chronos request succeed
-  EXPECT_CALL(*(this->_chronos_connection), send_post(s1->_timer_id, _, _, _, _, _)).
-       WillOnce(DoAll(SetArgReferee<0>("TIMER_ID"), Return(HTTP_OK)));
-  rc = this->_store->set_aor_data(std::string("5102175698@cw-ngv.com"), aor_data1, 0);
-  EXPECT_TRUE(rc);
-  delete aor_data1; aor_data1 = NULL;
+  // Add another binding to the record.
+  SubscriberDataManager::AoR::Binding* b2;
+  b2 = aor_data1->get_current()->get_binding(std::string("urn:uuid:00000000-0000-0000-0000-b4dd32817622:2"));
+  b2->_uri = std::string("<sip:5102175698@192.91.191.29:59934;transport=tcp;ob>");
+  b2->_cid = std::string("gfYHoZGaFaRNxhlV0WIwoS-f91NoJ2gq");
+  b2->_cseq = 17038;
+  b2->_expires = now + 300;
+  b2->_timer_id = "shouldbecomeDeprecated";
+  b2->_priority = 0;
+  b2->_path_headers.push_back(std::string("<sip:abcdefgh@bono-1.cw-ngv.com;lr>"));
+  b2->_params["+sip.instance"] = "\"<urn:uuid:00000000-0000-0000-0000-b4dd32817622>\"";
+  b2->_params["reg-id"] = "1";
+  b2->_params["+sip.ice"] = "";
+  b2->_private_id = "5102175698@cw-ngv.com";
+  b2->_emergency_registration = false;
 
-  // Read the record back in and check the timer ID.
-  aor_data1 = this->_store->get_aor_data(std::string("5102175698@cw-ngv.com"), 0);
-  ASSERT_TRUE(aor_data1 != NULL);
-  s1 = aor_data1->get_current()->get_subscription(std::string("1234"));
-  EXPECT_EQ("TIMER_ID", s1->_timer_id);
+  expected_tags["BIND"]++;
 
-  // Change the expiry time and check that we still get a Chronos request
-  s1->_expires++;
-  EXPECT_CALL(*(this->_chronos_connection), send_put(s1->_timer_id, _, _, _, _, _)).
-       WillOnce(Return(HTTP_OK));
-  rc = this->_store->set_aor_data(std::string("5102175698@cw-ngv.com"), aor_data1, 0);
-  EXPECT_TRUE(rc);
-  delete aor_data1; aor_data1 = NULL;
+  // Add another subscription to the record.
+  SubscriberDataManager::AoR::Subscription* s2;
+  s2 = aor_data1->get_current()->get_subscription("5678");
+  s2->_req_uri = std::string("sip:5102175698@192.91.191.29:59934;transport=tcp");
+  s2->_from_uri = std::string("<sip:5102175698@cw-ngv.com>");
+  s2->_from_tag = std::string("4321");
+  s2->_to_uri = std::string("<sip:5102175698@cw-ngv.com>");
+  s2->_to_tag = std::string("1234");
+  s2->_cid = std::string("xyzabc@192.91.191.29");
+  s2->_route_uris.push_back(std::string("<sip:abcdefgh@bono-1.cw-ngv.com;lr>"));
+  s2->_expires = now + 300;
 
-  // Read the record back in and check the timer ID.
-  aor_data1 = this->_store->get_aor_data(std::string("5102175698@cw-ngv.com"), 0);
-  ASSERT_TRUE(aor_data1 != NULL);
-  s1 = aor_data1->get_current()->get_subscription(std::string("1234"));
-  EXPECT_EQ("TIMER_ID", s1->_timer_id);
+  expected_tags["SUB"]++;
 
-  // Don't change the expiry time, and check there's no Chronos request
+  // Remove the original binding and subscription.
+  aor_data1->get_current()->remove_binding(std::string("urn:uuid:00000000-0000-0000-0000-b4dd32817622:1"));
+  aor_data1->get_current()->remove_subscription(std::string("1234"));
+  expected_tags["BIND"]--;  expected_tags["SUB"]--;
+
+  // Write the record back to the store, expecting no chronos PUT request.
   EXPECT_CALL(*(this->_chronos_connection), send_put(_, _, _, _, _, _)).Times(0);
   rc = this->_store->set_aor_data(std::string("5102175698@cw-ngv.com"), aor_data1, 0);
   EXPECT_TRUE(rc);
   delete aor_data1; aor_data1 = NULL;
 
-  // Remove the subscription. Read the record back in and check the timer ID.
+  // Read the record back in and check the new members were added correctly.
   aor_data1 = this->_store->get_aor_data(std::string("5102175698@cw-ngv.com"), 0);
   ASSERT_TRUE(aor_data1 != NULL);
-  aor_data1->get_current()->remove_subscription(std::string("1234"));
-  EXPECT_EQ(0u, aor_data1->get_current()->subscriptions().size());
+  EXPECT_EQ(1, aor_data1->get_current()->bindings().size());
+  EXPECT_EQ(1, aor_data1->get_current()->subscriptions().size());
+  EXPECT_EQ(std::string("urn:uuid:00000000-0000-0000-0000-b4dd32817622:2"), aor_data1->get_current()->bindings().begin()->first);
+  EXPECT_EQ(std::string("5678"), aor_data1->get_current()->subscriptions().begin()->first);
+  delete aor_data1; aor_data1 = NULL;
+}
 
-  // Write the record back to the store. Check a delete is sent
-  EXPECT_CALL(*(this->_chronos_connection), send_delete(_, _));
+// Test that changing the soonest expiry time of the AoR members generates a chronos PUT request.
+TEST_F(SubscriberDataManagerChronosRequestsTest, AoRNextExpiresUpdateTimerTest)
+{
+  SubscriberDataManager::AoRPair* aor_data1;
+  SubscriberDataManager::AoR::Binding* b1;
+  SubscriberDataManager::AoR::Subscription* s1;
+  std::map<std::string, uint32_t> expected_tags;
+  expected_tags["REG"] = 1;
+  expected_tags["BIND"] = 0;
+  expected_tags["SUB"] = 0;
+  bool rc;
+  int now;
+
+  // Get an initial empty AoR record and add a binding.
+  now = time(NULL);
+  aor_data1 = this->_store->get_aor_data(std::string("5102175698@cw-ngv.com"), 0);
+  ASSERT_TRUE(aor_data1 != NULL);
+  EXPECT_EQ(0u, aor_data1->get_current()->bindings().size());
+  b1 = aor_data1->get_current()->get_binding(std::string("urn:uuid:00000000-0000-0000-0000-b4dd32817622:1"));
+  b1->_uri = std::string("<sip:5102175698@192.91.191.29:59934;transport=tcp;ob>");
+  b1->_cid = std::string("gfYHoZGaFaRNxhlV0WIwoS-f91NoJ2gq");
+  b1->_cseq = 17038;
+  b1->_expires = now + 300;
+  b1->_timer_id = "shouldbecomeDeprecated";
+  b1->_priority = 0;
+  b1->_path_headers.push_back(std::string("<sip:abcdefgh@bono-1.cw-ngv.com;lr>"));
+  b1->_params["+sip.instance"] = "\"<urn:uuid:00000000-0000-0000-0000-b4dd32817622>\"";
+  b1->_params["reg-id"] = "1";
+  b1->_params["+sip.ice"] = "";
+  b1->_private_id = "5102175698@cw-ngv.com";
+  b1->_emergency_registration = false;
+
+  expected_tags["BIND"]++;
+
+  // Add a subscription to the record.
+  s1 = aor_data1->get_current()->get_subscription("1234");
+  s1->_req_uri = std::string("sip:5102175698@192.91.191.29:59934;transport=tcp");
+  s1->_from_uri = std::string("<sip:5102175698@cw-ngv.com>");
+  s1->_from_tag = std::string("4321");
+  s1->_to_uri = std::string("<sip:5102175698@cw-ngv.com>");
+  s1->_to_tag = std::string("1234");
+  s1->_cid = std::string("xyzabc@192.91.191.29");
+  s1->_route_uris.push_back(std::string("<sip:abcdefgh@bono-1.cw-ngv.com;lr>"));
+  s1->_expires = now + 300;
+
+  expected_tags["SUB"]++;
+
+  // Write the record back to the store.
+  EXPECT_CALL(*(this->_chronos_connection), send_post(_, (now + 300), _, _, _, expected_tags)).
+                   WillOnce(DoAll(SetArgReferee<0>("TIMER_ID"),
+                                  Return(HTTP_OK)));
   rc = this->_store->set_aor_data(std::string("5102175698@cw-ngv.com"), aor_data1, 0);
   EXPECT_TRUE(rc);
+  delete aor_data1; aor_data1 = NULL;
+
+  // Read the record back in and check the timer ID.
+  aor_data1 = this->_store->get_aor_data(std::string("5102175698@cw-ngv.com"), 0);
+  ASSERT_TRUE(aor_data1 != NULL);
+  EXPECT_EQ("TIMER_ID", aor_data1->get_current()->_timer_id);
+
+  // Modify the expiry time of the binding to be later. This should not update the timer.
+  b1 = aor_data1->get_current()->bindings().begin()->second;
+  b1->_expires = now + 500;
+
+  // Write the record back to the store.
+  EXPECT_CALL(*(this->_chronos_connection), send_put(_, _, _, _, _, _)).Times(0);
+  rc = this->_store->set_aor_data(std::string("5102175698@cw-ngv.com"), aor_data1, 0);
+  EXPECT_TRUE(rc);
+  delete aor_data1; aor_data1 = NULL;
+
+  // Read the record back in.
+  aor_data1 = this->_store->get_aor_data(std::string("5102175698@cw-ngv.com"), 0);
+  ASSERT_TRUE(aor_data1 != NULL);
+
+  // Modify the expiry time of the binding to be sooner. This should generate an update.
+  b1 = aor_data1->get_current()->bindings().begin()->second;
+  b1->_expires = now + 200;
+
+  // Write the record back to the store.
+  EXPECT_CALL(*(this->_chronos_connection), send_put(_, (now + 200), _, _, _, _)).
+                   WillOnce(Return(HTTP_OK));
+  rc = this->_store->set_aor_data(std::string("5102175698@cw-ngv.com"), aor_data1, 0);
+  EXPECT_TRUE(rc);
+  delete aor_data1; aor_data1 = NULL;
+
+  // Read the record back in.
+  aor_data1 = this->_store->get_aor_data(std::string("5102175698@cw-ngv.com"), 0);
+  ASSERT_TRUE(aor_data1 != NULL);
+
+  // Modify the expiry time of the subscription to be sooner. This should also generate an update.
+  s1 = aor_data1->get_current()->subscriptions().begin()->second;
+  s1->_expires = now + 100;
+
+  // Write the record back to the store.
+  EXPECT_CALL(*(this->_chronos_connection), send_put(_, (now + 100), _, _, _, _)).
+                   WillOnce(Return(HTTP_OK));
+  rc = this->_store->set_aor_data(std::string("5102175698@cw-ngv.com"), aor_data1, 0);
+  EXPECT_TRUE(rc);
+  delete aor_data1; aor_data1 = NULL;
+}
+
+// Test that a failed timer POST does not change the timer ID in the AoR.
+TEST_F(SubscriberDataManagerChronosRequestsTest, AoRTimerBadRequestNoIDTest)
+{
+  SubscriberDataManager::AoRPair* aor_data1;
+  SubscriberDataManager::AoR::Binding* b1;
+  bool rc;
+  int now;
+
+  // Get an initial empty AoR record and add a binding.
+  now = time(NULL);
+  aor_data1 = this->_store->get_aor_data(std::string("5102175698@cw-ngv.com"), 0);
+  ASSERT_TRUE(aor_data1 != NULL);
+  EXPECT_EQ(0u, aor_data1->get_current()->bindings().size());
+  b1 = aor_data1->get_current()->get_binding(std::string("urn:uuid:00000000-0000-0000-0000-b4dd32817622:1"));
+  b1->_uri = std::string("<sip:5102175698@192.91.191.29:59934;transport=tcp;ob>");
+  b1->_cid = std::string("gfYHoZGaFaRNxhlV0WIwoS-f91NoJ2gq");
+  b1->_cseq = 17038;
+  b1->_expires = now + 300;
+  b1->_timer_id = "shouldbecomeDeprecated";
+  b1->_priority = 0;
+  b1->_path_headers.push_back(std::string("<sip:abcdefgh@bono-1.cw-ngv.com;lr>"));
+  b1->_params["+sip.instance"] = "\"<urn:uuid:00000000-0000-0000-0000-b4dd32817622>\"";
+  b1->_params["reg-id"] = "1";
+  b1->_params["+sip.ice"] = "";
+  b1->_private_id = "5102175698@cw-ngv.com";
+  b1->_emergency_registration = false;
+
+  // Write the record back to the store.
+  EXPECT_CALL(*(this->_chronos_connection), send_post(aor_data1->get_current()->_timer_id, _, _, _, _, _)).
+                   WillOnce(DoAll(SetArgReferee<0>("TIMER_ID"),
+                                  Return(HTTP_BAD_REQUEST)));
+  rc = this->_store->set_aor_data(std::string("5102175698@cw-ngv.com"), aor_data1, 0);
+  EXPECT_TRUE(rc);
+  delete aor_data1; aor_data1 = NULL;
+
+  // Read the record back in and check the timer ID was not saved off.
+  aor_data1 = this->_store->get_aor_data(std::string("5102175698@cw-ngv.com"), 0);
+  ASSERT_TRUE(aor_data1 != NULL);
+  EXPECT_EQ("", aor_data1->get_current()->_timer_id);
+
   delete aor_data1; aor_data1 = NULL;
 }

--- a/src/ut/subscriber_data_manager_test.cpp
+++ b/src/ut/subscriber_data_manager_test.cpp
@@ -1066,7 +1066,7 @@ TEST_F(SubscriberDataManagerChronosRequestsTest, AoRNextExpiresUpdateTimerTest)
   expected_tags["SUB"]++;
 
   // Write the record back to the store.
-  EXPECT_CALL(*(this->_chronos_connection), send_post(_, (now + 300), _, _, _, expected_tags)).
+  EXPECT_CALL(*(this->_chronos_connection), send_post(_, (300), _, _, _, expected_tags)).
                    WillOnce(DoAll(SetArgReferee<0>("TIMER_ID"),
                                   Return(HTTP_OK)));
   rc = this->_store->set_aor_data(std::string("5102175698@cw-ngv.com"), aor_data1, 0);
@@ -1097,7 +1097,7 @@ TEST_F(SubscriberDataManagerChronosRequestsTest, AoRNextExpiresUpdateTimerTest)
   b1->_expires = now + 200;
 
   // Write the record back to the store.
-  EXPECT_CALL(*(this->_chronos_connection), send_put(_, (now + 200), _, _, _, _)).
+  EXPECT_CALL(*(this->_chronos_connection), send_put(_, (200), _, _, _, _)).
                    WillOnce(Return(HTTP_OK));
   rc = this->_store->set_aor_data(std::string("5102175698@cw-ngv.com"), aor_data1, 0);
   EXPECT_TRUE(rc);
@@ -1112,7 +1112,7 @@ TEST_F(SubscriberDataManagerChronosRequestsTest, AoRNextExpiresUpdateTimerTest)
   s1->_expires = now + 100;
 
   // Write the record back to the store.
-  EXPECT_CALL(*(this->_chronos_connection), send_put(_, (now + 100), _, _, _, _)).
+  EXPECT_CALL(*(this->_chronos_connection), send_put(_, (100), _, _, _, _)).
                    WillOnce(Return(HTTP_OK));
   rc = this->_store->set_aor_data(std::string("5102175698@cw-ngv.com"), aor_data1, 0);
   EXPECT_TRUE(rc);


### PR DESCRIPTION
This is the bulk of the work. 

I've added the AoR class methods for getting the number of bindings and subscriptions, and the next expiry time, as we decided. 
The SubscriberDataManager, and SubscriberDataManagerTests are where the biggest changes are. 
I'd particularly appreciate a look at the send_timers logic, and the tests associated with sending timers that i've added, to make sure i'm not missing some areas of testing.

There's also a number of minor changes throughout:
- changed RegSubTimeoutTask to AoRTimeoutTask
- made modifications to support the map of tags throughout.
- cleared out a couple of bits of whitespace i saw Andrew introduced in scscf-sproutlet code.

Let me know if anything isn't clear. Feedback as soon as is plausible would be good so i can try to get it in this week (assuming there aren't major markups).
I'll begin live testing it early tomorrow, at least initial tests, and will let you know if things aren't working and i'm going to have to make more code changes.