### PR TITLE
Sproutlet subscribe routing

### DIFF
--- a/mk/sprout.mk
+++ b/mk/sprout.mk
@@ -19,6 +19,9 @@ sprout_test:
 sprout_full_test:
 	${MAKE} -C ${SPROUT_DIR} full_test
 
+sprout_runtest:
+	${MAKE} -C ${SPROUT_DIR} run_test
+
 sprout_clean:
 	${MAKE} -C ${SPROUT_DIR} clean
 

--- a/mk/sprout.mk
+++ b/mk/sprout.mk
@@ -19,9 +19,6 @@ sprout_test:
 sprout_full_test:
 	${MAKE} -C ${SPROUT_DIR} full_test
 
-sprout_runtest:
-	${MAKE} -C ${SPROUT_DIR} run_test
-
 sprout_clean:
 	${MAKE} -C ${SPROUT_DIR} clean
 

--- a/src/sproutletproxy.cpp
+++ b/src/sproutletproxy.cpp
@@ -177,6 +177,14 @@ Sproutlet* SproutletProxy::target_sproutlet(pjsip_msg* req,
     TRC_DEBUG("Next route for message cannot be a sproutlet");
   }
 
+  // Force the S-CSCF Sproutlet to only be chosen based on port - this ensures that the PJSIP
+  // authentication module is invoked between the I-CSCF and the S-CSCF
+  if (sproutlet && (sproutlet->service_name() == "scscf"))
+  {
+    TRC_DEBUG("Ignore SCSCF service");
+    sproutlet = NULL;
+  }
+
   if ((sproutlet == NULL) &&
       (port != 0))
   {
@@ -203,6 +211,18 @@ Sproutlet* SproutletProxy::target_sproutlet(pjsip_msg* req,
     }
   }
 
+  if (sproutlet && 
+      (sproutlet->service_name() == "scscf") &&
+      pjsip_method_cmp(&req->line.req.method, 
+                       pjsip_get_subscribe_method()) == 0)
+  {
+    // This is a subscribe being routed back to the S-CSCF sproutlet but to 
+    // get this handled correctly we need route it externally to make sure it 
+    // hits the subscription module.
+    TRC_DEBUG("Don't route S-CSCF subscribe message via sproutlet");
+    sproutlet = NULL;
+  }
+  
   return sproutlet;
 }
 

--- a/src/sproutletproxy.cpp
+++ b/src/sproutletproxy.cpp
@@ -181,7 +181,7 @@ Sproutlet* SproutletProxy::target_sproutlet(pjsip_msg* req,
   // authentication module is invoked between the I-CSCF and the S-CSCF
   if (sproutlet && (sproutlet->service_name() == "scscf"))
   {
-    TRC_DEBUG("Ignore SCSCF service");
+    TRC_DEBUG("Only route to SCSCF by port");
     sproutlet = NULL;
   }
 

--- a/src/sproutletproxy.cpp
+++ b/src/sproutletproxy.cpp
@@ -177,14 +177,6 @@ Sproutlet* SproutletProxy::target_sproutlet(pjsip_msg* req,
     TRC_DEBUG("Next route for message cannot be a sproutlet");
   }
 
-  // Force the S-CSCF Sproutlet to only be chosen based on port - this ensures that the PJSIP
-  // authentication module is invoked between the I-CSCF and the S-CSCF
-  if (sproutlet && (sproutlet->service_name() == "scscf"))
-  {
-    TRC_DEBUG("Only route to SCSCF by port");
-    sproutlet = NULL;
-  }
-
   if ((sproutlet == NULL) &&
       (port != 0))
   {

--- a/src/ut/sproutletproxy_test.cpp
+++ b/src/ut/sproutletproxy_test.cpp
@@ -29,7 +29,7 @@
  * propagate, and distribute a work formed by combining OpenSSL with The
  * Software, or a work derivative of such a combination, even if such
  * copying, modification, propagation, or distribution would otherwise
- * violate the terms of the GPL. You must comply with the GPL in all
+ * violate the terms of the GPL. Y must comply with the GPL in all
  * respects for all of the code used other than OpenSSL.
  * "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
  * Project and licensed under the OpenSSL Licenses, or a work based on such
@@ -591,7 +591,9 @@ public:
   {
     // We shouldn't get passed any subscribe messages
     ASSERT_NE(pj_stricmp2(&req->line.req.method.name, "SUBSCRIBE"), 0);
-    send_request(req);
+    pjsip_msg* rsp = create_response(req, PJSIP_SC_NOT_FOUND);
+    free_msg(req);
+    send_response(rsp);
   }
 };
 
@@ -2255,6 +2257,51 @@ TEST_F(SproutletProxyTest, LocalSubscription)
   // Check the 200 OK.
   tdata = current_txdata();
   RespMatcher(200).matches(tdata->msg);
+  tp->expect_target(tdata);
+  free_txdata();
+
+  // All done!
+  ASSERT_EQ(0, txdata_count());
+
+  delete tp;
+}
+
+TEST_F(SproutletProxyTest, LocalNonSubscribe)
+{
+  // Tests standard routing of a local subscription request to ensure it is
+  // not routed via the sproutlet interface.
+  pjsip_tx_data* tdata;
+
+  // Create a TCP connection to the listening port.
+  TransportFlow* tp = new TransportFlow(TransportFlow::Protocol::TCP,
+                                        44444,
+                                        "1.2.3.4",
+                                        49152);
+
+  // Inject a request with a Route header not referencing this node or the
+  // home domain.
+  Message msg1;
+  msg1._method = "INVITE";
+  msg1._requri = "sip:bob@homedomain";
+  msg1._from = "sip:alice@homedomain";
+  msg1._to = "sip:bob@homedomain";
+  msg1._via = tp->to_string(false);
+  msg1._route = "Route: <sip:scscf@proxy1.homedomain;transport=TCP;lr>\r\nRoute: <sip:proxy1.awaydomain;transport=TCP;lr>";
+  inject_msg(msg1.get_request(), tp);
+
+  // Expecting the forwarded SUBSCRIBE
+  ASSERT_EQ(2, txdata_count());
+
+  // Check the 100 Trying.
+  tdata = current_txdata();
+  RespMatcher(100).matches(tdata->msg);
+  tp->expect_target(tdata);
+  EXPECT_EQ("To: <sip:bob@homedomain>", get_headers(tdata->msg, "To")); // No tag
+  free_txdata();
+
+  // Check the 486 Loop Detected.
+  tdata = current_txdata();
+  RespMatcher(404).matches(tdata->msg);
   tp->expect_target(tdata);
   free_txdata();
 

--- a/src/ut/sproutletproxy_test.cpp
+++ b/src/ut/sproutletproxy_test.cpp
@@ -29,7 +29,7 @@
  * propagate, and distribute a work formed by combining OpenSSL with The
  * Software, or a work derivative of such a combination, even if such
  * copying, modification, propagation, or distribution would otherwise
- * violate the terms of the GPL. Y must comply with the GPL in all
+ * violate the terms of the GPL. You must comply with the GPL in all
  * respects for all of the code used other than OpenSSL.
  * "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
  * Project and licensed under the OpenSSL Licenses, or a work based on such


### PR DESCRIPTION
Route subscribe messages over external port rather than sproutlet interface to allow subscription module to process them.

Fixes https://github.com/Metaswitch/sprout/issues/1389