### PR TITLE
[Reviewer: None] Use updated check-uptime script.

### DIFF
--- a/sprout-base.root/usr/share/clearwater/infrastructure/scripts/sprout.monit
+++ b/sprout-base.root/usr/share/clearwater/infrastructure/scripts/sprout.monit
@@ -48,15 +48,15 @@ check process sprout_process with pidfile /var/run/sprout/sprout.pid
   restart program = "/bin/bash -c '/usr/share/clearwater/bin/issue_alarm.py monit 1000.3; /etc/init.d/sprout restart'"
 
   # Check the service's resource usage, and abort the process if it's too high. This will
-  # generate a core file and trigger diagnostics collection. 
+  # generate a core file and trigger diagnostics collection.
   if memory > 80% for 6 cycles then exec "/bin/bash -c '/usr/share/clearwater/bin/issue_alarm.py monit 1000.3; /etc/init.d/sprout abort'"
 
 # Clear any alarms if the process has been running long enough.
-check program sprout_uptime with path "/usr/share/clearwater/bin/check-uptime /var/run/sprout/sprout.pid"
+check program sprout_uptime with path "/usr/share/clearwater/bin/check-uptime /var/run/sprout/sprout.pid monit 1000.1"
   group sprout
   depends on sprout_process
   every 3 cycles
-  if status = 0 then exec "/usr/share/clearwater/bin/issue_alarm.py monit 1000.1"
+  if status != 0 then alert
 
 # Check the SIP/HTTP interfaces. These depend on the Sprout process (and so won't run
 # unless the Sprout process is running)


### PR DESCRIPTION
Use check-uptime to clear alarms and avoid suprious monit failures.