### PR TITLE
[Reviewer: ANDY] Fix up Subscribe routing

### DIFF
--- a/include/pjutils.h
+++ b/include/pjutils.h
@@ -240,6 +240,7 @@ void mark_sas_call_branch_ids(const SAS::TrailId trail, pjsip_cid_hdr* cid_hdr, 
 
 bool is_emergency_registration(pjsip_contact_hdr* contact_hdr);
 
+bool check_route_headers(pjsip_msg* msg);
 bool check_route_headers(pjsip_rx_data* rdata);
 
 void put_unary_param(pjsip_param* params_list,

--- a/include/sproutletproxy.h
+++ b/include/sproutletproxy.h
@@ -90,7 +90,7 @@ protected:
   Sproutlet* target_sproutlet(pjsip_msg* req,
                               int port,
                               std::string& alias,
-                              bool& sproutlet_rejected);
+                              bool& force_external_routing);
 
   /// Compare a SIP URI to a Sproutlet to see if they are a match (e.g.
   /// a message targeted at that URI would arrive at the given Sproutlet).
@@ -181,7 +181,7 @@ protected:
     Sproutlet* target_sproutlet(pjsip_msg* msg,
                                 int port,
                                 std::string& alias,
-                                bool& sproutlet_rejected);
+                                bool& force_external_routing);
 
     /// Checks to see if it is safe to destroy the UASTsx.
     void check_destroy();

--- a/include/sproutletproxy.h
+++ b/include/sproutletproxy.h
@@ -87,7 +87,10 @@ protected:
 
   /// Gets the next target Sproutlet for the message by analysing the top
   /// Route header.
-  Sproutlet* target_sproutlet(pjsip_msg* req, int port, std::string& alias);
+  Sproutlet* target_sproutlet(pjsip_msg* req,
+                              int port,
+                              std::string& alias,
+                              bool& sproutlet_rejected);
 
   /// Compare a SIP URI to a Sproutlet to see if they are a match (e.g.
   /// a message targeted at that URI would arrive at the given Sproutlet).
@@ -172,7 +175,13 @@ protected:
 
     /// Gets the next target Sproutlet for the message by analysing the top
     /// Route header.
-    Sproutlet* target_sproutlet(pjsip_msg* msg, int port, std::string& alias);
+    Sproutlet* target_sproutlet(pjsip_msg* msg,
+                                int port,
+                                std::string& alias);
+    Sproutlet* target_sproutlet(pjsip_msg* msg,
+                                int port,
+                                std::string& alias,
+                                bool& sproutlet_rejected);
 
     /// Checks to see if it is safe to destroy the UASTsx.
     void check_destroy();

--- a/include/subscription.h
+++ b/include/subscription.h
@@ -56,6 +56,8 @@ extern pj_status_t init_subscription(SubscriberDataManager* sdm,
                                      AnalyticsLogger* analytics_logger,
                                      int cfg_max_expires);
 
+extern pj_bool_t request_acceptable_to_subscription_module(pjsip_msg* msg,
+                                                           SAS::TrailId trail);
 extern void destroy_subscription();
 
 #endif

--- a/include/subscription.h
+++ b/include/subscription.h
@@ -49,15 +49,15 @@ extern "C" {
 
 extern pjsip_module mod_subscription;
 
-extern pj_status_t init_subscription(SubscriberDataManager* sdm,
-                                     SubscriberDataManager* remote_sdm,
-                                     HSSConnection* hss_connection,
-                                     ACRFactory* rfacr_factory,
-                                     AnalyticsLogger* analytics_logger,
-                                     int cfg_max_expires);
+pj_status_t init_subscription(SubscriberDataManager* sdm,
+                              SubscriberDataManager* remote_sdm,
+                              HSSConnection* hss_connection,
+                              ACRFactory* rfacr_factory,
+                              AnalyticsLogger* analytics_logger,
+                              int cfg_max_expires);
 
-extern pj_bool_t request_acceptable_to_subscription_module(pjsip_msg* msg,
-                                                           SAS::TrailId trail);
-extern void destroy_subscription();
+pj_bool_t request_acceptable_to_subscription_module(pjsip_msg* msg,
+                                                    SAS::TrailId trail);
+void destroy_subscription();
 
 #endif

--- a/src/pjutils.cpp
+++ b/src/pjutils.cpp
@@ -1696,17 +1696,24 @@ bool PJUtils::is_emergency_registration(pjsip_contact_hdr* contact_hdr)
 // which is local
 bool PJUtils::check_route_headers(pjsip_rx_data* rdata)
 {
+  return check_route_headers(rdata->msg_info.msg);
+}
+
+// Return true if there are no route headers, or there is exactly one,
+// which is local
+bool PJUtils::check_route_headers(pjsip_msg* msg)
+{
   // Get all the route headers
   int count = 0;
   bool local = true;
-  pjsip_route_hdr* route_hdr = (pjsip_route_hdr*)pjsip_msg_find_hdr(rdata->msg_info.msg, PJSIP_H_ROUTE, NULL);
+  pjsip_route_hdr* route_hdr = (pjsip_route_hdr*)pjsip_msg_find_hdr(msg, PJSIP_H_ROUTE, NULL);
 
   while (route_hdr != NULL)
   {
     count++;
     URIClass uri_class = URIClassifier::classify_uri(route_hdr->name_addr.uri);
     local = (uri_class == NODE_LOCAL_SIP_URI) || (uri_class == HOME_DOMAIN_SIP_URI);
-    route_hdr = (pjsip_route_hdr*)pjsip_msg_find_hdr(rdata->msg_info.msg, PJSIP_H_ROUTE, route_hdr->next);
+    route_hdr = (pjsip_route_hdr*)pjsip_msg_find_hdr(msg, PJSIP_H_ROUTE, route_hdr->next);
   }
 
   return (count < 2 && local);

--- a/src/sproutletproxy.cpp
+++ b/src/sproutletproxy.cpp
@@ -116,12 +116,12 @@ BasicProxy::UASTsx* SproutletProxy::create_uas_tsx()
 Sproutlet* SproutletProxy::target_sproutlet(pjsip_msg* req,
                                             int port,
                                             std::string& alias,
-                                            bool& sproutlet_rejected)
+                                            bool& force_external_routing)
 {
   TRC_DEBUG("Find target Sproutlet for request");
 
   Sproutlet* sproutlet = NULL;
-  sproutlet_rejected = false;
+  force_external_routing = false;
   std::string id;
 
   // Find and parse the top Route header.
@@ -215,7 +215,7 @@ Sproutlet* SproutletProxy::target_sproutlet(pjsip_msg* req,
     // get this handled correctly we need route it externally to make sure it 
     // hits the subscription module.
     TRC_DEBUG("Don't route S-CSCF subscribe message via sproutlet");
-    sproutlet_rejected = true;
+    force_external_routing = true;
     sproutlet = NULL;
   }
   
@@ -509,12 +509,12 @@ pj_status_t SproutletProxy::UASTsx::init(pjsip_rx_data* rdata)
     // Locate the target Sproutlet for the request, and create the helper and
     // the Sproutlet transaction.
     std::string alias;
-    bool sproutlet_rejected;
+    bool force_external_routing;
     Sproutlet* sproutlet =
                    target_sproutlet(_req->msg,
                                     rdata->tp_info.transport->local_name.port,
                                     alias,
-                                    sproutlet_rejected);
+                                    force_external_routing);
 
     if (sproutlet == NULL)
     {
@@ -530,7 +530,7 @@ pj_status_t SproutletProxy::UASTsx::init(pjsip_rx_data* rdata)
         // rejected the sproutlet selection - which means that we want to
         // route to the same location but route externally to get the
         // registrar/subscription modules
-        if (!sproutlet_rejected)
+        if (!force_external_routing)
         {
           TRC_INFO("Remove top Route header and forward request");
           pj_list_erase(route);
@@ -720,22 +720,22 @@ Sproutlet* SproutletProxy::UASTsx::target_sproutlet(pjsip_msg* msg,
                                                     int port,
                                                     std::string& alias)
 {
-  bool unused_sproutlet_rejected;
+  bool unused_force_external_routing;
   return _sproutlet_proxy->target_sproutlet(msg,
                                             port,
                                             alias,
-                                            unused_sproutlet_rejected);
+                                            unused_force_external_routing);
 }
 
 Sproutlet* SproutletProxy::UASTsx::target_sproutlet(pjsip_msg* msg,
                                                     int port,
                                                     std::string& alias,
-                                                    bool& sproutlet_rejected)
+                                                    bool& force_external_routing)
 {
   return _sproutlet_proxy->target_sproutlet(msg,
                                             port,
                                             alias,
-                                            sproutlet_rejected);
+                                            force_external_routing);
 }
 
 

--- a/src/sproutletproxy.cpp
+++ b/src/sproutletproxy.cpp
@@ -54,6 +54,7 @@ extern "C" {
 #include "sproutsasevent.h"
 #include "sproutletproxy.h"
 #include "snmp_sip_request_types.h"
+#include "subscription.h"
 
 const pj_str_t SproutletProxy::STR_SERVICE = {"service", 7};
 
@@ -111,15 +112,16 @@ BasicProxy::UASTsx* SproutletProxy::create_uas_tsx()
   return (BasicProxy::UASTsx*)new SproutletProxy::UASTsx(this);
 }
 
-
 /// Utility method to find the appropriate Sproutlet to handle a request.
 Sproutlet* SproutletProxy::target_sproutlet(pjsip_msg* req,
                                             int port,
-                                            std::string& alias)
+                                            std::string& alias,
+                                            bool& sproutlet_rejected)
 {
   TRC_DEBUG("Find target Sproutlet for request");
 
   Sproutlet* sproutlet = NULL;
+  sproutlet_rejected = false;
   std::string id;
 
   // Find and parse the top Route header.
@@ -203,15 +205,17 @@ Sproutlet* SproutletProxy::target_sproutlet(pjsip_msg* req,
     }
   }
 
-  if (sproutlet && 
+  // Now check whether we've allocated any sproutlets when we really want to
+  // route the message to the Subscription module instead
+  if ((sproutlet) &&
       (sproutlet->service_name() == "scscf") &&
-      pjsip_method_cmp(&req->line.req.method, 
-                       pjsip_get_subscribe_method()) == 0)
+      (request_acceptable_to_subscription_module(req, 0)))
   {
     // This is a subscribe being routed back to the S-CSCF sproutlet but to 
     // get this handled correctly we need route it externally to make sure it 
     // hits the subscription module.
     TRC_DEBUG("Don't route S-CSCF subscribe message via sproutlet");
+    sproutlet_rejected = true;
     sproutlet = NULL;
   }
   
@@ -505,10 +509,12 @@ pj_status_t SproutletProxy::UASTsx::init(pjsip_rx_data* rdata)
     // Locate the target Sproutlet for the request, and create the helper and
     // the Sproutlet transaction.
     std::string alias;
+    bool sproutlet_rejected;
     Sproutlet* sproutlet =
                    target_sproutlet(_req->msg,
                                     rdata->tp_info.transport->local_name.port,
-                                    alias);
+                                    alias,
+                                    sproutlet_rejected);
 
     if (sproutlet == NULL)
     {
@@ -520,9 +526,15 @@ pj_status_t SproutletProxy::UASTsx::init(pjsip_rx_data* rdata)
       {
         // There is a top Route header in the request, which by definition
         // caused the request to be routed to this node, so remove it and
-        // allow the request to be forwarded.
-        TRC_INFO("Remove top Route header and forward request");
-        pj_list_erase(route);
+        // allow the request to be forwarded. The exception here is if we
+        // rejected the sproutlet selection - which means that we want to
+        // route to the same location but route externally to get the
+        // registrar/subscription modules
+        if (!sproutlet_rejected)
+        {
+          TRC_INFO("Remove top Route header and forward request");
+          pj_list_erase(route);
+        }
       }
       else
       {
@@ -708,7 +720,22 @@ Sproutlet* SproutletProxy::UASTsx::target_sproutlet(pjsip_msg* msg,
                                                     int port,
                                                     std::string& alias)
 {
-  return _sproutlet_proxy->target_sproutlet(msg, port, alias);
+  bool unused_sproutlet_rejected;
+  return _sproutlet_proxy->target_sproutlet(msg,
+                                            port,
+                                            alias,
+                                            unused_sproutlet_rejected);
+}
+
+Sproutlet* SproutletProxy::UASTsx::target_sproutlet(pjsip_msg* msg,
+                                                    int port,
+                                                    std::string& alias,
+                                                    bool& sproutlet_rejected)
+{
+  return _sproutlet_proxy->target_sproutlet(msg,
+                                            port,
+                                            alias,
+                                            sproutlet_rejected);
 }
 
 
@@ -762,7 +789,9 @@ void SproutletProxy::UASTsx::schedule_requests()
     else
     {
       std::string alias;
-      Sproutlet* sproutlet = target_sproutlet(req.req->msg, 0, alias);
+      Sproutlet* sproutlet = target_sproutlet(req.req->msg,
+                                              0,
+                                              alias);
 
       if (sproutlet != NULL)
       {

--- a/src/subscription.cpp
+++ b/src/subscription.cpp
@@ -644,8 +644,13 @@ pj_bool_t request_acceptable_to_subscription_module(pjsip_msg* msg,
       !PJUtils::check_route_headers(msg))
   {
     TRC_DEBUG("Not processing subscription request not targeted at this domain or node");
-    SAS::Event event(trail, SASEvent::SUBSCRIBE_FAILED_EARLY_DOMAIN, 0);
-    SAS::report_event(event);
+    if (trail != 0)
+    {
+      // LCOV_EXCL_START - No SAS events in UT
+      SAS::Event event(trail, SASEvent::SUBSCRIBE_FAILED_EARLY_DOMAIN, 0);
+      SAS::report_event(event);
+      // LCOV_EXCL_STOP
+    }
     return PJ_FALSE;
   }
 
@@ -662,15 +667,20 @@ pj_bool_t request_acceptable_to_subscription_module(pjsip_msg* msg,
     // The Event header is missing or doesn't match "reg"
     TRC_DEBUG("Not processing subscription request that's not for the 'reg' package");
 
-    SAS::Event sas_event(trail, SASEvent::SUBSCRIBE_FAILED_EARLY_EVENT, 0);
-    if (event)
+    if (trail != 0)
     {
-      char event_hdr_str[256];
-      memset(event_hdr_str, 0, 256);
-      pjsip_hdr_print_on(event, event_hdr_str, 255);
-      sas_event.add_var_param(event_hdr_str);
+      // LCOV_EXCL_START - No SAS events in UT
+      SAS::Event sas_event(trail, SASEvent::SUBSCRIBE_FAILED_EARLY_EVENT, 0);
+      if (event)
+      {
+        char event_hdr_str[256];
+        memset(event_hdr_str, 0, 256);
+        pjsip_hdr_print_on(event, event_hdr_str, 255);
+        sas_event.add_var_param(event_hdr_str);
+      }
+      SAS::report_event(sas_event);
+      // LCOV_EXCL_STOP
     }
-    SAS::report_event(sas_event);
 
     return PJ_FALSE;
   }
@@ -698,9 +708,14 @@ pj_bool_t request_acceptable_to_subscription_module(pjsip_msg* msg,
       memset(accept_hdr_str, 0, 256);
       pjsip_hdr_print_on(accept, accept_hdr_str, 255);
 
-      SAS::Event event(trail, SASEvent::SUBSCRIBE_FAILED_EARLY_ACCEPT, 0);
-      event.add_var_param(accept_hdr_str);
-      SAS::report_event(event);
+      if (trail != 0)
+      {
+        // LCOV_EXCL_START - No SAS events in UT
+        SAS::Event event(trail, SASEvent::SUBSCRIBE_FAILED_EARLY_ACCEPT, 0);
+        event.add_var_param(accept_hdr_str);
+        SAS::report_event(event);
+        // LCOV_EXCL_STOP
+      }
 
       return PJ_FALSE;
     }

--- a/src/ut/siptest.cpp
+++ b/src/ut/siptest.cpp
@@ -107,6 +107,7 @@ SipTest::~SipTest()
 
 SipTest::TransportFlow* SipTest::_tp_default;
 SipTest* SipTest::_current_instance;
+pj_str_t scscf_domain = pj_str("scscf.proxy1.homedomain");
 
 /// Automatically run once, before the first test.
 void SipTest::SetUpTestCase(bool clear_host_mapping)
@@ -124,7 +125,8 @@ void SipTest::SetUpTestCase(bool clear_host_mapping)
   stack_data.home_domains.insert("homedomain");
   stack_data.default_home_domain = pj_str("homedomain");
   URIClassifier::home_domains.push_back(&stack_data.default_home_domain);
-  stack_data.scscf_uri = pj_str("sip:sprout.homedomain:5058;transport=TCP");
+  URIClassifier::home_domains.push_back(&scscf_domain);
+  stack_data.scscf_uri = pj_str("sip:scscf.sprout.homedomain:5058;transport=TCP");
   stack_data.cdf_domain = pj_str("cdfdomain");
   stack_data.name_cnt = 0;
   stack_data.name[stack_data.name_cnt] = stack_data.local_host;


### PR DESCRIPTION
This fixes up the Gemini Subscribe live tests

The change has been to make sure that the selected sproutlet is only rejected if the subscribe would be absorbed by the subscription module. Tested in UTs and the live tests