### PR TITLE
[Reviewer: Ellie] Add port to the default Sproutlet URIs

### DIFF
--- a/include/sproutlet_options.h
+++ b/include/sproutlet_options.h
@@ -172,6 +172,7 @@
                            opt.prefix_##NAME_LOWER +                           \
                            "." +                                               \
                            opt.sprout_hostname +                               \
+                           ":" + std::to_string(opt.port_##NAME_LOWER) +       \
                            ";transport=TCP";                                   \
   }                                                                            \
                                                                                \


### PR DESCRIPTION
This matches the old behaviour, where the default included a port (https://github.com/Metaswitch/sprout/blob/937b339c7949415102fe1332cb9371d8c9c10c43/sprout-base.root/etc/init.d/sprout#L265).

I've run make to confirm it compiles, and I'll test immediately on staging-aio.