### PR TITLE
[Reviewer: Rob] Stop crashes on process stop or quiesce

### DIFF
--- a/src/stack.cpp
+++ b/src/stack.cpp
@@ -711,10 +711,10 @@ pj_status_t init_stack(const std::string& system_name,
        ++ii)
   {
     pjsip_tpfactory* tcp_factory = NULL;
-    stack_data.sproutlets.insert(std::pair<int, pjsip_tpfactory*>(*ii, tcp_factory));
     status = start_transports(*ii,
                               stack_data.public_host,
                               &tcp_factory);
+    stack_data.sproutlets.insert(std::pair<int, pjsip_tpfactory*>(*ii, tcp_factory));
 
     if (status == PJ_SUCCESS)
     {


### PR DESCRIPTION
When running `sudo service sprout stop` or `sudo service sprout quiesce`, we were seeing the process crash with a signal 11. 

This change should stop this happening.
I have tested this alongside PR #1378 and am in the process of building it to test separately to ensure it fixes the issue on its own. 
This will be a critical fix.