### PR TITLE
[Reviewer: Adam] Control time in unit tests

### DIFF
--- a/src/ut/siptest.cpp
+++ b/src/ut/siptest.cpp
@@ -84,6 +84,12 @@ SipTest::SipTest(pjsip_module* module) :
   EXPECT_TRUE(_current_instance == NULL) << "Can't run two SipTests in parallel";
   _current_instance = this;
   _module = module;
+
+  // Call cwtest_completely_control_time to freeze time unless explicitly moved
+  // forwards - this prevents spurious failures like, for example, a test taking
+  // 1s longer than expected, getting "expires=299" in a Contact header rather
+  // than "expires=300", and failing the match.
+  cwtest_completely_control_time();
 }
 
 /// Runs after each test.


### PR DESCRIPTION
This takes a slightly scattergun approach of controlling time in all our SIP unit tests, to fix #1324. I can't think of any other tests where this would be useful (it seems that the main offender is SIP registration expiry times, which only Sprout handles, I think), and I can't think of any tests where this is the wrong thing to do (if a test is reliant on time moving forwards, it should do so explicitly with cwtest_advance_time).

I've:
* verified that `make test` still works
* added a `sleep(5)` at the start of `SubscriberDataManager::set_aor_data` to emulate a test taking longer than expected, which makes the test fail (due to an "expires=295") without this change, and pass with this change