### PR TITLE
[Reviewer: Rob] Fix possible deadlock in quiescing

### DIFF
--- a/include/connection_tracker.h
+++ b/include/connection_tracker.h
@@ -84,9 +84,6 @@ public:
   void unquiesce();
 
 private:
-  // This must be held when accessing any of this object's member variables.
-  pthread_mutex_t _lock;
-
   // A map of all the connections known to the connection manager, and their
   // state listeners.  This is a set of pjsip transports, but only includes
   // connection-based transports (not datagram transports).

--- a/include/stack.h
+++ b/include/stack.h
@@ -134,6 +134,26 @@ inline SAS::TrailId get_trail(const pjsip_transaction* tsx)
   return (SAS::TrailId)tsx->mod_data[stack_data.sas_logging_module_id];
 }
 
+/*
+// Variable to store our current quiescing state
+static pj_bool_t quiescing = PJ_FALSE;
+
+// Functions to set quiescing state
+inline void set_quiescing_true()
+{
+  quiescing = PJ_TRUE;
+}
+
+inline void set_quiescing_false()
+{
+  quiescing = PJ_FALSE;
+}
+*/
+
+extern void set_quiescing_true();
+extern void set_quiescing_false();
+
+
 extern void init_pjsip_logging(int log_level,
                                pj_bool_t log_to_file,
                                const std::string& directory);

--- a/include/stack.h
+++ b/include/stack.h
@@ -134,25 +134,9 @@ inline SAS::TrailId get_trail(const pjsip_transaction* tsx)
   return (SAS::TrailId)tsx->mod_data[stack_data.sas_logging_module_id];
 }
 
-/*
-// Variable to store our current quiescing state
-static pj_bool_t quiescing = PJ_FALSE;
-
-// Functions to set quiescing state
-inline void set_quiescing_true()
-{
-  quiescing = PJ_TRUE;
-}
-
-inline void set_quiescing_false()
-{
-  quiescing = PJ_FALSE;
-}
-*/
-
 extern void set_quiescing_true();
-extern void set_quiescing_false();
 
+extern void set_quiescing_false();
 
 extern void init_pjsip_logging(int log_level,
                                pj_bool_t log_to_file,

--- a/src/connection_tracker.cpp
+++ b/src/connection_tracker.cpp
@@ -40,6 +40,7 @@
 #include "utils.h"
 #include "pjutils.h"
 #include "connection_tracker.h"
+#include "stack.h"
 
 ConnectionTracker::ConnectionTracker(
                               ConnectionsQuiescedInterface *on_quiesced_handler)
@@ -48,11 +49,6 @@ ConnectionTracker::ConnectionTracker(
   _quiescing(PJ_FALSE),
   _on_quiesced_handler(on_quiesced_handler)
 {
-  pthread_mutexattr_t attrs;
-  pthread_mutexattr_init(&attrs);
-  pthread_mutexattr_settype(&attrs, PTHREAD_MUTEX_RECURSIVE);
-  pthread_mutex_init(&_lock, &attrs);
-  pthread_mutexattr_destroy(&attrs);
 }
 
 
@@ -68,8 +64,6 @@ ConnectionTracker::~ConnectionTracker()
                                           it->second,
                                           (void *)this);
   }
-
-  pthread_mutex_destroy(&_lock);
 }
 
 
@@ -90,7 +84,10 @@ void ConnectionTracker::connection_state_update(pjsip_transport *tp,
   {
     TRC_DEBUG("Connection %p has been destroyed", tp);
 
-    pthread_mutex_lock(&_lock);
+    // We expect to only be called on the PJSIP transport thread, and our data
+    // race/locking safety is based on this assumption. Raise an error log if
+    // this is not the case.
+    CHECK_PJ_TRANSPORT_THREAD();
 
     _connection_listeners.erase(tp);
 
@@ -101,10 +98,7 @@ void ConnectionTracker::connection_state_update(pjsip_transport *tp,
       quiesce_complete = PJ_TRUE;
     }
 
-    pthread_mutex_unlock(&_lock);
-
-    // If quiescing is now complete notify the quiescing manager.  This is done
-    // without holding the lock to avoid potential deadlocks.
+    // If quiescing is now complete notify the quiescing manager.
     if (quiesce_complete) {
       _on_quiesced_handler->connections_quiesced();
     }
@@ -117,7 +111,10 @@ void ConnectionTracker::connection_active(pjsip_transport *tp)
   // We only track connection-oriented transports.
   if ((tp->flag & PJSIP_TRANSPORT_DATAGRAM) == 0)
   {
-    pthread_mutex_lock(&_lock);
+    // We expect to only be called on the PJSIP transport thread, and our data
+    // race/locking safety is based on this assumption. Raise an error log if
+    // this is not the case.
+    CHECK_PJ_TRANSPORT_THREAD();
 
     if (_connection_listeners.find(tp) == _connection_listeners.end())
     {
@@ -144,8 +141,6 @@ void ConnectionTracker::connection_active(pjsip_transport *tp)
         pjsip_transport_shutdown(tp);
       }
     }
-
-    pthread_mutex_unlock(&_lock);
   }
 }
 
@@ -156,7 +151,10 @@ void ConnectionTracker::quiesce()
 
   TRC_DEBUG("Start quiescing connections");
 
-  pthread_mutex_lock(&_lock);
+  // We expect to only be called on the PJSIP transport thread, and our data
+  // race/locking safety is based on this assumption. Raise an error log if
+  // this is not the case.
+  CHECK_PJ_TRANSPORT_THREAD();
 
   // Flag that we're now quiescing. It is illegal to call this method if we're
   // already quiescing.
@@ -184,10 +182,7 @@ void ConnectionTracker::quiesce()
     }
   }
 
-  pthread_mutex_unlock(&_lock);
-
-  // If quiescing is now complete notify the quiescing manager.  This is done
-  // without holding the lock to avoid potential deadlocks.
+  // If quiescing is now complete notify the quiescing manager.
   if (quiesce_complete) {
     _on_quiesced_handler->connections_quiesced();
   }
@@ -198,7 +193,10 @@ void ConnectionTracker::unquiesce()
 {
   TRC_DEBUG("Unquiesce connections");
 
-  pthread_mutex_lock(&_lock);
+  // We expect to only be called on the PJSIP transport thread, and our data
+  // race/locking safety is based on this assumption. Raise an error log if
+  // this is not the case.
+  CHECK_PJ_TRANSPORT_THREAD();
 
   // It is not possible to "un-shutdown" a pjsip transport.  All connections
   // that were previously active will eventually be closed. Instead we just
@@ -208,6 +206,4 @@ void ConnectionTracker::unquiesce()
   // Note it is illegal to call this method if we're not quiescing.
   assert(_quiescing);
   _quiescing = PJ_FALSE;
-
-  pthread_mutex_unlock(&_lock);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -233,7 +233,6 @@ static std::string pj_options_description = "p:s:i:l:D:c:C:n:e:I:A:R:M:S:H:T:o:q
 
 static sem_t term_sem;
 
-static pj_bool_t quiescing = PJ_FALSE;
 static sem_t quiescing_sem;
 QuiescingManager* quiescing_mgr;
 
@@ -1204,12 +1203,12 @@ void quiesce_unquiesce_handler(int sig)
   if (sig == QUIESCE_SIGNAL)
   {
     TRC_STATUS("Quiesce signal received");
-    quiescing = PJ_TRUE;
+    set_quiescing_true();
   }
   else
   {
     TRC_STATUS("Unquiesce signal received");
-    quiescing = PJ_FALSE;
+    set_quiescing_false();
   }
 
   // Wake up the thread that acts on the notification (don't act on it in this
@@ -1224,7 +1223,7 @@ void terminate_handler(int sig)
   sem_post(&term_sem);
 }
 
-
+/*
 void* quiesce_unquiesce_thread_func(void* dummy)
 {
   // First register the thread with PJSIP.
@@ -1276,7 +1275,7 @@ void* quiesce_unquiesce_thread_func(void* dummy)
 
   return NULL;
 }
-
+*/
 class QuiesceCompleteHandler : public QuiesceCompletionInterface
 {
 public:
@@ -1356,7 +1355,7 @@ int main(int argc, char* argv[])
 
   Logger* analytics_logger_logger = NULL;
   AnalyticsLogger* analytics_logger = NULL;
-  pthread_t quiesce_unquiesce_thread;
+//  pthread_t quiesce_unquiesce_thread;
   DnsCachedResolver* dns_resolver = NULL;
   SIPResolver* sip_resolver = NULL;
   Store* remote_data_store = NULL;
@@ -1827,11 +1826,11 @@ int main(int argc, char* argv[])
   // itself. This must happen after init_stack is called, because this
   // calls init_pjsip, which calls pj_init, which sets up the
   // necessary environment for us to register threads with pjsip.
-  sem_init(&quiescing_sem, 0, 0);
-  pthread_create(&quiesce_unquiesce_thread,
-                 NULL,
-                 quiesce_unquiesce_thread_func,
-                 NULL);
+//  sem_init(&quiescing_sem, 0, 0);
+//  pthread_create(&quiesce_unquiesce_thread,
+//                 NULL,
+//                 quiesce_unquiesce_thread_func,
+//                 NULL);
 
   // Set up our signal handler for (un)quiesce signals.
   signal(QUIESCE_SIGNAL, quiesce_unquiesce_handler);
@@ -2386,10 +2385,10 @@ int main(int argc, char* argv[])
 
   // Cancel the (un)quiesce thread (so that we can safely destroy the semaphore
   // it uses).
-  pthread_cancel(quiesce_unquiesce_thread);
-  pthread_join(quiesce_unquiesce_thread, NULL);
+//  pthread_cancel(quiesce_unquiesce_thread);
+//  pthread_join(quiesce_unquiesce_thread, NULL);
 
-  sem_destroy(&quiescing_sem);
+//  sem_destroy(&quiescing_sem);
   sem_destroy(&term_sem);
 
   return 0;

--- a/src/stack.cpp
+++ b/src/stack.cpp
@@ -166,6 +166,11 @@ extern void set_quiescing_false()
 /// and timers.
 static int pjsip_thread_func(void *p)
 {
+  // We expect to only be called on the PJSIP transport thread, and our data
+  // race/locking safety is based on this assumption. Raise an error log if
+  // this is not the case.
+  CHECK_PJ_TRANSPORT_THREAD();
+
   pj_time_val delay = {0, 10};
 
   PJ_UNUSED_ARG(p);

--- a/src/stack.cpp
+++ b/src/stack.cpp
@@ -148,6 +148,7 @@ const static std::string _known_statnames[] = {
 const std::string* known_statnames = _known_statnames;
 const int num_known_stats = sizeof(_known_statnames) / sizeof(std::string);
 
+// Variable to hold quiescing state, and interfaces to alter it
 static pj_bool_t quiescing = PJ_FALSE;
 
 extern void set_quiescing_true()
@@ -183,17 +184,15 @@ static int pjsip_thread_func(void *p)
     new_quiescing = quiescing;
     if (curr_quiescing != new_quiescing)
     {
-      TRC_DEBUG("quiescing state changed");
+      TRC_DEBUG("Quiescing state changed");
       curr_quiescing = new_quiescing;
 
       if (new_quiescing)
       {
-        TRC_DEBUG("calling quiescing manager quiesce");
         quiescing_mgr->quiesce();
       }
       else
       {
-       TRC_DEBUG("calling quiescing manager unquiesce");
        quiescing_mgr->unquiesce();
       }
     }

--- a/src/stack.cpp
+++ b/src/stack.cpp
@@ -166,11 +166,6 @@ extern void set_quiescing_false()
 /// and timers.
 static int pjsip_thread_func(void *p)
 {
-  // We expect to only be called on the PJSIP transport thread, and our data
-  // race/locking safety is based on this assumption. Raise an error log if
-  // this is not the case.
-  CHECK_PJ_TRANSPORT_THREAD();
-
   pj_time_val delay = {0, 10};
 
   PJ_UNUSED_ARG(p);

--- a/src/stack.cpp
+++ b/src/stack.cpp
@@ -747,10 +747,10 @@ pj_status_t init_stack(const std::string& system_name,
        ++ii)
   {
     pjsip_tpfactory* tcp_factory = NULL;
+    stack_data.sproutlets.insert(std::pair<int, pjsip_tpfactory*>(*ii, tcp_factory));
     status = start_transports(*ii,
                               stack_data.public_host,
                               &tcp_factory);
-    stack_data.sproutlets.insert(std::pair<int, pjsip_tpfactory*>(*ii, tcp_factory));
 
     if (status == PJ_SUCCESS)
     {

--- a/src/stack.cpp
+++ b/src/stack.cpp
@@ -747,10 +747,10 @@ pj_status_t init_stack(const std::string& system_name,
        ++ii)
   {
     pjsip_tpfactory* tcp_factory = NULL;
-    stack_data.sproutlets.insert(std::pair<int, pjsip_tpfactory*>(*ii, tcp_factory));
     status = start_transports(*ii,
                               stack_data.public_host,
                               &tcp_factory);
+    stack_data.sproutlets.insert(std::pair<int, pjsip_tpfactory*>(*ii, tcp_factory));
 
     if (status == PJ_SUCCESS)
     {


### PR DESCRIPTION
This merges the quiescing thread with the PJSIP transport thread. 
This should avoid a possible deadlock condition. 

The relocation of stack.cpp:L714/753 is to fix crashes that were seen on stopping or quiescing sprout. 

These changes have been tested on a live deployment, and quiescing shows no crashing or locking.
Once https://github.com/Metaswitch/sprout/pull/1344 is merged, it may be worth adding in CHECK_PJ_TRANSPORT_THREAD() before running the quiesce calls, to ensure we are being safe.

Will fix #1351 