### PR TITLE
[Reviewer Adam] Update sprout to use new uptime infrastructure.

### DIFF
--- a/sprout-base.root/usr/share/clearwater/infrastructure/scripts/sprout.monit
+++ b/sprout-base.root/usr/share/clearwater/infrastructure/scripts/sprout.monit
@@ -51,10 +51,12 @@ check process sprout_process with pidfile /var/run/sprout/sprout.pid
   # generate a core file and trigger diagnostics collection. 
   if memory > 80% for 6 cycles then exec "/bin/bash -c '/usr/share/clearwater/bin/issue_alarm.py monit 1000.3; /etc/init.d/sprout abort'"
 
-  # Clear any alarms if the process has been running for 30 seconds
-  if uptime < 30 seconds
-     then exec "/bin/true"
-     else if succeeded then exec "/usr/share/clearwater/bin/issue_alarm.py monit 1000.1"
+# Clear any alarms if the process has been running long enough.
+check program sprout_uptime with path "/usr/share/clearwater/bin/check-uptime /var/run/sprout/sprout.pid"
+  group sprout
+  depends on sprout_process
+  every 3 cycles
+  if status = 0 then exec "/usr/share/clearwater/bin/issue_alarm.py monit 1000.1"
 
 # Check the SIP/HTTP interfaces. These depend on the Sprout process (and so won't run
 # unless the Sprout process is running)


### PR DESCRIPTION
See clearwater-infrastructure for the new script which this uses.
