### PR TITLE
[Reviewer: Matt] Allow plugins to load on filesystems which don't support readdir

### DIFF
--- a/src/pluginloader.cpp
+++ b/src/pluginloader.cpp
@@ -70,9 +70,14 @@ bool PluginLoader::load(std::list<Sproutlet*>& sproutlets)
     struct dirent *de;
     while ((de = readdir(d)) != NULL)
     {
-      // We don't bother checking the file name as this isn't a reliable
-      // indication that the file is a shared object.
-      // We also don't check the file type - some filesystems like XFS don't support this.
+      // The file name isn't a reliable indication that the file is a shared
+      // object, but checking for a ".so" extension filters out files like "."
+      // and ".." and prevents spurious error logs. If a file isn't a valid
+      // shared object, dlopen will return NULL and we'll log an error.
+      
+      // We don't check the file type as given by de->d_type - this would also
+      // filter out directories like "." and "..", but some filesystems like
+      // XFS don't support this.
       Plugin p;
       p.name = _path + "/";
       p.name.append(de->d_name);


### PR DESCRIPTION
This removes the check on file type for plugins, replacing it with a check for a ".so" extension (just to filter out "." and "..", which otherwise gave spurious error logs).

I've tested by creating a directory, block device and symlink in the pluginsdirectory - dlopen follows the symlink and fails gracefully on the other two.

Fixes #1340 .

```
$ ls -l /usr/share/clearwater/sprout/plugins/
total 588
brw-r--r-- 1 root root  7, 21 Mar  1 14:16 blkdev.so
drwxr-xr-x 2 root root   4096 Mar  1 14:15 directory.so
-rw-r--r-- 1 root root 208288 Mar  1 14:37 sprout_bgcf.so
-rw-r--r-- 1 root root 249536 Mar  1 14:37 sprout_icscf.so
lrwxrwxrwx 1 root root     24 Mar  1 14:43 sprout_mmtel_as.so -> /root/sprout_mmtel_as.so
-rw-r--r-- 1 root root 138744 Mar  1 14:37 sprout_scscf.so
```

```
01-03-2016 14:46:08.649 UTC Status pluginloader.cpp:63: Loading plug-ins from /usr/share/clearwater/sprout/plugins
01-03-2016 14:46:08.649 UTC Status pluginloader.cpp:88: Attempt to load plug-in /usr/share/clearwater/sprout/plugins/blkdev.so
01-03-2016 14:46:08.649 UTC Error pluginloader.cpp:142: Error loading Sproutlet plug-in /usr/share/clearwater/sprout/plugins/blkdev.so - /usr/share/clearwater/sprout/plugins/blkdev.so: file too short
01-03-2016 14:46:08.649 UTC Status pluginloader.cpp:88: Attempt to load plug-in /usr/share/clearwater/sprout/plugins/sprout_bgcf.so
01-03-2016 14:46:08.650 UTC Debug pluginloader.cpp:116: Sproutlet bgcf using API version 1
01-03-2016 14:46:08.650 UTC Status pluginloader.cpp:122: Loaded sproutlet bgcf using API version 1
01-03-2016 14:46:08.650 UTC Debug pluginloader.cpp:84: Skipping /usr/share/clearwater/sprout/plugins/. - doesn't have .so extension
01-03-2016 14:46:08.650 UTC Status pluginloader.cpp:88: Attempt to load plug-in /usr/share/clearwater/sprout/plugins/sprout_mmtel_as.so
01-03-2016 14:46:08.650 UTC Debug pluginloader.cpp:116: Sproutlet mmtel using API version 1
01-03-2016 14:46:08.650 UTC Status pluginloader.cpp:122: Loaded sproutlet mmtel using API version 1
01-03-2016 14:46:08.650 UTC Debug pluginloader.cpp:84: Skipping /usr/share/clearwater/sprout/plugins/.. - doesn't have .so extension
01-03-2016 14:46:08.650 UTC Status pluginloader.cpp:88: Attempt to load plug-in /usr/share/clearwater/sprout/plugins/sprout_icscf.so
01-03-2016 14:46:08.651 UTC Debug pluginloader.cpp:116: Sproutlet icscf using API version 1
01-03-2016 14:46:08.651 UTC Status pluginloader.cpp:122: Loaded sproutlet icscf using API version 1
01-03-2016 14:46:08.651 UTC Status pluginloader.cpp:88: Attempt to load plug-in /usr/share/clearwater/sprout/plugins/sprout_scscf.so
01-03-2016 14:46:08.652 UTC Debug pluginloader.cpp:116: Sproutlet scscf using API version 1
01-03-2016 14:46:08.652 UTC Status pluginloader.cpp:122: Loaded sproutlet scscf using API version 1
01-03-2016 14:46:08.652 UTC Status pluginloader.cpp:88: Attempt to load plug-in /usr/share/clearwater/sprout/plugins/directory.so
01-03-2016 14:46:08.652 UTC Error pluginloader.cpp:142: Error loading Sproutlet plug-in /usr/share/clearwater/sprout/plugins/directory.so - /usr/share/clearwater/sprout/plugins/directory.so: cannot read file data: Is a directory
01-03-2016 14:46:08.652 UTC Status pluginloader.cpp:152: Finished loading plug-ins
```