### PR TITLE
[Reviewer: Alex] Pass trail ID on deregistration

### DIFF
--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -281,7 +281,7 @@ void AoRTimeoutTask::handle_response()
     if (all_bindings_expired)
     {
       TRC_DEBUG("All bindings have expired based on a Chronos callback - triggering deregistration at the HSS");
-      _cfg->_hss->update_registration_state(_aor_id, "", HSSConnection::DEREG_TIMEOUT, 0);
+      _cfg->_hss->update_registration_state(_aor_id, "", HSSConnection::DEREG_TIMEOUT, trail());
     }
   }
   else


### PR DESCRIPTION
This is a trivial change for #1201.

I think this is actually so trivial that I'm not proposing to test it before merging - I'll merge, then register a client on the VMware system and make it fail (i.e. kill my X-Lite process), and make sure I get a sensible SAS log.