### PR TITLE
[Reviewer: Rob] AS alarms

### DIFF
--- a/include/as_communication_tracker.h
+++ b/include/as_communication_tracker.h
@@ -57,8 +57,8 @@ public:
   ///
   /// The object takes ownership of the alarm and the logs passed to it.
   AsCommunicationTracker(Alarm* alarm,
-                         PDLog1<const char*>* as_failed_log,
-                         PDLog1<const char*>* as_ok_log);
+                         const PDLog1<const char*>* as_failed_log,
+                         const PDLog1<const char*>* as_ok_log);
 
   /// Destructor.
   virtual ~AsCommunicationTracker();
@@ -96,8 +96,8 @@ private:
   // and when they are considered to be OK.
   //
   // Each log takes the URI of the AS as a parameter.
-  PDLog1<const char*>* _as_failed_log;
-  PDLog1<const char*>* _as_ok_log;
+  const PDLog1<const char*>* _as_failed_log;
+  const PDLog1<const char*>* _as_ok_log;
 
   /// Check if any application servers are healthy. If so, log them and
   /// consider clearing the alarm.

--- a/include/as_communication_tracker.h
+++ b/include/as_communication_tracker.h
@@ -1,0 +1,111 @@
+/**
+ * @file as_communication_tracker.h
+ *
+ * Project Clearwater - IMS in the Cloud
+ * Copyright (C) 2016  Metaswitch Networks Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version, along with the "Special Exception" for use of
+ * the program along with SSL, set forth below. This program is distributed
+ * in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * The author can be reached by email at clearwater@metaswitch.com or by
+ * post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+ *
+ * Special Exception
+ * Metaswitch Networks Ltd  grants you permission to copy, modify,
+ * propagate, and distribute a work formed by combining OpenSSL with The
+ * Software, or a work derivative of such a combination, even if such
+ * copying, modification, propagation, or distribution would otherwise
+ * violate the terms of the GPL. You must comply with the GPL in all
+ * respects for all of the code used other than OpenSSL.
+ * "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+ * Project and licensed under the OpenSSL Licenses, or a work based on such
+ * software and licensed under the OpenSSL Licenses.
+ * "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+ * under which the OpenSSL Project distributes the OpenSSL toolkit software,
+ * as those licenses appear in the file LICENSE-OPENSSL.
+ */
+
+#include <map>
+#include <string>
+
+#include "pdlog.h"
+#include "alarm.h"
+
+#ifndef AS_COMMUNICATION_TRACKER_H__
+#define AS_COMMUNICATION_TRACKER_H__
+
+class AsCommunicationTracker
+{
+public:
+  /// Constructor.
+  ///
+  /// @param alarm         - The alarm to raise when AS communication is not
+  ///                        working correctly.
+  /// @param as_failed_log - The log to generate when communication to an AS
+  ///                        has started to fail.
+  /// @param as_ok_log     - The log to generate when communication to an AS
+  ///                        has started succeeding again.
+  ///
+  /// The object takes ownership of the alarm and the logs passed to it.
+  AsCommunicationTracker(Alarm* alarm,
+                         PDLog1<const char*>* as_failed_log,
+                         PDLog1<const char*>* as_ok_log);
+
+  /// Destructor.
+  virtual ~AsCommunicationTracker();
+
+  /// Method to be called when communication to an Application Server succeeds.
+  ///
+  /// @param as_uri - The URI of the AS in question.
+  virtual void on_success(const std::string& as_uri);
+
+  /// Method to be called when communication to an Application Server fails.
+  ///
+  /// @param as_uri - The URI of the AS in question.
+  virtual void on_failure(const std::string& as_uri);
+
+private:
+  // A lock that protects all member variables of this class.
+  pthread_mutex_t _lock;
+
+  // A count of how many times we have had a communication failure to each AS
+  // in the last time period.
+  std::map<std::string, int> _as_failures;
+
+  // The time (in ms since the epoch) at which we should check the _as_failures
+  // to determine if some ASs are now OK again.
+  uint64_t _next_check_time_ms;
+
+  // The length of time that must pass between checks of _as_failures.
+  const static uint64_t NEXT_CHECK_INTERVAL_MS = 5 * 60 * 1000;
+
+  // The alarm to raise when communication to some Application Servers is
+  // failing.
+  Alarm* _alarm;
+
+  // Logs that are raised when communications are considered to have failed,
+  // and when they are considered to be OK.
+  //
+  // Each log takes the URI of the AS as a parameter.
+  PDLog1<const char*>* _as_failed_log;
+  PDLog1<const char*>* _as_ok_log;
+
+  /// Check if any application servers are healthy. If so, log them and
+  /// consider clearing the alarm.
+  void check_for_healthy_app_servers();
+
+  /// @return The current monotonic time in ms. Note that this is not wall time!
+  uint64_t current_time_ms();
+};
+
+#endif
+

--- a/include/as_communication_tracker.h
+++ b/include/as_communication_tracker.h
@@ -83,7 +83,7 @@ private:
 
   // The time (in ms since the epoch) at which we should check the _as_failures
   // to determine if some ASs are now OK again.
-  uint64_t _next_check_time_ms;
+  std::atomic<uint64_t> _next_check_time_ms;
 
   // The length of time that must pass between checks of _as_failures.
   const static uint64_t NEXT_CHECK_INTERVAL_MS = 5 * 60 * 1000;
@@ -104,7 +104,7 @@ private:
   void check_for_healthy_app_servers();
 
   /// @return The current monotonic time in ms. Note that this is not wall time!
-  uint64_t current_time_ms();
+  static uint64_t current_time_ms();
 };
 
 #endif

--- a/include/as_communication_tracker.h
+++ b/include/as_communication_tracker.h
@@ -40,8 +40,8 @@
 #include "pdlog.h"
 #include "alarm.h"
 
-#ifndef AS_COMMUNICATION_TRACKER_H__
-#define AS_COMMUNICATION_TRACKER_H__
+#ifndef AS_COMMUNICATION_TRACKER_H_
+#define AS_COMMUNICATION_TRACKER_H_
 
 class AsCommunicationTracker
 {

--- a/include/aschain.h
+++ b/include/aschain.h
@@ -289,11 +289,10 @@ public:
     return _as_chain->_odi_tokens[_index + 1];
   }
 
-  /// Returns whether or not processing of the AS chain should continue on
-  /// a timeout or 5xx error from the AS.
-  bool continue_session() const
+  /// Returns whether the AS is responsive.
+  bool responsive() const
   {
-    return (_default_handling == SESSION_CONTINUED) && (!_as_chain->_responsive[_index]);
+    return _as_chain->_responsive[_index];
   }
 
   /// Returns the default handling for this AS chain link.

--- a/include/aschain.h
+++ b/include/aschain.h
@@ -339,6 +339,12 @@ public:
     _interrupted = true;
   }
 
+  /// @return The URI of the AS associated with this AS chain.
+  std::string uri()
+  {
+    return is_set() ? _as_chain->_as_info[_index].as_uri : "";
+  }
+
 private:
   friend class AsChainTable;
 

--- a/include/aschain.h
+++ b/include/aschain.h
@@ -296,6 +296,12 @@ public:
     return (_default_handling == SESSION_CONTINUED) && (!_as_chain->_responsive[_index]);
   }
 
+  /// Returns the default handling for this AS chain link.
+  DefaultHandling default_handling()
+  {
+    return _default_handling;
+  }
+
   /// Called on receipt of each response from the AS.
   void on_response(int status_code);
 

--- a/include/scscfsproutlet.h
+++ b/include/scscfsproutlet.h
@@ -151,6 +151,20 @@ private:
                      std::deque<std::string>& ecfs,
                      SAS::TrailId trail);
 
+  /// Record that communication with an AS failed.
+  ///
+  /// @param uri               - The URI of the AS.
+  /// @param session_continued - Whether the AS uses session continued default
+  ///                            handling (true) or session terminated (false).
+  void track_app_serv_comm_failure(const std::string& uri, bool session_continued);
+
+  /// Record that communication with an AS succeeded.
+  ///
+  /// @param uri               - The URI of the AS.
+  /// @param session_continued - Whether the AS uses session continued default
+  ///                            handling (true) or session terminated (false).
+  void track_app_serv_comm_success(const std::string& uri, bool session_continued);
+
   /// Translate RequestURI using ENUM service if appropriate.
   void translate_request_uri(pjsip_msg* req, pj_pool_t* pool, SAS::TrailId trail);
 

--- a/include/scscfsproutlet.h
+++ b/include/scscfsproutlet.h
@@ -66,6 +66,7 @@ extern "C" {
 #include "sproutlet.h"
 #include "snmp_counter_table.h"
 #include "session_expires_helper.h"
+#include "as_communication_tracker.h"
 
 class SCSCFSproutletTsx;
 
@@ -87,7 +88,9 @@ public:
                  ACRFactory* acr_factory,
                  bool override_npdi,
                  int session_continued_timeout = DEFAULT_SESSION_CONTINUED_TIMEOUT,
-                 int session_terminated_timeout = DEFAULT_SESSION_TERMINATED_TIMEOUT);
+                 int session_terminated_timeout = DEFAULT_SESSION_TERMINATED_TIMEOUT,
+                 AsCommunicationTracker* sess_term_as_tracker = NULL,
+                 AsCommunicationTracker* sess_cont_as_tracker = NULL);
   ~SCSCFSproutlet();
 
   bool init();
@@ -199,6 +202,9 @@ private:
   SNMP::CounterTable* _routed_by_preloaded_route_tbl = NULL;
   SNMP::CounterTable* _invites_cancelled_before_1xx_tbl = NULL;
   SNMP::CounterTable* _invites_cancelled_after_1xx_tbl = NULL;
+
+  AsCommunicationTracker* _sess_term_as_tracker;
+  AsCommunicationTracker* _sess_cont_as_tracker;
 };
 
 

--- a/include/scscfsproutlet.h
+++ b/include/scscfsproutlet.h
@@ -154,16 +154,16 @@ private:
   /// Record that communication with an AS failed.
   ///
   /// @param uri               - The URI of the AS.
-  /// @param session_continued - Whether the AS uses session continued default
-  ///                            handling (true) or session terminated (false).
-  void track_app_serv_comm_failure(const std::string& uri, bool session_continued);
+  /// @param default_handling  - The AS's default handling.
+  void track_app_serv_comm_failure(const std::string& uri,
+                                   DefaultHandling default_handling);
 
   /// Record that communication with an AS succeeded.
   ///
   /// @param uri               - The URI of the AS.
-  /// @param session_continued - Whether the AS uses session continued default
-  ///                            handling (true) or session terminated (false).
-  void track_app_serv_comm_success(const std::string& uri, bool session_continued);
+  /// @param default_handling  - The AS's default handling.
+  void track_app_serv_comm_success(const std::string& uri,
+                                   DefaultHandling default_handling);
 
   /// Translate RequestURI using ENUM service if appropriate.
   void translate_request_uri(pjsip_msg* req, pj_pool_t* pool, SAS::TrailId trail);
@@ -396,6 +396,10 @@ private:
   /// correct stats can be updated.
   pjsip_method_e _req_type;
   bool _seen_1xx;
+
+  // Track whether any response has been seen from the AS. Primarily used for
+  // default handling processing.
+  bool _seen_response;
 
   static const int MAX_FORKING = 10;
 

--- a/include/sprout_pd_definitions.h
+++ b/include/sprout_pd_definitions.h
@@ -45,14 +45,14 @@
 
 // The fields for each PDLog instance contains:
 //   Identity - Identifies the log id to be used in the syslog id field.
-//   Severity - One of Emergency, Alert, Critical, Error, Warning, Notice, 
+//   Severity - One of Emergency, Alert, Critical, Error, Warning, Notice,
 //              and Info.  Directly corresponds to the syslog severity types.
-//              Only PDLOG_ERROR or PDLOG_NOTICE are used.  
+//              Only PDLOG_ERROR or PDLOG_NOTICE are used.
 //              See syslog_facade.h for definitions.
 //   Message  - Formatted description of the condition.
 //   Cause    - The cause of the condition.
 //   Effect   - The effect the condition.
-//   Action   - A list of one or more actions to take to resolve the condition 
+//   Action   - A list of one or more actions to take to resolve the condition
 //              if it is an error.
 static const PDLog1<const char*> CL_SPROUT_INVALID_S_CSCF_PORT
 (
@@ -170,7 +170,7 @@ static const PDLog1<const char*> CL_SPROUT_SIP_INIT_INTERFACE_FAIL
   "The application will exit and restart until the problem is fixed.",
   "(1). Check the /etc/clearwater/config configuration."
   "(2). Check the /etc/clearwater/user_settings configuration."
-  "(3). Check the network configuration and status." 
+  "(3). Check the network configuration and status."
 );
 
 static const PDLog CL_SPROUT_NO_RALF_CONFIGURED
@@ -256,7 +256,7 @@ static const PDLog2<const char*, int> CL_SPROUT_HTTP_INTERFACE_FAIL
   "An HTTP interface failed to initialize or start in %s with error %d.",
   "An HTTP interface has failed initialization.",
   "The application will exit and restart until the problem is fixed.",
-  "Check the network status and configuration." 
+  "Check the network status and configuration."
 );
 
 static const PDLog CL_SPROUT_ENDED
@@ -506,8 +506,48 @@ static const PDLog CL_SPROUT_BGCF_FILE_INVALID
   PDLOG_ERR,
   "The file listing BGCF routes is not present or empty.",
   "The /etc/clearwater/bgcf.json file, defining which BGCF routes to use, is not valid (due to invalid JSON or missing elements).",
-  "Sprout will not be able to route some or all calls outside the local deployment.", 
+  "Sprout will not be able to route some or all calls outside the local deployment.",
   "If you are expecting to route calls off-net, follow the documentation to create routes in /etc/clearwater/bgcf.json. Otherwise, delete this file."
+);
+
+static const PDLog1<const char *> CL_SPROUT_SESS_TERM_AS_COMM_FAILURE
+(
+  PDLogBase::CL_SPROUT_ID + 48,
+  PDLOG_ERR,
+  "Sprout is currently unable to successfully communicate with an Application Server that uses session terminated default handling. The server's URI is: %s",
+  "Communication is failing to an Application Server",
+  "Probable major loss of service. The precise impact will vary depending on the role of this Application Server.",
+  "Investigate why communication to this Application Server is failing. It might be due to failure of the AS, misconfiguration of Initial Filter Criteria, or network / DNS problems"
+);
+
+static const PDLog1<const char *> CL_SPROUT_SESS_TERM_AS_COMM_SUCCESS
+(
+  PDLogBase::CL_SPROUT_ID + 49,
+  PDLOG_NOTICE,
+  "Sprout is able to successfully communicate with an Application Server that uses session terminated default handling. ",
+  "Communication has been restored to an Application Server",
+  "Full service has been restored.",
+  "No action"
+);
+
+static const PDLog1<const char *> CL_SPROUT_SESS_CONT_AS_COMM_FAILURE
+(
+  PDLogBase::CL_SPROUT_ID + 50,
+  PDLOG_ERR,
+  "Sprout is currently unable to successfully communicate with an Application Server that uses session continued default handling. The server's URI is %s",
+  "Communication is failing to <URI>",
+  "Probable minor degradation of service, or loss of a supplemental service. The precise impact will vary depending on the role of the Application Server in the deployment.",
+  "Investigate why communication to this Application Server is failing. It might be due to failure of the AS, misconfiguration of Initial Filter Criteria, or network / DNS problems"
+);
+
+static const PDLog1<const char *> CL_SPROUT_SESS_CONT_AS_COMM_SUCCESS
+(
+  PDLogBase::CL_SPROUT_ID + 51,
+  PDLOG_NOTICE,
+  "Sprout is able to successfully communicate with an Application Server that uses session continued default handling.",
+  "Communication has been restored to an Application Server",
+  "Full service has been restored.",
+  "No action"
 );
 
 #endif

--- a/sprout-base.root/usr/share/clearwater/infrastructure/alarms/sprout_alarms.json
+++ b/sprout-base.root/usr/share/clearwater/infrastructure/alarms/sprout_alarms.json
@@ -206,6 +206,52 @@
                     "action": "Monitor for this alarm to clear. If this alarm does not clear, ensure that at least one remote Memcached is operational thus providing at least partial geographic redundancy support to some subscribers. Full service for all subscribers is not restored until nearly all Memcached processes are operational. Make sure that network connectivity exists between Memcached and Sprout. If remote Memcached processes do not return to service then contact your support representative."
                 }
             ]
+        },
+        {
+            "index": 1009,
+            "cause": "UNDERLYING_RESOURCE_UNAVAILABLE",
+            "name": "SPROUT_SESS_TERMINATED_AS_COMM_ERROR",
+            "levels" : [
+                {
+                    "severity": "cleared",
+                    "details": "Sprout communication to all active session terminated Application Servers has been restored.",
+                    "description": "Sprout communication error to session terminated Application Servers cleared.",
+                    "cause": "Sprout communication to all active Application Servers that use session terminated iFC default handling has been restored. The previously issued alarm has been cleared. ",
+                    "effect": "Normal Application Server communications have been restored.",
+                    "action": "No action."
+                },
+                {
+                    "severity": "major",
+                    "details": "Sprout cannot successfully communicate with one or more Application Servers that use session terminated default handling. Check that all ASs are operational, they have network connectivity to Sprout, and iFCs are properly configured.",
+                    "description": "Sprout communication error to session terminated Application Server.",
+                    "cause": "Sprout is unable to successfully communicate with at least one active Application Server that uses session terminated iFC default handling. ",
+                    "effect": "Probable major loss of service. The precise impact will vary depending on the role of Application Servers in the deployment. ",
+                    "action": "Use ENT logs to identify which Application Servers cannot be successfully communicated with and investigate the cause. It might be due to failure of an AS, misconfiguration of Initial Filter Criteria, or network / DNS problems. Once the issue has been resolved this alarm will clear after approximately 5-10 minutes."
+                }
+            ]
+        },
+        {
+            "index": 1010,
+            "cause": "UNDERLYING_RESOURCE_UNAVAILABLE",
+            "name": "SPROUT_SESS_CONTINUED_AS_COMM_ERROR",
+            "levels": [
+                {
+                    "severity": "cleared",
+                    "details": "Sprout communication to all active session continued Application Servers has been restored",
+                    "description": "Sprout communication error to session continued Application Servers cleared.",
+                    "cause": "Sprout communication to all active Application Servers that use session continued iFC default handling has been restored. The previously issued alarm has been cleared.",
+                    "effect": "Normal Application Server communications have been restored",
+                    "action": "No action"
+                },
+                {
+                    "severity": "minor",
+                    "details": "Sprout cannot successfully communicate with one or more Application Servers that use session continued default handling. Check that all ASs are operational, they have network connectivity to Sprout, and iFCs are properly configured.",
+                    "description": "Sprout communication error to session continued Application Server.",
+                    "cause": "Sprout is unable to successfully communicate with at least one active Application Server that uses session continued iFC default handling.",
+                    "effect": "Probable minor degradation of service, or loss of a supplemental service. The precise impact will vary depending on the role of Application Servers in the deployment.",
+                    "action": "Use ENT logs to identify which Application Servers cannot be successfully communicated with and investigate the cause. It might be due to failure of an AS, misconfiguration of Initial Filter Criteria, or network / DNS problems. Once the issue has been resolved this alarm will clear after approximately 5-10 minutes."
+                }
+            ]
         }
     ]
 }

--- a/src/Makefile
+++ b/src/Makefile
@@ -83,6 +83,7 @@ SPROUT_COMMON_SOURCES := logger.cpp \
                          namespace_hop.cpp \
                          session_expires_helper.cpp \
                          base64.cpp \
+                         as_communication_tracker.cpp
 
 sprout_SOURCES := ${SPROUT_COMMON_SOURCES} \
                   snmp_counter_table.cpp \

--- a/src/Makefile
+++ b/src/Makefile
@@ -167,7 +167,8 @@ sprout_test_SOURCES := ${SPROUT_COMMON_SOURCES} \
                        call_list_store_processor_test.cpp \
                        mementoappserver_test.cpp \
                        httpnotifier_test.cpp \
-                       bgcf_test.cpp
+                       bgcf_test.cpp \
+                       as_communication_tracker_test.cpp
 
 COVERAGE_ROOT := ..
 sprout_test_COVERAGE_EXCLUSIONS := ^src/ut|^usr|^modules/gmock|^modules/cpp-common|^modules/rapidjson|^include|^src/mangelwurzel/ut|^modules/gemini/src/ut|^modules/gemini/include|^modules/memento-as/modules|^modules/memento-as/src/ut|^modules/memento-as/include

--- a/src/as_communication_tracker.cpp
+++ b/src/as_communication_tracker.cpp
@@ -37,8 +37,8 @@
 #include "as_communication_tracker.h"
 
 AsCommunicationTracker::AsCommunicationTracker(Alarm* alarm,
-                                               PDLog1<const char*>* as_failed_log,
-                                               PDLog1<const char*>* as_ok_log) :
+                                               const PDLog1<const char*>* as_failed_log,
+                                               const PDLog1<const char*>* as_ok_log) :
   _next_check_time_ms(0),
   _alarm(alarm),
   _as_failed_log(as_failed_log),

--- a/src/as_communication_tracker.cpp
+++ b/src/as_communication_tracker.cpp
@@ -1,0 +1,165 @@
+/**
+ * @file as_communication_tracker.cpp
+ *
+ * Project Clearwater - IMS in the Cloud
+ * Copyright (C) 2016  Metaswitch Networks Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version, along with the "Special Exception" for use of
+ * the program along with SSL, set forth below. This program is distributed
+ * in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * The author can be reached by email at clearwater@metaswitch.com or by
+ * post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+ *
+ * Special Exception
+ * Metaswitch Networks Ltd  grants you permission to copy, modify,
+ * propagate, and distribute a work formed by combining OpenSSL with The
+ * Software, or a work derivative of such a combination, even if such
+ * copying, modification, propagation, or distribution would otherwise
+ * violate the terms of the GPL. You must comply with the GPL in all
+ * respects for all of the code used other than OpenSSL.
+ * "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+ * Project and licensed under the OpenSSL Licenses, or a work based on such
+ * software and licensed under the OpenSSL Licenses.
+ * "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+ * under which the OpenSSL Project distributes the OpenSSL toolkit software,
+ * as those licenses appear in the file LICENSE-OPENSSL.
+ */
+
+#include "as_communication_tracker.h"
+
+AsCommunicationTracker::AsCommunicationTracker(Alarm* alarm,
+                                               PDLog1<const char*>* as_failed_log,
+                                               PDLog1<const char*>* as_ok_log) :
+  _next_check_time_ms(0),
+  _alarm(alarm),
+  _as_failed_log(as_failed_log),
+  _as_ok_log(as_ok_log)
+{
+  pthread_mutex_init(&_lock, NULL);
+}
+
+
+AsCommunicationTracker::~AsCommunicationTracker()
+{
+  pthread_mutex_destroy(&_lock);
+}
+
+
+void AsCommunicationTracker::on_success(const std::string& as_uri)
+{
+  TRC_DEBUG("Communication with AS %s successful", as_uri.c_str());
+  pthread_mutex_lock(&_lock);
+  check_for_healthy_app_servers();
+  pthread_mutex_unlock(&_lock);
+}
+
+
+void AsCommunicationTracker::on_failure(const std::string& as_uri)
+{
+  TRC_DEBUG("Communication with AS %s failed", as_uri.c_str());
+
+  pthread_mutex_lock(&_lock);
+
+  // If we didn't know of any failed ASs, we do now so we should raise the
+  // alarm.
+  if (_as_failures.empty())
+  {
+    TRC_DEBUG("First failure - raise the alarm");
+    _alarm->set();
+
+    // Work out the next time we need to check for ASs that have started
+    // succeeding again.
+    _next_check_time_ms = current_time_ms() + NEXT_CHECK_INTERVAL_MS;
+  }
+
+  // Add an entry to the failed ASs map (incrementing the count of failures if
+  // it has already failed).
+  std::map<std::string, int>::iterator as_iter = _as_failures.find(as_uri);
+
+  if (as_iter != _as_failures.end())
+  {
+    _as_failures.emplace(as_iter->first, as_iter->second + 1);
+  }
+  else
+  {
+    TRC_DEBUG("First failure for this AS - generate log");
+    as_iter->second = 1;
+
+    // This is the first time we've spotted that the AS has failed, so log this
+    // fact.
+    _as_failed_log->log(as_uri.c_str());
+  }
+
+  // Even though communication to this AS has failed, other ASs may have become
+  // healthy recently so we still need to check them.
+  check_for_healthy_app_servers();
+
+  pthread_mutex_unlock(&_lock);
+}
+
+
+void AsCommunicationTracker::check_for_healthy_app_servers()
+{
+  uint64_t now = current_time_ms();
+
+  if (now > _next_check_time_ms)
+  {
+    TRC_DEBUG("Check for ASs that have become healthy again");
+
+    // Iterate through all the AS in our map. If any of them have not had any
+    // failures in the last time period we will log they are now working
+    // correctly and remove them from the map.
+    //
+    // We mutate the map as we iterate over it. The non-standard loop construct
+    // avoids iterator invalidation.
+    std::map<std::string, int>::iterator curr_as;
+    std::map<std::string, int>::iterator next_as;
+
+    for (curr_as = _as_failures.begin(), next_as = std::next(curr_as);
+         curr_as != _as_failures.end();
+         curr_as = next_as)
+    {
+      if (curr_as->second == 0)
+      {
+        TRC_DEBUG("AS %s has become healthy", curr_as->first.c_str());
+        _as_ok_log->log(curr_as->first.c_str());
+        _as_failures.erase(curr_as);
+      }
+      else
+      {
+        curr_as->second = 0;
+      }
+    }
+
+    if (_as_failures.empty())
+    {
+      TRC_DEBUG("Ass Ass OK - clear the alarm");
+      // No ASs are currently failed. Clear the alarm.
+      _alarm->clear();
+    }
+    else
+    {
+      // There are still some failed ASs. Check again a bit later.
+      TRC_DEBUG("Some Ass still failed - check again in %d ms",
+                NEXT_CHECK_INTERVAL_MS);
+      _next_check_time_ms = NEXT_CHECK_INTERVAL_MS;
+    }
+  }
+}
+
+
+uint64_t AsCommunicationTracker::current_time_ms()
+{
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return ts.tv_sec * 1000 + (ts.tv_nsec / 1000000);
+}

--- a/src/as_communication_tracker.cpp
+++ b/src/as_communication_tracker.cpp
@@ -89,8 +89,7 @@ void AsCommunicationTracker::on_failure(const std::string& as_uri)
     // fact.
     TRC_DEBUG("First failure for this AS - generate log");
     _as_failed_log->log(as_uri.c_str());
-
-    _as_failures.emplace(as_uri, 1);
+    _as_failures[as_uri] = 1;
   }
   pthread_mutex_unlock(&_lock);
 

--- a/src/aschain.cpp
+++ b/src/aschain.cpp
@@ -71,6 +71,15 @@ AsChain::AsChain(AsChainTable* as_chain_table,
   TRC_DEBUG("Creating AsChain %p with %d IFC and adding to map", this, ifcs.size());
   _as_chain_table->register_(this, _odi_tokens);
   TRC_DEBUG("Attached ACR (%p) to chain", _acr);
+
+  // We need to initialize `_responsive` as bools are PODs which are not
+  // initialized.
+  for(std::vector<bool>::iterator it = _responsive.begin();
+      it != _responsive.end();
+      ++it)
+  {
+    *it = false;
+  }
 }
 
 

--- a/src/scscfplugin.cpp
+++ b/src/scscfplugin.cpp
@@ -57,6 +57,8 @@ public:
 
 private:
   SCSCFSproutlet* _scscf_sproutlet;
+  Alarm* _sess_cont_as_alarm;
+  Alarm* _sess_term_as_alarm;
 };
 
 /// Export the plug-in using the magic symbol "sproutlet_plugin"
@@ -118,23 +120,21 @@ bool SCSCFPlugin::load(struct options& opt, std::list<Sproutlet*>& sproutlets)
     }
 
     // Create Application Server communication trackers.
+    _sess_term_as_alarm = new Alarm("sprout",
+                                    AlarmDef::SPROUT_SESS_TERMINATED_AS_COMM_ERROR,
+                                    AlarmDef::MAJOR);
     AsCommunicationTracker* sess_term_as_tracker =
-      new AsCommunicationTracker(
-        new Alarm("sprout",
-                  AlarmDef::SPROUT_SESS_TERMINATED_AS_COMM_ERROR,
-                  AlarmDef::MAJOR),
-        &CL_SPROUT_SESS_TERM_AS_COMM_FAILURE,
-        &CL_SPROUT_SESS_TERM_AS_COMM_SUCCESS
-      );
+        new AsCommunicationTracker(_sess_term_as_alarm,
+                                   &CL_SPROUT_SESS_TERM_AS_COMM_FAILURE,
+                                   &CL_SPROUT_SESS_TERM_AS_COMM_SUCCESS);
 
+    _sess_cont_as_alarm =  new Alarm("sprout",
+                                     AlarmDef::SPROUT_SESS_CONTINUED_AS_COMM_ERROR,
+                                     AlarmDef::MINOR);
     AsCommunicationTracker* sess_cont_as_tracker =
-      new AsCommunicationTracker(
-        new Alarm("sprout",
-                  AlarmDef::SPROUT_SESS_CONTINUED_AS_COMM_ERROR,
-                  AlarmDef::MINOR),
-        &CL_SPROUT_SESS_CONT_AS_COMM_FAILURE,
-        &CL_SPROUT_SESS_CONT_AS_COMM_SUCCESS
-      );
+        new AsCommunicationTracker(_sess_cont_as_alarm,
+                                   &CL_SPROUT_SESS_CONT_AS_COMM_FAILURE,
+                                   &CL_SPROUT_SESS_CONT_AS_COMM_SUCCESS);
 
     _scscf_sproutlet = new SCSCFSproutlet(scscf_cluster_uri,
                                           scscf_node_uri,
@@ -164,4 +164,6 @@ bool SCSCFPlugin::load(struct options& opt, std::list<Sproutlet*>& sproutlets)
 void SCSCFPlugin::unload()
 {
   delete _scscf_sproutlet;
+  delete _sess_term_as_alarm; _sess_term_as_alarm = NULL;
+  delete _sess_cont_as_alarm; _sess_cont_as_alarm = NULL;
 }

--- a/src/scscfsproutlet.cpp
+++ b/src/scscfsproutlet.cpp
@@ -66,7 +66,9 @@ SCSCFSproutlet::SCSCFSproutlet(const std::string& scscf_cluster_uri,
                                ACRFactory* acr_factory,
                                bool override_npdi,
                                int session_continued_timeout_ms,
-                               int session_terminated_timeout_ms) :
+                               int session_terminated_timeout_ms,
+                               AsCommunicationTracker* sess_term_as_tracker,
+                               AsCommunicationTracker* sess_cont_as_tracker) :
   Sproutlet("scscf", port),
   _scscf_cluster_uri(NULL),
   _scscf_node_uri(NULL),
@@ -83,7 +85,9 @@ SCSCFSproutlet::SCSCFSproutlet(const std::string& scscf_cluster_uri,
   _scscf_cluster_uri_str(scscf_cluster_uri),
   _scscf_node_uri_str(scscf_node_uri),
   _icscf_uri_str(icscf_uri),
-  _bgcf_uri_str(bgcf_uri)
+  _bgcf_uri_str(bgcf_uri),
+  _sess_term_as_tracker(sess_term_as_tracker),
+  _sess_cont_as_tracker(sess_cont_as_tracker)
 {
   _incoming_sip_transactions_tbl = SNMP::SuccessFailCountByRequestTypeTable::create("scscf_incoming_sip_transactions",
                                                                                     "1.2.826.0.1.1578918.9.3.20");

--- a/src/ut/as_communication_tracker_test.cpp
+++ b/src/ut/as_communication_tracker_test.cpp
@@ -83,7 +83,7 @@ public:
 };
 
 // Advance time to the next AsCommunicationTracker checking period. This is
-// slightly encapsulation breaking (sincec it means the UT knows how long this
+// slightly encapsulation breaking (since it means the UT knows how long this
 // period is) but is the most practical thing to do in UT.
 static void advance_time()
 {

--- a/src/ut/as_communication_tracker_test.cpp
+++ b/src/ut/as_communication_tracker_test.cpp
@@ -82,7 +82,7 @@ public:
 
 static void advance_time()
 {
-  cwtest_advance_time_ms(5 * 60 * 1000 + 1);
+  cwtest_advance_time_ms((5 * 60 * 1000) + 1);
 }
 
 

--- a/src/ut/as_communication_tracker_test.cpp
+++ b/src/ut/as_communication_tracker_test.cpp
@@ -1,0 +1,111 @@
+/**
+ * @file as_communication_tracker_test.cpp
+ *
+ * Project Clearwater - IMS in the Cloud
+ * Copyright (C) 2016  Metaswitch Networks Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version, along with the "Special Exception" for use of
+ * the program along with SSL, set forth below. This program is distributed
+ * in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * The author can be reached by email at clearwater@metaswitch.com or by
+ * post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+ *
+ * Special Exception
+ * Metaswitch Networks Ltd  grants you permission to copy, modify,
+ * propagate, and distribute a work formed by combining OpenSSL with The
+ * Software, or a work derivative of such a combination, even if such
+ * copying, modification, propagation, or distribution would otherwise
+ * violate the terms of the GPL. You must comply with the GPL in all
+ * respects for all of the code used other than OpenSSL.
+ * "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+ * Project and licensed under the OpenSSL Licenses, or a work based on such
+ * software and licensed under the OpenSSL Licenses.
+ * "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+ * under which the OpenSSL Project distributes the OpenSSL toolkit software,
+ * as those licenses appear in the file LICENSE-OPENSSL.
+ */
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+
+#include "as_communication_tracker.h"
+
+#include "mockalarm.h"
+#include "test_interposer.hpp"
+
+using ::testing::_;
+
+class MockLog : public PDLog1<const char*>
+{
+public:
+  MockLog() : PDLog1(1, 2, "", "", "", "") {};
+  MOCK_CONST_METHOD1(log, void(const char*));
+};
+
+class AsCommunicationTrackerTest : public ::testing::Test
+{
+public:
+  AsCommunicationTracker* _comm_tracker;
+  MockAlarm* _mock_alarm;
+  const MockLog* _mock_error_log;
+  const MockLog* _mock_ok_log;
+
+  void SetUp()
+  {
+    _mock_alarm = new MockAlarm();
+    _mock_error_log = new MockLog();
+    _mock_ok_log = new MockLog();
+    _comm_tracker = new AsCommunicationTracker(_mock_alarm,
+                                               _mock_error_log,
+                                               _mock_ok_log);
+  }
+
+  void TearDown()
+  {
+    delete _comm_tracker;
+    delete _mock_alarm;
+    delete _mock_error_log;
+    delete _mock_ok_log;
+  }
+
+  const std::string AS1 = "as1";
+};
+
+static void advance_time()
+{
+  cwtest_advance_time_ms(5 * 60 * 1000 + 1);
+}
+
+
+TEST_F(AsCommunicationTrackerTest, SuccessIsIdempotent)
+{
+  _comm_tracker->on_success(AS1);
+  _comm_tracker->on_success(AS1);
+  _comm_tracker->on_success(AS1);
+}
+
+
+TEST_F(AsCommunicationTrackerTest, SingleAsFailure)
+{
+  EXPECT_CALL(*_mock_alarm, set());
+  EXPECT_CALL(*_mock_error_log, log(_));
+  _comm_tracker->on_failure(AS1);
+
+  advance_time();
+  _comm_tracker->on_success(AS1);
+
+  EXPECT_CALL(*_mock_alarm, clear());
+  EXPECT_CALL(*_mock_ok_log, log(_));
+
+  advance_time();
+  _comm_tracker->on_success(AS1);
+}

--- a/src/ut/mock_as_communication_tracker.h
+++ b/src/ut/mock_as_communication_tracker.h
@@ -1,37 +1,37 @@
 /**
  * @file mock_as_communication_tracker.h
  *
- * project clearwater - ims in the cloud
- * copyright (c) 2013  metaswitch networks ltd
+ * Project Clearwater - IMS in the Cloud
+ * Copyright (C) 2016  Metaswitch Networks Ltd
  *
- * this program is free software: you can redistribute it and/or modify it
- * under the terms of the gnu general public license as published by the
- * free software foundation, either version 3 of the license, or (at your
- * option) any later version, along with the "special exception" for use of
- * the program along with ssl, set forth below. this program is distributed
- * in the hope that it will be useful, but without any warranty;
- * without even the implied warranty of merchantability or fitness for
- * a particular purpose.  see the gnu general public license for more
- * details. you should have received a copy of the gnu general public
- * license along with this program.  if not, see
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version, along with the "Special Exception" for use of
+ * the program along with SSL, set forth below. This program is distributed
+ * in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
  * <http://www.gnu.org/licenses/>.
  *
- * the author can be reached by email at clearwater@metaswitch.com or by
- * post at metaswitch networks ltd, 100 church st, enfield en2 6bq, uk
+ * The author can be reached by email at clearwater@metaswitch.com or by
+ * post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
  *
- * special exception
- * metaswitch networks ltd  grants you permission to copy, modify,
- * propagate, and distribute a work formed by combining openssl with the
- * software, or a work derivative of such a combination, even if such
+ * Special Exception
+ * Metaswitch Networks Ltd  grants you permission to copy, modify,
+ * propagate, and distribute a work formed by combining OpenSSL with The
+ * Software, or a work derivative of such a combination, even if such
  * copying, modification, propagation, or distribution would otherwise
- * violate the terms of the gpl. you must comply with the gpl in all
- * respects for all of the code used other than openssl.
- * "openssl" means openssl toolkit software distributed by the openssl
- * project and licensed under the openssl licenses, or a work based on such
- * software and licensed under the openssl licenses.
- * "openssl licenses" means the openssl license and original ssleay license
- * under which the openssl project distributes the openssl toolkit software,
- * as those licenses appear in the file license-openssl.
+ * violate the terms of the GPL. You must comply with the GPL in all
+ * respects for all of the code used other than OpenSSL.
+ * "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+ * Project and licensed under the OpenSSL Licenses, or a work based on such
+ * software and licensed under the OpenSSL Licenses.
+ * "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+ * under which the OpenSSL Project distributes the OpenSSL toolkit software,
+ * as those licenses appear in the file LICENSE-OPENSSL.
  */
 
 #ifndef MOCK_AS_COMMUNICATION_TRACKER_H__

--- a/src/ut/mock_as_communication_tracker.h
+++ b/src/ut/mock_as_communication_tracker.h
@@ -1,0 +1,53 @@
+/**
+ * @file mock_as_communication_tracker.h
+ *
+ * project clearwater - ims in the cloud
+ * copyright (c) 2013  metaswitch networks ltd
+ *
+ * this program is free software: you can redistribute it and/or modify it
+ * under the terms of the gnu general public license as published by the
+ * free software foundation, either version 3 of the license, or (at your
+ * option) any later version, along with the "special exception" for use of
+ * the program along with ssl, set forth below. this program is distributed
+ * in the hope that it will be useful, but without any warranty;
+ * without even the implied warranty of merchantability or fitness for
+ * a particular purpose.  see the gnu general public license for more
+ * details. you should have received a copy of the gnu general public
+ * license along with this program.  if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * the author can be reached by email at clearwater@metaswitch.com or by
+ * post at metaswitch networks ltd, 100 church st, enfield en2 6bq, uk
+ *
+ * special exception
+ * metaswitch networks ltd  grants you permission to copy, modify,
+ * propagate, and distribute a work formed by combining openssl with the
+ * software, or a work derivative of such a combination, even if such
+ * copying, modification, propagation, or distribution would otherwise
+ * violate the terms of the gpl. you must comply with the gpl in all
+ * respects for all of the code used other than openssl.
+ * "openssl" means openssl toolkit software distributed by the openssl
+ * project and licensed under the openssl licenses, or a work based on such
+ * software and licensed under the openssl licenses.
+ * "openssl licenses" means the openssl license and original ssleay license
+ * under which the openssl project distributes the openssl toolkit software,
+ * as those licenses appear in the file license-openssl.
+ */
+
+#ifndef MOCK_AS_COMMUNICATION_TRACKER_H__
+#define MOCK_AS_COMMUNICATION_TRACKER_H__
+
+#include "gmock/gmock.h"
+
+class MockAsCommunicationTracker : public AsCommunicationTracker
+{
+public:
+  MockAsCommunicationTracker() : AsCommunicationTracker(NULL, NULL, NULL) {};
+  ~MockAsCommunicationTracker() {}
+
+  MOCK_METHOD1(on_success, void(const std::string&));
+  MOCK_METHOD1(on_failure, void(const std::string&));
+};
+
+#endif
+


### PR DESCRIPTION
HI Rob, please could you review this change to add AS alarms to sprout? A couple of things to note:

* I tweaked all the S-CSCF UTs to check that AS communication tracker was being invoked correctly. I did this as the tests involve a lot of interesting AS topologies that I wanted to test.  I also decided to add a lot of missing 100 trying flows (from the AS -> Sprout) so that the majority of testcases were treated as AS successes (as that is less confusing).
* I am hoping to add the feature that support requested to log the error reason, but I'll do that as a separate PR. 

Tested in UT so far. I'll test live when you have reviewed the code (or at least gotten far enough through to say "this doesn't need a fundamental re-write"). 