### PR TITLE
Reviewer MIRW: Change stack_data name array to a vector

### DIFF
--- a/include/stack.h
+++ b/include/stack.h
@@ -86,8 +86,7 @@ struct stack_data_struct
 
   int                  addr_family;
 
-  unsigned             name_cnt;
-  pj_str_t             name[30];
+  std::vector<pj_str_t> name;
   LastValueCache *     stats_aggregator;
 
   bool record_route_on_every_hop;

--- a/src/uri_classifier.cpp
+++ b/src/uri_classifier.cpp
@@ -83,13 +83,15 @@ static bool is_home_domain(pj_str_t host)
 
 static bool is_local_name(pj_str_t host)
 {
-    for (unsigned int i = 0; i < stack_data.name_cnt; ++i)
+  for (std::vector<pj_str_t>::iterator it = stack_data.name.begin();
+       it != stack_data.name.end();
+       ++it)
+  {
+    if (pj_stricmp(&host, &(*it)) == 0)
     {
-      if (pj_stricmp(&host, &stack_data.name[i]) == 0)
-      {
-        return true;
-      }
+      return true;
     }
+  }
 
   // Doesn't match
   return false;

--- a/src/ut/siptest.cpp
+++ b/src/ut/siptest.cpp
@@ -128,13 +128,7 @@ void SipTest::SetUpTestCase(bool clear_host_mapping)
   URIClassifier::home_domains.push_back(&scscf_domain);
   stack_data.scscf_uri = pj_str("sip:scscf.sprout.homedomain:5058;transport=TCP");
   stack_data.cdf_domain = pj_str("cdfdomain");
-  stack_data.name_cnt = 0;
-  stack_data.name[stack_data.name_cnt] = stack_data.local_host;
-  stack_data.name_cnt++;
-  stack_data.name[stack_data.name_cnt] = stack_data.public_host;
-  stack_data.name_cnt++;
-  stack_data.name[stack_data.name_cnt] = pj_str("sprout.homedomain");
-  stack_data.name_cnt++;
+  stack_data.name = {stack_data.local_host, stack_data.public_host, pj_str("sprout.homedomain")};
   stack_data.record_route_on_initiation_of_originating = true;
   stack_data.record_route_on_completion_of_terminating = true;
   stack_data.default_session_expires = 60 * 10;


### PR DESCRIPTION
Fixes #1427.

Tested by running the UTs cleanly and running the live tests against a system running Gemini and Memento that I happened to have lying around.

I've increased the array size to 30 in release-94-fixes and I'm not intending to merge this PR to that branch.