### PR TITLE
[Reviewer: Andy] Send ACRs when the registrar rejects a REGISTER. 

### DIFF
--- a/include/acr.h
+++ b/include/acr.h
@@ -54,12 +54,6 @@ extern "C" {
 #include "ralf_processor.h"
 #include "servercaps.h"
 
-typedef enum { SCSCF=0, PCSCF=1, ICSCF=2, BGCF=5, AS=6, IBCF=7 } Node;
-
-typedef enum { CALLED_PARTY=0, CALLING_PARTY=1 } Initiator;
-
-typedef enum { NODE_ROLE_ORIGINATING=0, NODE_ROLE_TERMINATING=1 } NodeRole;
-
 /// Class tracking state required for Rf ACR messages.  An instance of this
 /// class is created for each SIP transaction that requires accounting, and
 /// the class is passed messages and other data during processing of the
@@ -90,6 +84,10 @@ typedef enum { NODE_ROLE_ORIGINATING=0, NODE_ROLE_TERMINATING=1 } NodeRole;
 class ACR
 {
 public:
+  typedef enum { SCSCF=0, PCSCF=1, ICSCF=2, BGCF=5, AS=6, IBCF=7 } Node;
+  typedef enum { CALLED_PARTY=0, CALLING_PARTY=1 } Initiator;
+  typedef enum { NODE_ROLE_ORIGINATING=0, NODE_ROLE_TERMINATING=1 } NodeRole;
+
   /// Unspecified timestamp value.
   static const pj_time_val unspec;
 
@@ -222,7 +220,9 @@ public:
   /// @param trail                SAS trail identifier to use for the ACR.
   /// @param initiator            The initiator of the SIP transaction (calling
   ///                             or called party).
-  virtual ACR* get_acr(SAS::TrailId trail, Initiator initiator, NodeRole role);
+  virtual ACR* get_acr(SAS::TrailId trail,
+                       ACR::Initiator initiator,
+                       ACR::NodeRole role);
 };
 
 
@@ -502,7 +502,7 @@ public:
   ///                             Ralf cluster.
   /// @param node_functionality   Node-Functionality value to set in ACRs.
   RalfACRFactory(RalfProcessor* ralf,
-                 Node node_functionality);
+                 ACR::Node node_functionality);
 
   /// Destructor.
   ~RalfACRFactory();
@@ -513,11 +513,13 @@ public:
   ///                             or called party).
   /// @param role                 The role that this node is playing
   ///                             (originating or terminating).
-  virtual ACR* get_acr(SAS::TrailId trail, Initiator initiator, NodeRole role);
+  virtual ACR* get_acr(SAS::TrailId trail,
+                       ACR::Initiator initiator,
+                       ACR::NodeRole role);
 
 private:
   RalfProcessor* _ralf;
-  Node _node_functionality;
+  ACR::Node _node_functionality;
 };
 
 #endif

--- a/include/pjutils.h
+++ b/include/pjutils.h
@@ -56,6 +56,7 @@ extern "C" {
 #include "sipresolver.h"
 #include "enumservice.h"
 #include "uri_classifier.h"
+#include "acr.h"
 
 namespace PJUtils {
 
@@ -204,17 +205,19 @@ pj_status_t send_request_stateless(pjsip_tx_data* tdata,
 pj_status_t respond_stateless(pjsip_endpoint* endpt,
                               pjsip_rx_data* rdata,
                               int st_code,
-                              const pj_str_t* st_text,
-                              const pjsip_hdr* hdr_list,
-                              const pjsip_msg_body* body);
+                              const pj_str_t* st_text = NULL,
+                              const pjsip_hdr* hdr_list = NULL,
+                              const pjsip_msg_body* body = NULL,
+                              ACR* acr = NULL);
 
 pj_status_t respond_stateful(pjsip_endpoint* endpt,
                              pjsip_transaction* uas_tsx,
                              pjsip_rx_data* rdata,
                              int st_code,
-                             const pj_str_t* st_text,
-                             const pjsip_hdr* hdr_list,
-                             const pjsip_msg_body* body);
+                             const pj_str_t* st_text = NULL,
+                             const pjsip_hdr* hdr_list = NULL,
+                             const pjsip_msg_body* body = NULL,
+                             ACR* acr = NULL);
 
 pjsip_tx_data *clone_tdata(pjsip_tx_data* tdata);
 void clone_header(const pj_str_t* hdr_name, pjsip_msg* old_msg, pjsip_msg* new_msg, pj_pool_t* pool);

--- a/include/scscfsproutlet.h
+++ b/include/scscfsproutlet.h
@@ -155,7 +155,7 @@ private:
   /// @param trail                SAS trail identifier to use for the ACR.
   /// @param initiator            The initiator of the SIP transaction (calling
   ///                             or called party).
-  ACR* get_acr(SAS::TrailId trail, Initiator initiator, NodeRole role);
+  ACR* get_acr(SAS::TrailId trail, ACR::Initiator initiator, ACR::NodeRole role);
 
   friend class SCSCFSproutletTsx;
 
@@ -300,11 +300,13 @@ private:
   /// @param billing_rr   - Whether to add a `billing-role` parameter to the RR
   /// @param billing_role - The contents of the `billing-role` (ignored if
   ///                       `billing_rr` is false)
-  void add_record_route(pjsip_msg* msg, bool billing_rr, NodeRole billing_role);
+  void add_record_route(pjsip_msg* msg,
+                        bool billing_rr,
+                        ACR::NodeRole billing_role);
 
   /// Retrieve the billing role for the incoming message.  This should have been
   /// set during session initiation.
-  NodeRole get_billing_role();
+  ACR::NodeRole get_billing_role();
 
   /// Adds a second P-Asserted-Identity header to a message when required.
   void add_second_p_a_i_hdr(pjsip_msg* msg);

--- a/src/acr.cpp
+++ b/src/acr.cpp
@@ -146,7 +146,9 @@ ACRFactory::~ACRFactory()
 {
 }
 
-ACR* ACRFactory::get_acr(SAS::TrailId trail, Initiator initiator, NodeRole role)
+ACR* ACRFactory::get_acr(SAS::TrailId trail,
+                         ACR::Initiator initiator,
+                         ACR::NodeRole role)
 {
   return new ACR();
 }
@@ -1740,7 +1742,7 @@ std::string RalfACR::hdr_contents(pjsip_hdr* hdr)
 
 /// RalfACRFactory Constructor.
 RalfACRFactory::RalfACRFactory(RalfProcessor* ralf,
-                               Node node_functionality) :
+                               ACR::Node node_functionality) :
   _ralf(ralf),
   _node_functionality(node_functionality)
 {
@@ -1755,8 +1757,8 @@ RalfACRFactory::~RalfACRFactory()
 
 /// Get an RalfACR instance from the factory.
 ACR* RalfACRFactory::get_acr(SAS::TrailId trail,
-                             Initiator initiator,
-                             NodeRole role)
+                             ACR::Initiator initiator,
+                             ACR::NodeRole role)
 {
   TRC_DEBUG("Create RalfACR for node type %s with role %s",
             ACR::node_name(_node_functionality).c_str(),

--- a/src/authentication.cpp
+++ b/src/authentication.cpp
@@ -874,8 +874,8 @@ pj_bool_t authenticate_rx_request(pjsip_rx_data* rdata)
   // Create an ACR for the message and pass the request to it.  Role is always
   // considered originating for a REGISTER request.
   ACR* acr = acr_factory->get_acr(trail,
-                                  CALLING_PARTY,
-                                  NODE_ROLE_ORIGINATING);
+                                  ACR::CALLING_PARTY,
+                                  ACR::NODE_ROLE_ORIGINATING);
   acr->rx_request(rdata->msg_info.msg, rdata->pkt_info.timestamp);
 
   pjsip_tx_data* tdata;

--- a/src/bgcfplugin.cpp
+++ b/src/bgcfplugin.cpp
@@ -89,14 +89,14 @@ bool BGCFPlugin::load(struct options& opt, std::list<Sproutlet*>& sproutlets)
 
     // Create the BGCF ACR factory.
     _acr_factory = (ralf_processor != NULL) ?
-                       (ACRFactory*)new RalfACRFactory(ralf_processor, BGCF) :
+                       (ACRFactory*)new RalfACRFactory(ralf_processor, ACR::BGCF) :
                        new ACRFactory();
 
     // Create the Sproutlet.
-    _bgcf_sproutlet = new BGCFSproutlet(0, 
-                                        _bgcf_service, 
-                                        enum_service, 
-                                        _acr_factory, 
+    _bgcf_sproutlet = new BGCFSproutlet(0,
+                                        _bgcf_service,
+                                        enum_service,
+                                        _acr_factory,
                                         opt.override_npdi);
 
     sproutlets.push_back(_bgcf_sproutlet);

--- a/src/bgcfsproutlet.cpp
+++ b/src/bgcfsproutlet.cpp
@@ -109,7 +109,9 @@ std::vector<std::string> BGCFSproutlet::get_route_from_number(
 /// @param trail                SAS trail identifier to use for the ACR.
 ACR* BGCFSproutlet::get_acr(SAS::TrailId trail)
 {
-  return _acr_factory->get_acr(trail, CALLING_PARTY, NODE_ROLE_TERMINATING);
+  return _acr_factory->get_acr(trail,
+                               ACR::CALLING_PARTY,
+                               ACR::NODE_ROLE_TERMINATING);
 }
 
 /// Individual Tsx constructor.

--- a/src/bono.cpp
+++ b/src/bono.cpp
@@ -241,7 +241,7 @@ static int compare_sip_sc(int sc1, int sc2);
 static pj_status_t add_path(pjsip_tx_data* tdata,
                             const Flow* flow_data,
                             const pjsip_rx_data* rdata);
-static NodeRole acr_node_role(pjsip_msg *req);
+static ACR::NodeRole acr_node_role(pjsip_msg *req);
 
 
 // Utility class that automatically flushes a trail ID when it goes out of
@@ -452,7 +452,7 @@ void process_tsx_request(pjsip_rx_data* rdata)
   assert(target);
 
   acr = cscf_acr_factory->get_acr(get_trail(rdata),
-                                  CALLING_PARTY,
+                                  ACR::CALLING_PARTY,
                                   acr_node_role(rdata->msg_info.msg));
   acr->set_default_ccf(PJUtils::pj_str_to_string(&stack_data.cdf_domain));
 
@@ -664,7 +664,7 @@ void process_cancel_request(pjsip_rx_data* rdata)
 
   // Create and send an ACR for the CANCEL request.
   ACR* acr = cscf_acr_factory->get_acr(get_trail(rdata),
-                                       CALLING_PARTY,
+                                       ACR::CALLING_PARTY,
                                        acr_node_role(rdata->msg_info.msg));
   acr->set_default_ccf(PJUtils::pj_str_to_string(&stack_data.cdf_domain));
   acr->rx_request(rdata->msg_info.msg, rdata->pkt_info.timestamp);
@@ -744,7 +744,7 @@ static void reject_request(pjsip_rx_data* rdata, int status_code)
   pj_status_t status;
 
   ACR* acr = cscf_acr_factory->get_acr(get_trail(rdata),
-                                       CALLING_PARTY,
+                                       ACR::CALLING_PARTY,
                                        acr_node_role(rdata->msg_info.msg));
   acr->set_default_ccf(PJUtils::pj_str_to_string(&stack_data.cdf_domain));
   acr->rx_request(rdata->msg_info.msg, rdata->pkt_info.timestamp);
@@ -1596,9 +1596,9 @@ static pj_status_t proxy_process_routing(pjsip_tx_data *tdata)
 
 /// For a given message, calculate the role the message is requesting the
 /// node carry out.
-static NodeRole acr_node_role(pjsip_msg *req)
+static ACR::NodeRole acr_node_role(pjsip_msg *req)
 {
-  NodeRole role;
+  ACR::NodeRole role;
 
   // Determine whether this an originating or terminating request by looking for
   // the `orig` parameter in the top route header.  REGISTERs, are neither, but
@@ -1611,15 +1611,15 @@ static NodeRole acr_node_role(pjsip_msg *req)
       (pjsip_param_find(&((pjsip_sip_uri*)route_hdr->name_addr.uri)->other_param,
                         &STR_ORIG) != NULL))
   {
-    role = NODE_ROLE_ORIGINATING;
+    role = ACR::NODE_ROLE_ORIGINATING;
   }
   else if (req->line.req.method.id == PJSIP_REGISTER_METHOD)
   {
-    role = NODE_ROLE_ORIGINATING;
+    role = ACR::NODE_ROLE_ORIGINATING;
   }
   else
   {
-    role = NODE_ROLE_TERMINATING;
+    role = ACR::NODE_ROLE_TERMINATING;
   }
 
   return role;

--- a/src/icscfplugin.cpp
+++ b/src/icscfplugin.cpp
@@ -93,7 +93,7 @@ bool ICSCFPlugin::load(struct options& opt, std::list<Sproutlet*>& sproutlets)
 
     // Create the I-CSCF ACR factory.
     _acr_factory = (ralf_processor != NULL) ?
-                        (ACRFactory*)new RalfACRFactory(ralf_processor, ICSCF) :
+                        (ACRFactory*)new RalfACRFactory(ralf_processor, ACR::ICSCF) :
                         new ACRFactory();
 
     // Create the I-CSCF sproutlet.
@@ -105,7 +105,7 @@ bool ICSCFPlugin::load(struct options& opt, std::list<Sproutlet*>& sproutlets)
                                           enum_service,
                                           opt.override_npdi);
     _icscf_sproutlet->init();
-    
+
     sproutlets.push_back(_icscf_sproutlet);
   }
 

--- a/src/icscfsproutlet.cpp
+++ b/src/icscfsproutlet.cpp
@@ -132,7 +132,9 @@ SproutletTsx* ICSCFSproutlet::get_tsx(SproutletTsxHelper* helper,
 /// @param trail                SAS trail identifier to use for the ACR.
 ACR* ICSCFSproutlet::get_acr(SAS::TrailId trail)
 {
-  return _acr_factory->get_acr(trail, CALLING_PARTY, NODE_ROLE_TERMINATING);
+  return _acr_factory->get_acr(trail,
+                               ACR::CALLING_PARTY,
+                               ACR::NODE_ROLE_TERMINATING);
 }
 
 /// Translates a Tel URI to a SIP URI (if ENUM is enabled).

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1090,7 +1090,7 @@ static pj_status_t init_options(int argc, char* argv[], struct options* options)
       }
       break;
 
- 
+
     case 'h':
       usage();
       return -1;
@@ -1493,7 +1493,7 @@ int main(int argc, char* argv[])
     closelog();
     return 1;
   }
-  
+
   if (opt.pidfile != "")
   {
     int rc = Utils::lock_and_write_pidfile(opt.pidfile);
@@ -1923,7 +1923,7 @@ int main(int argc, char* argv[])
   {
     // Create an ACR factory for the P-CSCF.
     pcscf_acr_factory = (ralf_processor != NULL) ?
-                (ACRFactory*)new RalfACRFactory(ralf_processor, PCSCF) :
+                (ACRFactory*)new RalfACRFactory(ralf_processor, ACR::PCSCF) :
                 new ACRFactory();
 
     // Launch stateful proxy as P-CSCF.
@@ -1975,7 +1975,7 @@ int main(int argc, char* argv[])
   if (opt.scscf_enabled)
   {
     scscf_acr_factory = (ralf_processor != NULL) ?
-                      (ACRFactory*)new RalfACRFactory(ralf_processor, SCSCF) :
+                      (ACRFactory*)new RalfACRFactory(ralf_processor, ACR::SCSCF) :
                       new ACRFactory();
 
     if (opt.store_servers != "")

--- a/src/pjutils.cpp
+++ b/src/pjutils.cpp
@@ -1394,7 +1394,8 @@ pj_status_t PJUtils::respond_stateless(pjsip_endpoint* endpt,
                                        int st_code,
                                        const pj_str_t* st_text,
                                        const pjsip_hdr* hdr_list,
-                                       const pjsip_msg_body* body)
+                                       const pjsip_msg_body* body,
+                                       ACR* acr)
 {
   pj_status_t status;
   pjsip_response_addr res_addr;
@@ -1437,6 +1438,12 @@ pj_status_t PJUtils::respond_stateless(pjsip_endpoint* endpt,
     return status;
   }
 
+  // Show the response to the ACR if we have one.
+  if (acr != NULL)
+  {
+    acr->tx_response(tdata->msg);
+  }
+
   // Send!
   status = pjsip_endpt_send_response(endpt, &res_addr, tdata, NULL, NULL);
   if (status != PJ_SUCCESS)
@@ -1458,7 +1465,8 @@ pj_status_t PJUtils::respond_stateful(pjsip_endpoint* endpt,
                                       int st_code,
                                       const pj_str_t* st_text,
                                       const pjsip_hdr* hdr_list,
-                                      const pjsip_msg_body* body)
+                                      const pjsip_msg_body* body,
+                                      ACR* acr)
 {
   pj_status_t status;
   pjsip_tx_data* tdata;
@@ -1490,6 +1498,12 @@ pj_status_t PJUtils::respond_stateful(pjsip_endpoint* endpt,
       pjsip_tx_data_dec_ref(tdata);
       return status;
     }
+  }
+
+  // Show the response to the ACR if we have one.
+  if (acr != NULL)
+  {
+    acr->tx_response(tdata->msg);
   }
 
   status = pjsip_tsx_send_msg(uas_tsx, tdata);

--- a/src/subscription.cpp
+++ b/src/subscription.cpp
@@ -435,8 +435,8 @@ void process_subscription_request(pjsip_rx_data* rdata)
   // Create an ACR for the request.  The node role is always considered
   // originating for SUBSCRIBE requests.
   ACR* acr = acr_factory->get_acr(get_trail(rdata),
-                                  CALLING_PARTY,
-                                  NODE_ROLE_ORIGINATING);
+                                  ACR::CALLING_PARTY,
+                                  ACR::NODE_ROLE_ORIGINATING);
   acr->rx_request(rdata->msg_info.msg, rdata->pkt_info.timestamp);
 
   // Canonicalize the public ID from the URI in the To header.

--- a/src/ut/acr_test.cpp
+++ b/src/ut/acr_test.cpp
@@ -271,10 +271,10 @@ TEST_F(ACRTest, SCSCFRegister)
   std::string acr_message;
 
   // Create a Ralf ACR factory for S-CSCF ACRs.
-  RalfACRFactory f(NULL, SCSCF);
+  RalfACRFactory f(NULL, ACR::SCSCF);
 
   // Create an ACR instance for the ACR[EVENT] triggered by the REGISTER.
-  acr = f.get_acr(0, CALLING_PARTY, NODE_ROLE_ORIGINATING);
+  acr = f.get_acr(0, ACR::CALLING_PARTY, ACR::NODE_ROLE_ORIGINATING);
 
   // Build the original REGISTER request.
   SIPRequest reg("REGISTER");
@@ -316,10 +316,10 @@ TEST_F(ACRTest, CancelledACR)
   std::string acr_message;
 
   // Create a Ralf ACR factory for S-CSCF ACRs.
-  RalfACRFactory f(NULL, SCSCF);
+  RalfACRFactory f(NULL, ACR::SCSCF);
 
   // Create an ACR instance for the ACR[EVENT] triggered by the REGISTER.
-  acr = f.get_acr(0, CALLING_PARTY, NODE_ROLE_ORIGINATING);
+  acr = f.get_acr(0, ACR::CALLING_PARTY, ACR::NODE_ROLE_ORIGINATING);
 
   // Build the original REGISTER request.
   SIPRequest reg("REGISTER");
@@ -352,10 +352,10 @@ TEST_F(ACRTest, SCSCFOrigCall)
   std::string acr_message;
 
   // Create a Ralf ACR factory for S-CSCF ACRs.
-  RalfACRFactory f(NULL, SCSCF);
+  RalfACRFactory f(NULL, ACR::SCSCF);
 
   // Create an ACR instance for the ACR[START] triggered by the INVITE.
-  acr = f.get_acr(0, CALLING_PARTY, NODE_ROLE_ORIGINATING);
+  acr = f.get_acr(0, ACR::CALLING_PARTY, ACR::NODE_ROLE_ORIGINATING);
 
   // Build the original INVITE request.
   SIPRequest invite("INVITE");
@@ -595,7 +595,7 @@ TEST_F(ACRTest, SCSCFOrigCall)
   delete acr;
 
   // Create an ACR instance for the ACR[INTERIM] triggered by a reINVITE.
-  acr = f.get_acr(0, CALLING_PARTY, NODE_ROLE_ORIGINATING);
+  acr = f.get_acr(0, ACR::CALLING_PARTY, ACR::NODE_ROLE_ORIGINATING);
 
   // Build the reINVITE request.
   SIPRequest reinvite("INVITE");
@@ -634,7 +634,7 @@ TEST_F(ACRTest, SCSCFOrigCall)
   delete acr;
 
   // Create an ACR instance for the ACR[STOP] triggered by a BYE.
-  acr = f.get_acr(0, CALLING_PARTY, NODE_ROLE_ORIGINATING);
+  acr = f.get_acr(0, ACR::CALLING_PARTY, ACR::NODE_ROLE_ORIGINATING);
 
   // Build the BYE request.
   SIPRequest bye("BYE");
@@ -682,10 +682,10 @@ TEST_F(ACRTest, SCSCFTermCall)
   std::string acr_message;
 
   // Create a Ralf ACR factory for S-CSCF ACRs.
-  RalfACRFactory f(NULL, SCSCF);
+  RalfACRFactory f(NULL, ACR::SCSCF);
 
   // Create an ACR instance for the test.
-  acr = f.get_acr(0, CALLING_PARTY, NODE_ROLE_TERMINATING);
+  acr = f.get_acr(0, ACR::CALLING_PARTY, ACR::NODE_ROLE_TERMINATING);
 
   // Build the original INVITE request.
   SIPRequest invite("INVITE");
@@ -928,7 +928,7 @@ TEST_F(ACRTest, SCSCFTermCall)
   delete acr;
 
   // Create an ACR instance for the ACR[INTERIM] triggered by a reINVITE.
-  acr = f.get_acr(0, CALLING_PARTY, NODE_ROLE_TERMINATING);
+  acr = f.get_acr(0, ACR::CALLING_PARTY, ACR::NODE_ROLE_TERMINATING);
 
   // Build the reINVITE request.
   SIPRequest reinvite("INVITE");
@@ -967,7 +967,7 @@ TEST_F(ACRTest, SCSCFTermCall)
   delete acr;
 
   // Create an ACR instance for the ACR[STOP] triggered by a BYE.
-  acr = f.get_acr(0, CALLING_PARTY, NODE_ROLE_TERMINATING);
+  acr = f.get_acr(0, ACR::CALLING_PARTY, ACR::NODE_ROLE_TERMINATING);
 
   // Build the BYE request.
   SIPRequest bye("BYE");
@@ -1015,10 +1015,10 @@ TEST_F(ACRTest, ICSCFRegister)
   std::string acr_message;
 
   // Create a Ralf ACR factory for I-CSCF ACRs.
-  RalfACRFactory f(NULL, ICSCF);
+  RalfACRFactory f(NULL, ACR::ICSCF);
 
   // Create an ACR instance for the ACR[EVENT] triggered by the REGISTER.
-  acr = f.get_acr(0, CALLING_PARTY, NODE_ROLE_ORIGINATING);
+  acr = f.get_acr(0, ACR::CALLING_PARTY, ACR::NODE_ROLE_ORIGINATING);
 
   // Build the original REGISTER request.
   SIPRequest reg("REGISTER");
@@ -1080,10 +1080,10 @@ TEST_F(ACRTest, SCSCFPublish)
   std::string acr_message;
 
   // Create a Ralf ACR factory for S-CSCF ACRs.
-  RalfACRFactory f(NULL, SCSCF);
+  RalfACRFactory f(NULL, ACR::SCSCF);
 
   // Create an ACR instance for the ACR[EVENT] triggered by the REGISTER.
-  acr = f.get_acr(0, CALLING_PARTY, NODE_ROLE_ORIGINATING);
+  acr = f.get_acr(0, ACR::CALLING_PARTY, ACR::NODE_ROLE_ORIGINATING);
 
   // Build the original REGISTER request.
   SIPRequest pub("PUBLISH");
@@ -1125,10 +1125,10 @@ TEST_F(ACRTest, SCSCFTermChangeCallId)
   std::string acr_message;
 
   // Create a Ralf ACR factory for S-CSCF ACRs.
-  RalfACRFactory f(NULL, SCSCF);
+  RalfACRFactory f(NULL, ACR::SCSCF);
 
   // Create an ACR instance for the test.
-  acr = f.get_acr(0, CALLING_PARTY, NODE_ROLE_TERMINATING);
+  acr = f.get_acr(0, ACR::CALLING_PARTY, ACR::NODE_ROLE_TERMINATING);
 
   // Build the original INVITE request.
   SIPRequest invite("INVITE");


### PR DESCRIPTION
Andy, please can you review this PR to make sure the registrar sends ACRs even when it rejects REGISTERs. This contains a big refactor to move some enums into the `ACR` class to avoid them polluting the namespace (I started to hit this because I included `acr.h` in `pjutils.h` and found some places where some identifiers defined in `acr.h` conflicted with identifiers in cpp files). 

I haven't unit tested this due to https://github.com/Metaswitch/sprout/issues/1347. I have checked the existing UTs work.

This is surprisingly difficult to live test as its difficult to get a REGISTER to fail in the registrar without also having it fail earlier on. In the end I run the following testcase:

* Set up deployment to not use an I-CSCF. 
* Send REGISTER, receive 401. 
* Kill homestead. 
* Send REGISTER, receive rejection from the registrar (jn this case a 403). 

This gave me two ACRs (one for the REGISTER/401 from the authentication module, the other for the REGISTER/403 from the registrar). Here's the second ACR:

```javascript
{"peers":{"ccf":["cdf.ajh1.cw-ngv.com"]},"event":{"Accounting-Record-Type":1,"User-Name":"3010000839@ajh1.cw-ngv.com","Event-Timestamp":1458043857,"Service-Information":{"Subscription-Id":[{"Subscription-Id-Type":2,"Subscription-Id-Data":"sip:3010000839@ajh1.cw-ngv.com"}],"IMS-Information":{"Event-Type":{"SIP-Method":"REGISTER","Expires":3600},"Role-Of-Node":0,"Node-Functionality":0,"User-Session-Id":"3fa769708ec3f9907f5283930cbe05fa","Called-Party-Address":"sip:3010000839@ajh1.cw-ngv.com","Time-Stamps":{"SIP-Request-Timestamp":1458043857,"SIP-Request-Timestamp-Fraction":817,"SIP-Response-Timestamp":1458043857,"SIP-Response-Timestamp-Fraction":820},"IMS-Charging-Identifier":"3fa769708ec3f9907f5283930cbe05fa","Cause-Code":403,"From-Address":"<sip:3010000839@ajh1.cw-ngv.com>;tag=7c8297cbe2219c2f1675b1394f887ac6","IMS-Visited-Network-Identifier":"ajh1.cw-ngv.com","Route-Header-Received":"<sip:sprout.ajh1.cw-ngv.com:5054;transport=TCP;lr;orig>","Instance-Id":"<urn:uuid:30d86d6f-d52c-59d2-b678-1182f3c65fbb>"}}}}
```

This ACR looks sensible to me - note in particular that the cause code is correctly reported as 403. 

I haven't been able to test all the other cases where we reject a REGISTER, but hopefully this testcase is convincing enough that the approach I've taken works. 