### PR TITLE
[Reviewer: Alex] Replace a lock with a check for PJSIP transport thread

### DIFF
--- a/debian/bono.init.d
+++ b/debian/bono.init.d
@@ -109,7 +109,6 @@ get_settings()
         # Bono doesn't need multi-threading, so set the number of threads to
         # the number of cores.  The number of PJSIP threads must be 1, as its
         # code is not multi-threadable.
-        num_pjsip_threads=1
         num_worker_threads=$(grep processor /proc/cpuinfo | wc -l)
         log_level=2
         upstream_connections=50
@@ -160,7 +159,6 @@ get_daemon_args()
                      $ralf_arg
                      --sas=$sas_server,$NAME@$public_hostname
                      --dns-server=$signaling_dns_server
-                     --pjsip-threads=$num_pjsip_threads
                      --worker-threads=$num_worker_threads
                      --analytics=$log_directory
                      --log-file=$log_directory

--- a/include/basicproxy.h
+++ b/include/basicproxy.h
@@ -256,7 +256,6 @@ protected:
 
     pj_timer_entry       _trying_timer;
     static const int     TRYING_TIMER = 1;
-    pthread_mutex_t      _trying_timer_lock;
 
     friend class UACTsx;
   };

--- a/include/cfgoptions.h
+++ b/include/cfgoptions.h
@@ -106,7 +106,6 @@ struct options
   std::string                          analytics_directory;
   int                                  reg_max_expires;
   int                                  sub_max_expires;
-  int                                  pjsip_threads;
   std::string                          http_address;
   int                                  http_port;
   int                                  http_threads;

--- a/include/stack.h
+++ b/include/stack.h
@@ -109,7 +109,12 @@ extern struct stack_data_struct stack_data;
 
 inline bool is_pjsip_transport_thread()
 {
+#ifdef UNIT_TEST
+  // This check doesn't make sense in UT, where we use a different threading model
+  return true;
+#else
   return (pj_thread_this() == stack_data.pjsip_transport_thread);
+#endif
 }
 
 #define CHECK_PJ_TRANSPORT_THREAD() \

--- a/include/stack.h
+++ b/include/stack.h
@@ -66,6 +66,7 @@ struct stack_data_struct
   pj_caching_pool      cp;
   pj_pool_t           *pool;
   pjsip_endpoint      *endpt;
+  pj_thread_t         *pjsip_transport_thread;
   int                  pcscf_untrusted_port;
   pjsip_tpfactory     *pcscf_untrusted_tcp_factory;
   int                  pcscf_trusted_port;
@@ -105,6 +106,11 @@ struct stack_data_struct
 };
 
 extern struct stack_data_struct stack_data;
+
+inline bool is_pjsip_transport_thread()
+{
+  return (pj_thread_this() == stack_data.pjsip_transport_thread);
+}
 
 inline void set_trail(pjsip_rx_data* rdata, SAS::TrailId trail)
 {
@@ -153,7 +159,6 @@ extern pj_status_t init_stack(const std::string& sas_system_name,
                               const std::string& scscf_uri,
                               const std::string& alias_hosts,
                               SIPResolver* sipresolver,
-                              int num_pjsip_threads,
                               int record_routing_model,
                               const int default_session_expires,
                               const int max_session_expires,
@@ -161,8 +166,8 @@ extern pj_status_t init_stack(const std::string& sas_system_name,
                               const int sip_tcp_send_timeout,
                               QuiescingManager *quiescing_mgr,
                               const std::string& cdf_domain);
-extern pj_status_t start_pjsip_threads();
-extern pj_status_t stop_pjsip_threads();
+extern pj_status_t start_pjsip_thread();
+extern pj_status_t stop_pjsip_thread();
 extern void stop_stack();
 extern void destroy_stack();
 extern pj_status_t init_pjsip();

--- a/include/stack.h
+++ b/include/stack.h
@@ -112,6 +112,12 @@ inline bool is_pjsip_transport_thread()
   return (pj_thread_this() == stack_data.pjsip_transport_thread);
 }
 
+#define CHECK_PJ_TRANSPORT_THREAD() \
+  if (!is_pjsip_transport_thread()) \
+  { \
+    TRC_ERROR("Function expected to be called on PJSIP transport thread (%s) - has been called on different thread (%s)", pj_thread_get_name(pj_thread_this())); \
+  };
+
 inline void set_trail(pjsip_rx_data* rdata, SAS::TrailId trail)
 {
   rdata->endpt_info.mod_data[stack_data.sas_logging_module_id] = (void*)trail;

--- a/sprout-base.root/etc/init.d/sprout
+++ b/sprout-base.root/etc/init.d/sprout
@@ -105,7 +105,6 @@ get_settings()
 
         # Set up defaults for user settings then pull in any overrides.
         # Sprout uses blocking look-up services, so must run multi-threaded.
-        num_pjsip_threads=1
         num_worker_threads=$(($(grep processor /proc/cpuinfo | wc -l) * 50))
         num_http_threads=$(($(grep processor /proc/cpuinfo | wc -l) * 50))
 
@@ -192,7 +191,6 @@ get_daemon_args()
                      $enum_file_arg
                      --sas=$sas_server,$NAME@$public_hostname
                      --dns-server=$signaling_dns_server
-                     --pjsip-threads=$num_pjsip_threads
                      --worker-threads=$num_worker_threads
                      --http-threads=$num_http_threads
                      --record-routing-model=$sprout_rr_level

--- a/src/basicproxy.cpp
+++ b/src/basicproxy.cpp
@@ -1444,10 +1444,7 @@ void BasicProxy::UASTsx::cancel_trying_timer()
   // We expect to only be called on the PJSIP transport thread, and our data
   // race/locking safety is based on this assumption. Raise an error log if
   // this is not the case.
-  if (!is_pjsip_transport_thread())
-  {
-    TRC_ERROR("Function expected to be called on PJSIP transport thread - has been called on different thread");
-  }
+  CHECK_PJ_TRANSPORT_THREAD();
 
   if (_trying_timer.id == TRYING_TIMER)
   {
@@ -1466,10 +1463,7 @@ void BasicProxy::UASTsx::trying_timer_expired()
   // We expect to only be called on the PJSIP transport thread, and our data
   // race/locking safety is based on this assumption. Raise an error log if
   // this is not the case.
-  if (!is_pjsip_transport_thread())
-  {
-    TRC_ERROR("Function expected to be called on PJSIP transport thread - has been called on different thread");
-  }
+  CHECK_PJ_TRANSPORT_THREAD();
 
   TRC_DEBUG("Trying timer expired for %s, transaction state = %s",
             name(),

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -842,11 +842,6 @@ static pj_status_t init_options(int argc, char* argv[], struct options* options)
       }
       break;
 
-    case 'P':
-      options->pjsip_threads = atoi(pj_optarg);
-      TRC_INFO("Use %d PJSIP threads", options->pjsip_threads);
-      break;
-
     case 'W':
       options->worker_threads = atoi(pj_optarg);
       TRC_INFO("Use %d worker threads", options->worker_threads);
@@ -1386,7 +1381,6 @@ int main(int argc, char* argv[])
   opt.icscf_port = 0;
   opt.sas_server = "0.0.0.0";
   opt.chronos_service = "localhost:7253";
-  opt.pjsip_threads = 1;
   opt.record_routing_model = 1;
   opt.default_session_expires = 10 * 60;
   opt.max_session_expires = 10 * 60;
@@ -1805,7 +1799,6 @@ int main(int argc, char* argv[])
                       opt.scscf_uri,
                       opt.alias_hosts,
                       sip_resolver,
-                      opt.pjsip_threads,
                       opt.record_routing_model,
                       opt.default_session_expires,
                       opt.max_session_expires,
@@ -2201,7 +2194,7 @@ int main(int argc, char* argv[])
     return 1;
   }
 
-  status = start_pjsip_threads();
+  status = start_pjsip_thread();
   if (status != PJ_SUCCESS)
   {
     CL_SPROUT_SIP_STACK_INIT_FAIL.log(PJUtils::pj_status_to_string(status).c_str());
@@ -2263,11 +2256,11 @@ int main(int argc, char* argv[])
     }
   }
 
-  // Terminate the PJSIP threads and the worker threads to exit.  We kill
-  // the PJSIP threads first - if we killed the worker threads first the
+  // Terminate the PJSIP thread and the worker threads to exit.  We kill
+  // the PJSIP thread first - if we killed the worker threads first the
   // rx_msg_q will stop getting serviced so could fill up blocking
-  // PJSIP threads, causing a deadlock.
-  stop_pjsip_threads();
+  // the PJSIP thread, causing a deadlock.
+  stop_pjsip_thread();
   stop_worker_threads();
 
   // We must call stop_stack here because this terminates the

--- a/src/stack.cpp
+++ b/src/stack.cpp
@@ -87,7 +87,6 @@ static StackQuiesceHandler *stack_quiesce_handler = NULL;
 static ConnectionTracker *connection_tracker = NULL;
 
 static volatile pj_bool_t quit_flag;
-static std::vector<pj_thread_t*> pjsip_threads;
 static pj_bool_t on_rx_msg(pjsip_rx_data* rdata);
 
 // Handles updating the connection tracker when requests are received,
@@ -518,23 +517,17 @@ pj_status_t init_pjsip()
   return PJ_SUCCESS;
 }
 
-pj_status_t start_pjsip_threads()
+pj_status_t start_pjsip_thread()
 {
   pj_status_t status = PJ_SUCCESS;
 
-  for (size_t ii = 0; ii < pjsip_threads.size(); ++ii)
+  status = pj_thread_create(stack_data.pool, "pjsip", &pjsip_thread_func,
+                            NULL, 0, 0, &stack_data.pjsip_transport_thread);
+  if (status != PJ_SUCCESS)
   {
-    pj_thread_t* thread;
-
-    status = pj_thread_create(stack_data.pool, "pjsip", &pjsip_thread_func,
-                              NULL, 0, 0, &thread);
-    if (status != PJ_SUCCESS)
-    {
-        TRC_ERROR("Error creating PJSIP thread, %s",
-                  PJUtils::pj_status_to_string(status).c_str());
-        return 1;
-    }
-    pjsip_threads[ii] = thread;
+    TRC_ERROR("Error creating PJSIP thread, %s",
+              PJUtils::pj_status_to_string(status).c_str());
+    return 1;
   }
 
   return PJ_SUCCESS;
@@ -554,7 +547,6 @@ pj_status_t init_stack(const std::string& system_name,
                        const std::string& scscf_uri,
                        const std::string& alias_hosts,
                        SIPResolver* sipresolver,
-                       int num_pjsip_threads,
                        int record_routing_model,
                        const int default_session_expires,
                        const int max_session_expires,
@@ -568,11 +560,6 @@ pj_status_t init_stack(const std::string& system_name,
   pj_sockaddr addr_list[16];
   unsigned addr_cnt = PJ_ARRAY_SIZE(addr_list);
   unsigned i;
-
-  // Set up the vectors of threads.  The threads don't get created until
-  // start_pjsip_threads is called.
-  pjsip_threads.resize(num_pjsip_threads);
-
 
   // Get ports and host names specified on options.  If local host was not
   // specified, use the host name returned by pj_gethostname.
@@ -875,20 +862,16 @@ pj_status_t init_stack(const std::string& system_name,
 }
 
 
-pj_status_t stop_pjsip_threads()
+pj_status_t stop_pjsip_thread()
 {
-  // Set the quit flag to signal the PJSIP threads to exit, then wait
+  // Set the quit flag to signal the PJSIP thread to exit, then wait
   // for them to exit.
   quit_flag = PJ_TRUE;
 
-  for (std::vector<pj_thread_t*>::iterator i = pjsip_threads.begin();
-       i != pjsip_threads.end();
-       ++i)
-  {
-    pj_thread_join(*i);
-  }
+  pj_thread_join(stack_data.pjsip_transport_thread);
 
-  pjsip_threads.clear();
+  stack_data.pjsip_transport_thread = NULL;
+
   return PJ_SUCCESS;
 }
 


### PR DESCRIPTION
This:

* formalises the long-established practice that we can only have one PJSIP transport thread
* adds a function to tell you whether you're on that thread
* changes the SproutletProxy timer functions to check they're on that thread, instead of using a lock

Connection tracking stuff looked more complicated, I'll come and talk to you about that.