### PR TITLE
[Reviewer: Rob] Fixes iss1267: Adds a tel URI alias to the P-Asserted-Identity header

### DIFF
--- a/src/scscfsproutlet.cpp
+++ b/src/scscfsproutlet.cpp
@@ -1830,16 +1830,18 @@ void SCSCFSproutletTsx::add_second_p_a_i_hdr(pjsip_msg* msg)
       }
       else
       {
-        for (unsigned int i=0; i<_aliases.size(); i++)
+        for (std::vector<std::string>::iterator it = _aliases.begin();
+             it != _aliases.end();
+             ++it)
         {
-          std::string tel_URI = "tel:";
-          std::size_t found = _aliases[i].rfind(tel_URI.c_str(), 4); 
-          if (found!=std::string::npos)
+          std::string tel_URI_prefix = "tel:";
+          bool has_tel_prefix = ((*it).rfind(tel_URI_prefix.c_str(), 4) != std::string::npos); 
+          if (has_tel_prefix)
           {
-            TRC_DEBUG("Add second P-Assered Identity for %s", _aliases[i].c_str());
+            TRC_DEBUG("Add second P-Asserted Identity for %s", (*it).c_str());
             PJUtils::add_asserted_identity(msg,
                                            get_pool(msg),
-                                           _aliases[i],
+                                           *it,
                                            asserted_id->name_addr.display);
             break;
           }

--- a/src/scscfsproutlet.cpp
+++ b/src/scscfsproutlet.cpp
@@ -1830,18 +1830,18 @@ void SCSCFSproutletTsx::add_second_p_a_i_hdr(pjsip_msg* msg)
       }
       else
       {
-        for (std::vector<std::string>::iterator it = _aliases.begin();
-             it != _aliases.end();
-             ++it)
+        for (std::vector<std::string>::iterator alias = _aliases.begin();
+             alias != _aliases.end();
+             ++alias)
         {
           std::string tel_URI_prefix = "tel:";
-          bool has_tel_prefix = ((*it).rfind(tel_URI_prefix.c_str(), 4) != std::string::npos); 
+          bool has_tel_prefix = (it->rfind(tel_URI_prefix.c_str(), 4) != std::string::npos); 
           if (has_tel_prefix)
           {
-            TRC_DEBUG("Add second P-Asserted Identity for %s", (*it).c_str());
+            TRC_DEBUG("Add second P-Asserted Identity for %s",it->c_str());
             PJUtils::add_asserted_identity(msg,
                                            get_pool(msg),
-                                           *it,
+                                           *alias,
                                            asserted_id->name_addr.display);
             break;
           }

--- a/src/scscfsproutlet.cpp
+++ b/src/scscfsproutlet.cpp
@@ -1791,7 +1791,7 @@ void SCSCFSproutletTsx::add_second_p_a_i_hdr(pjsip_msg* msg)
     // header.
     return;
   }
- 
+
   // Look for P-Asserted-Identity header.
   pjsip_routing_hdr* asserted_id =
     (pjsip_routing_hdr*)pjsip_msg_find_hdr_by_name(msg,

--- a/src/scscfsproutlet.cpp
+++ b/src/scscfsproutlet.cpp
@@ -1835,10 +1835,10 @@ void SCSCFSproutletTsx::add_second_p_a_i_hdr(pjsip_msg* msg)
              ++alias)
         {
           std::string tel_URI_prefix = "tel:";
-          bool has_tel_prefix = (it->rfind(tel_URI_prefix.c_str(), 4) != std::string::npos); 
+          bool has_tel_prefix = (alias->rfind(tel_URI_prefix.c_str(), 4) != std::string::npos); 
           if (has_tel_prefix)
           {
-            TRC_DEBUG("Add second P-Asserted Identity for %s",it->c_str());
+            TRC_DEBUG("Add second P-Asserted Identity for %s", alias->c_str());
             PJUtils::add_asserted_identity(msg,
                                            get_pool(msg),
                                            *alias,

--- a/src/scscfsproutlet.cpp
+++ b/src/scscfsproutlet.cpp
@@ -1791,7 +1791,7 @@ void SCSCFSproutletTsx::add_second_p_a_i_hdr(pjsip_msg* msg)
     // header.
     return;
   }
-  
+ 
   // Look for P-Asserted-Identity header.
   pjsip_routing_hdr* asserted_id =
     (pjsip_routing_hdr*)pjsip_msg_find_hdr_by_name(msg,
@@ -1811,9 +1811,10 @@ void SCSCFSproutletTsx::add_second_p_a_i_hdr(pjsip_msg* msg)
     if (PJSIP_URI_SCHEME_IS_SIP(uri))
     {
       // If we have a SIP URI, we add a second P-Asserted-Identity containing a
-      // tel URI if this SIP URI has a tel URI alias. 
+      // tel URI if this SIP URI has a tel URI alias.
       new_p_a_i_str = "tel:";
       new_p_a_i_str += PJUtils::pj_str_to_string(&((pjsip_sip_uri*)uri)->user);
+
       // If the SIP URI has a alias tel URI with the same username we add this
       // tel URI to the P-Asserted-Identity header. If not we select the first
       // tel URI in the alias list to add to the P-Asserted-Identity header.

--- a/src/ut/scscf_test.cpp
+++ b/src/ut/scscf_test.cpp
@@ -7056,6 +7056,25 @@ TEST_F(SCSCFTest, TestAddSecondTelPAIHdr)
   doSuccessfulFlow(msg, testing::MatchesRegex(".*wuntootreefower.*"), hdrs, false);
 }
 
+TEST_F(SCSCFTest, TestAddSecondTelPAIHdriWithAlias)
+{
+  SCOPED_TRACE("");
+  register_uri(_sdm, _hss_connection, "6505551234", "homedomain", "sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob");
+  _hss_connection->set_impu_result("sip:6505551000@homedomain", "call", HSSConnection::STATE_REGISTERED,
+                                   "<IMSSubscription><ServiceProfile>\n"
+                                   "<PublicIdentity><Identity>sip:6505551000@homedomain</Identity></PublicIdentity>"
+                                   "<PublicIdentity><Identity>tel:6505551001</Identity></PublicIdentity>"
+                                   "  <InitialFilterCriteria>\n"
+                                   "  </InitialFilterCriteria>\n"
+                                   "</ServiceProfile></IMSSubscription>");
+  Message msg;
+  msg._route = "Route: <sip:homedomain;orig>";
+  msg._extra = "P-Asserted-Identity: Andy <sip:6505551000@homedomain>";
+  list<HeaderMatcher> hdrs;
+  hdrs.push_back(HeaderMatcher("P-Asserted-Identity", "P-Asserted-Identity: \"Andy\" <sip:6505551000@homedomain>", "P-Asserted-Identity: \"Andy\" <tel:6505551001>"));
+  doSuccessfulFlow(msg, testing::MatchesRegex(".*wuntootreefower.*"), hdrs, false);
+}
+
 TEST_F(SCSCFTest, TestAddSecondSIPPAIHdr)
 {
   SCOPED_TRACE("");
@@ -7063,6 +7082,24 @@ TEST_F(SCSCFTest, TestAddSecondSIPPAIHdr)
   _hss_connection->set_impu_result("tel:6505551000", "call", HSSConnection::STATE_REGISTERED,
                                    "<IMSSubscription><ServiceProfile>\n"
                                    "<PublicIdentity><Identity>sip:6505551000@homedomain</Identity></PublicIdentity>"
+                                   "<PublicIdentity><Identity>tel:6505551000</Identity></PublicIdentity>"
+                                   "  <InitialFilterCriteria>\n"
+                                   "  </InitialFilterCriteria>\n"
+                                   "</ServiceProfile></IMSSubscription>");
+  Message msg;
+  msg._route = "Route: <sip:homedomain;orig>";
+  msg._extra = "P-Asserted-Identity: Andy <tel:6505551000>";
+  list<HeaderMatcher> hdrs;
+  hdrs.push_back(HeaderMatcher("P-Asserted-Identity", "P-Asserted-Identity: \"Andy\" <tel:6505551000>", "P-Asserted-Identity: \"Andy\" <sip:6505551000@homedomain;user=phone>"));
+  doSuccessfulFlow(msg, testing::MatchesRegex(".*wuntootreefower.*"), hdrs, false);
+}
+
+TEST_F(SCSCFTest, TestAddSecondSIPPAIHdrNoSIPUri)
+{
+  SCOPED_TRACE("");
+  register_uri(_sdm, _hss_connection, "6505551234", "homedomain", "sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob");
+  _hss_connection->set_impu_result("tel:6505551000", "call", HSSConnection::STATE_REGISTERED,
+                                   "<IMSSubscription><ServiceProfile>\n"
                                    "<PublicIdentity><Identity>tel:6505551000</Identity></PublicIdentity>"
                                    "  <InitialFilterCriteria>\n"
                                    "  </InitialFilterCriteria>\n"

--- a/src/ut/scscf_test.cpp
+++ b/src/ut/scscf_test.cpp
@@ -7077,7 +7077,7 @@ TEST_F(SCSCFTest, TestAddSecondTelPAIHdrWithAlias)
   doSuccessfulFlow(msg, testing::MatchesRegex(".*wuntootreefower.*"), hdrs, false);
 }
 
-// Checks if we have multiple aliases and non of them matches the SIP URI
+// Checks if we have multiple aliases and none of them matches the SIP URI
 // supplied that we add the first tel URI on the alias list to the
 // P-Asserted-Identity header.
 TEST_F(SCSCFTest, TestAddSecondTelPAIHdrMultipleAliasesNoMatch)

--- a/src/ut/scscf_test.cpp
+++ b/src/ut/scscf_test.cpp
@@ -7056,7 +7056,9 @@ TEST_F(SCSCFTest, TestAddSecondTelPAIHdr)
   doSuccessfulFlow(msg, testing::MatchesRegex(".*wuntootreefower.*"), hdrs, false);
 }
 
-TEST_F(SCSCFTest, TestAddSecondTelPAIHdriWithAlias)
+// Checks that a tel URI alias is added to the P-Asserted-Identity header even
+// when the username is different from the sip URI.
+TEST_F(SCSCFTest, TestAddSecondTelPAIHdrWithAlias)
 {
   SCOPED_TRACE("");
   register_uri(_sdm, _hss_connection, "6505551234", "homedomain", "sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob");
@@ -7075,6 +7077,51 @@ TEST_F(SCSCFTest, TestAddSecondTelPAIHdriWithAlias)
   doSuccessfulFlow(msg, testing::MatchesRegex(".*wuntootreefower.*"), hdrs, false);
 }
 
+// Checks if we have multiple aliases and non of them matches the SIP URI
+// supplied that we add the first tel URI on the alias list to the
+// P-Asserted-Identity header.
+TEST_F(SCSCFTest, TestAddSecondTelPAIHdrMultipleAliasesNoMatch)
+{
+  SCOPED_TRACE("");
+  register_uri(_sdm, _hss_connection, "6505551234", "homedomain", "sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob");
+  _hss_connection->set_impu_result("sip:6505551000@homedomain", "call", HSSConnection::STATE_REGISTERED,
+                                   "<IMSSubscription><ServiceProfile>\n"
+                                   "<PublicIdentity><Identity>sip:6505551000@homedomain</Identity></PublicIdentity>"
+                                   "<PublicIdentity><Identity>tel:6505551003</Identity></PublicIdentity>"
+                                   "<PublicIdentity><Identity>tel:6505551002</Identity></PublicIdentity>"
+                                   "  <InitialFilterCriteria>\n"
+                                   "  </InitialFilterCriteria>\n"
+                                   "</ServiceProfile></IMSSubscription>");
+  Message msg;
+  msg._route = "Route: <sip:homedomain;orig>";
+  msg._extra = "P-Asserted-Identity: Andy <sip:6505551000@homedomain>";
+  list<HeaderMatcher> hdrs;
+  hdrs.push_back(HeaderMatcher("P-Asserted-Identity", "P-Asserted-Identity: \"Andy\" <sip:6505551000@homedomain>", "P-Asserted-Identity: \"Andy\" <tel:6505551003>"));
+  doSuccessfulFlow(msg, testing::MatchesRegex(".*wuntootreefower.*"), hdrs, false);
+}
+
+// Checks if we have multiple aliases and one of them matches the SIP URI
+// supplied that we add the matching alias even if it's not the first on the
+// alias list.
+TEST_F(SCSCFTest, TestAddSecondTelPAIHdrMultipleAliases)
+{
+  SCOPED_TRACE("");
+  register_uri(_sdm, _hss_connection, "6505551234", "homedomain", "sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob");
+  _hss_connection->set_impu_result("sip:6505551000@homedomain", "call", HSSConnection::STATE_REGISTERED,
+                                   "<IMSSubscription><ServiceProfile>\n"
+                                   "<PublicIdentity><Identity>sip:6505551000@homedomain</Identity></PublicIdentity>"
+                                   "<PublicIdentity><Identity>tel:6505551003</Identity></PublicIdentity>"
+                                   "<PublicIdentity><Identity>tel:6505551000</Identity></PublicIdentity>"
+                                   "  <InitialFilterCriteria>\n"
+                                   "  </InitialFilterCriteria>\n"
+                                   "</ServiceProfile></IMSSubscription>");
+  Message msg;
+  msg._route = "Route: <sip:homedomain;orig>";
+  msg._extra = "P-Asserted-Identity: Andy <sip:6505551000@homedomain>";
+  list<HeaderMatcher> hdrs;
+  hdrs.push_back(HeaderMatcher("P-Asserted-Identity", "P-Asserted-Identity: \"Andy\" <sip:6505551000@homedomain>", "P-Asserted-Identity: \"Andy\" <tel:6505551000>"));
+  doSuccessfulFlow(msg, testing::MatchesRegex(".*wuntootreefower.*"), hdrs, false);
+}
 TEST_F(SCSCFTest, TestAddSecondSIPPAIHdr)
 {
   SCOPED_TRACE("");
@@ -7094,6 +7141,8 @@ TEST_F(SCSCFTest, TestAddSecondSIPPAIHdr)
   doSuccessfulFlow(msg, testing::MatchesRegex(".*wuntootreefower.*"), hdrs, false);
 }
 
+// Checks that a matching SIP URI is added to the P-Asserted-Identity header
+// even when there is no alias of the original tel URI.
 TEST_F(SCSCFTest, TestAddSecondSIPPAIHdrNoSIPUri)
 {
   SCOPED_TRACE("");


### PR DESCRIPTION
Fixes iss1267 
https://github.com/Metaswitch/sprout/issues/1267
Instead of only adding a tel URI alias if it matches the user of the SIP URI, we now check if there is a tel URI alias whose username matches the SIP URI. If there is we add it to the P-Asserted-Identity header and if there isn't we add the first tel URI in the alias list.