### PR TITLE
[Reviewer: Rob] Fix possible deadlock in quiescing

### DIFF
--- a/include/stack.h
+++ b/include/stack.h
@@ -134,6 +134,26 @@ inline SAS::TrailId get_trail(const pjsip_transaction* tsx)
   return (SAS::TrailId)tsx->mod_data[stack_data.sas_logging_module_id];
 }
 
+/*
+// Variable to store our current quiescing state
+static pj_bool_t quiescing = PJ_FALSE;
+
+// Functions to set quiescing state
+inline void set_quiescing_true()
+{
+  quiescing = PJ_TRUE;
+}
+
+inline void set_quiescing_false()
+{
+  quiescing = PJ_FALSE;
+}
+*/
+
+extern void set_quiescing_true();
+extern void set_quiescing_false();
+
+
 extern void init_pjsip_logging(int log_level,
                                pj_bool_t log_to_file,
                                const std::string& directory);

--- a/include/stack.h
+++ b/include/stack.h
@@ -134,25 +134,9 @@ inline SAS::TrailId get_trail(const pjsip_transaction* tsx)
   return (SAS::TrailId)tsx->mod_data[stack_data.sas_logging_module_id];
 }
 
-/*
-// Variable to store our current quiescing state
-static pj_bool_t quiescing = PJ_FALSE;
-
-// Functions to set quiescing state
-inline void set_quiescing_true()
-{
-  quiescing = PJ_TRUE;
-}
-
-inline void set_quiescing_false()
-{
-  quiescing = PJ_FALSE;
-}
-*/
-
 extern void set_quiescing_true();
-extern void set_quiescing_false();
 
+extern void set_quiescing_false();
 
 extern void init_pjsip_logging(int log_level,
                                pj_bool_t log_to_file,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -233,7 +233,6 @@ static std::string pj_options_description = "p:s:i:l:D:c:C:n:e:I:A:R:M:S:H:T:o:q
 
 static sem_t term_sem;
 
-static pj_bool_t quiescing = PJ_FALSE;
 static sem_t quiescing_sem;
 QuiescingManager* quiescing_mgr;
 
@@ -1204,12 +1203,12 @@ void quiesce_unquiesce_handler(int sig)
   if (sig == QUIESCE_SIGNAL)
   {
     TRC_STATUS("Quiesce signal received");
-    quiescing = PJ_TRUE;
+    set_quiescing_true();
   }
   else
   {
     TRC_STATUS("Unquiesce signal received");
-    quiescing = PJ_FALSE;
+    set_quiescing_false();
   }
 
   // Wake up the thread that acts on the notification (don't act on it in this
@@ -1224,7 +1223,7 @@ void terminate_handler(int sig)
   sem_post(&term_sem);
 }
 
-
+/*
 void* quiesce_unquiesce_thread_func(void* dummy)
 {
   // First register the thread with PJSIP.
@@ -1276,7 +1275,7 @@ void* quiesce_unquiesce_thread_func(void* dummy)
 
   return NULL;
 }
-
+*/
 class QuiesceCompleteHandler : public QuiesceCompletionInterface
 {
 public:
@@ -1356,7 +1355,7 @@ int main(int argc, char* argv[])
 
   Logger* analytics_logger_logger = NULL;
   AnalyticsLogger* analytics_logger = NULL;
-  pthread_t quiesce_unquiesce_thread;
+//  pthread_t quiesce_unquiesce_thread;
   DnsCachedResolver* dns_resolver = NULL;
   SIPResolver* sip_resolver = NULL;
   Store* remote_data_store = NULL;
@@ -1827,11 +1826,11 @@ int main(int argc, char* argv[])
   // itself. This must happen after init_stack is called, because this
   // calls init_pjsip, which calls pj_init, which sets up the
   // necessary environment for us to register threads with pjsip.
-  sem_init(&quiescing_sem, 0, 0);
-  pthread_create(&quiesce_unquiesce_thread,
-                 NULL,
-                 quiesce_unquiesce_thread_func,
-                 NULL);
+//  sem_init(&quiescing_sem, 0, 0);
+//  pthread_create(&quiesce_unquiesce_thread,
+//                 NULL,
+//                 quiesce_unquiesce_thread_func,
+//                 NULL);
 
   // Set up our signal handler for (un)quiesce signals.
   signal(QUIESCE_SIGNAL, quiesce_unquiesce_handler);
@@ -2386,10 +2385,10 @@ int main(int argc, char* argv[])
 
   // Cancel the (un)quiesce thread (so that we can safely destroy the semaphore
   // it uses).
-  pthread_cancel(quiesce_unquiesce_thread);
-  pthread_join(quiesce_unquiesce_thread, NULL);
+//  pthread_cancel(quiesce_unquiesce_thread);
+//  pthread_join(quiesce_unquiesce_thread, NULL);
 
-  sem_destroy(&quiescing_sem);
+//  sem_destroy(&quiescing_sem);
   sem_destroy(&term_sem);
 
   return 0;

--- a/src/stack.cpp
+++ b/src/stack.cpp
@@ -148,6 +148,7 @@ const static std::string _known_statnames[] = {
 const std::string* known_statnames = _known_statnames;
 const int num_known_stats = sizeof(_known_statnames) / sizeof(std::string);
 
+// Variable to hold quiescing state, and interfaces to alter it
 static pj_bool_t quiescing = PJ_FALSE;
 
 extern void set_quiescing_true()
@@ -183,17 +184,15 @@ static int pjsip_thread_func(void *p)
     new_quiescing = quiescing;
     if (curr_quiescing != new_quiescing)
     {
-      TRC_DEBUG("quiescing state changed");
+      TRC_DEBUG("Quiescing state changed");
       curr_quiescing = new_quiescing;
 
       if (new_quiescing)
       {
-        TRC_DEBUG("calling quiescing manager quiesce");
         quiescing_mgr->quiesce();
       }
       else
       {
-       TRC_DEBUG("calling quiescing manager unquiesce");
        quiescing_mgr->unquiesce();
       }
     }

--- a/src/stack.cpp
+++ b/src/stack.cpp
@@ -747,10 +747,10 @@ pj_status_t init_stack(const std::string& system_name,
        ++ii)
   {
     pjsip_tpfactory* tcp_factory = NULL;
+    stack_data.sproutlets.insert(std::pair<int, pjsip_tpfactory*>(*ii, tcp_factory));
     status = start_transports(*ii,
                               stack_data.public_host,
                               &tcp_factory);
-    stack_data.sproutlets.insert(std::pair<int, pjsip_tpfactory*>(*ii, tcp_factory));
 
     if (status == PJ_SUCCESS)
     {

--- a/src/stack.cpp
+++ b/src/stack.cpp
@@ -747,10 +747,10 @@ pj_status_t init_stack(const std::string& system_name,
        ++ii)
   {
     pjsip_tpfactory* tcp_factory = NULL;
-    stack_data.sproutlets.insert(std::pair<int, pjsip_tpfactory*>(*ii, tcp_factory));
     status = start_transports(*ii,
                               stack_data.public_host,
                               &tcp_factory);
+    stack_data.sproutlets.insert(std::pair<int, pjsip_tpfactory*>(*ii, tcp_factory));
 
     if (status == PJ_SUCCESS)
     {


### PR DESCRIPTION
[Supercedes #1377]
This merges the quiescing thread with the PJSIP transport thread. 
This should avoid a possible deadlock condition.

These changes have been tested on a live deployment, and quiescing shows no crashing or locking.
Once #1344 is merged, it may be worth adding in CHECK_PJ_TRANSPORT_THREAD() before running the quiesce calls, to ensure we are being safe.

Will fix #1351