### PR TITLE
Reviewer EM: Check whether remote_sdms have servers configured before using them

### DIFF
--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -96,19 +96,23 @@ static bool sdm_access_common(SubscriberDataManager::AoRPair** aor_pair,
 
       while ((it != remote_sdms.end()) && (!found_binding))
       {
-        local_backup_aor_pair = (*it)->get_aor_data(aor_id, trail);
-
-        if ((local_backup_aor_pair != NULL) &&
-            (local_backup_aor_pair->current_contains_bindings()))
+        if ((*it)->has_servers())
         {
-          found_binding = true;
-          backup_aor_pair = local_backup_aor_pair;
+          local_backup_aor_pair = (*it)->get_aor_data(aor_id, trail);
 
-          // Flag that we have allocated the memory for the backup pair so
-          // that we can tidy it up later.
-          backup_aor_pair_alloced = true;
+          if ((local_backup_aor_pair != NULL) &&
+              (local_backup_aor_pair->current_contains_bindings()))
+          {
+            found_binding = true;
+            backup_aor_pair = local_backup_aor_pair;
+
+            // Flag that we have allocated the memory for the backup pair so
+            // that we can tidy it up later.
+            backup_aor_pair_alloced = true;
+          }
         }
-        else
+
+        if (!found_binding)
         {
           ++it;
 
@@ -305,14 +309,17 @@ void AoRTimeoutTask::handle_response()
          sdm != _cfg->_remote_sdms.end();
          ++sdm)
     {
-      bool ignored;
-      SubscriberDataManager::AoRPair* remote_aor_pair =
-                                         set_aor_data(*sdm,
-                                                      _aor_id,
-                                                      aor_pair,
-                                                      {},
-                                                      ignored);
-      delete remote_aor_pair;
+      if ((*sdm)->has_servers())
+      {
+        bool ignored;
+        SubscriberDataManager::AoRPair* remote_aor_pair =
+                                                         set_aor_data(*sdm,
+                                                                      _aor_id,
+                                                                      aor_pair,
+                                                                      {},
+                                                                      ignored);
+        delete remote_aor_pair;
+      }
     }
     // LCOV_EXCL_STOP
 
@@ -489,14 +496,17 @@ HTTPCode DeregistrationTask::handle_request()
            sdm != _cfg->_remote_sdms.end();
            ++sdm)
       {
-        SubscriberDataManager::AoRPair* remote_aor_pair =
-          deregister_bindings(*sdm,
-                              it->first,
-                              it->second,
-                              aor_pair,
-                              {},
-                              impis_to_delete);
-        delete remote_aor_pair;
+        if ((*sdm)->has_servers())
+        {
+          SubscriberDataManager::AoRPair* remote_aor_pair =
+            deregister_bindings(*sdm,
+                                it->first,
+                                it->second,
+                                aor_pair,
+                                {},
+                                impis_to_delete);
+          delete remote_aor_pair;
+        }
       }
     }
     // LCOV_EXCL_STOP

--- a/src/registrar.cpp
+++ b/src/registrar.cpp
@@ -279,19 +279,23 @@ SubscriberDataManager::AoRPair* write_to_store(
 
         while ((it != backup_sdms.end()) && (!found_binding))
         {
-          local_backup_aor = (*it)->get_aor_data(aor, trail);
-
-          if ((local_backup_aor != NULL) &&
-              (local_backup_aor->current_contains_bindings()))
+          if ((*it)->has_servers())
           {
-            found_binding = true;
-            backup_aor = local_backup_aor;
+            local_backup_aor = (*it)->get_aor_data(aor, trail);
 
-            // Flag that we have allocated the memory for the backup pair so
-            // that we can tidy it up later.
-            backup_aor_alloced = true;
+            if ((local_backup_aor != NULL) &&
+                (local_backup_aor->current_contains_bindings()))
+            {
+              found_binding = true;
+              backup_aor = local_backup_aor;
+
+              // Flag that we have allocated the memory for the backup pair so
+              // that we can tidy it up later.
+              backup_aor_alloced = true;
+            }
           }
-          else
+
+          if (!found_binding)
           {
             ++it;
 
@@ -753,20 +757,23 @@ void process_register_request(pjsip_rx_data* rdata)
          it != remote_sdms.end();
          ++it)
     {
-      int tmp_expiry = 0;
-      bool ignored;
-      SubscriberDataManager::AoRPair* remote_aor_pair =
-                                      write_to_store(*it,
-                                                     aor,
-                                                     rdata,
-                                                     now,
-                                                     tmp_expiry,
-                                                     ignored,
-                                                     aor_pair,
-                                                     {},
-                                                     private_id_for_binding,
-                                                     trail);
-      delete remote_aor_pair;
+      if ((*it)->has_servers())
+      {
+        int tmp_expiry = 0;
+        bool ignored;
+        SubscriberDataManager::AoRPair* remote_aor_pair =
+          write_to_store(*it,
+                         aor,
+                         rdata,
+                         now,
+                         tmp_expiry,
+                         ignored,
+                         aor_pair,
+                         {},
+                         private_id_for_binding,
+                         trail);
+        delete remote_aor_pair;
+      }
     }
   }
   else

--- a/src/scscfsproutlet.cpp
+++ b/src/scscfsproutlet.cpp
@@ -236,7 +236,12 @@ void SCSCFSproutlet::get_bindings(const std::string& aor,
            ((*aor_pair == NULL) || !(*aor_pair)->current_contains_bindings()))
     {
       delete *aor_pair;
-      *aor_pair = (*it)->get_aor_data(aor, trail);
+
+      if ((*it)->has_servers())
+      {
+        *aor_pair = (*it)->get_aor_data(aor, trail);
+      }
+
       ++it;
     }
   }

--- a/src/subscription.cpp
+++ b/src/subscription.cpp
@@ -197,21 +197,25 @@ SubscriberDataManager::AoRPair* write_subscriptions_to_store(
 
         while ((it != backup_sdms.end()) && (!found_subscription))
         {
-          local_backup_aor = (*it)->get_aor_data(aor, trail);
-
-          if ((local_backup_aor != NULL) &&
-              (local_backup_aor->current_contains_subscriptions()))
+          if ((*it)->has_servers())
           {
-            // LCOV_EXCL_START - this code is very similar to code in handlers.cpp and is unit tested there.
-            found_subscription = true;
-            backup_aor = local_backup_aor;
+            local_backup_aor = (*it)->get_aor_data(aor, trail);
 
-            // Flag that we have allocated the memory for the backup pair so
-            // that we can tidy it up later.
-            backup_aor_alloced = true;
-            // LCOV_EXCL_STOP
+            if ((local_backup_aor != NULL) &&
+                (local_backup_aor->current_contains_subscriptions()))
+            {
+              // LCOV_EXCL_START - this code is very similar to code in handlers.cpp and is unit tested there.
+              found_subscription = true;
+              backup_aor = local_backup_aor;
+
+              // Flag that we have allocated the memory for the backup pair so
+              // that we can tidy it up later.
+              backup_aor_alloced = true;
+              // LCOV_EXCL_STOP
+            }
           }
-          else
+
+          if (!found_subscription)
           {
             ++it;
 
@@ -574,20 +578,23 @@ void process_subscription_request(pjsip_rx_data* rdata)
          it != remote_sdms.end();
          ++it)
     {
-      SubscriberDataManager::AoRPair* remote_aor_pair =
-         write_subscriptions_to_store(*it,
-                                      aor,
-                                      rdata,
-                                      now,
-                                      aor_pair,
-                                      {},
-                                      trail,
-                                      public_id,
-                                      false,
-                                      acr,
-                                      ccfs,
-                                      ecfs);
-      delete remote_aor_pair;
+      if ((*it)->has_servers())
+      {
+        SubscriberDataManager::AoRPair* remote_aor_pair =
+          write_subscriptions_to_store(*it,
+                                       aor,
+                                       rdata,
+                                       now,
+                                       aor_pair,
+                                       {},
+                                       trail,
+                                       public_id,
+                                       false,
+                                       acr,
+                                       ccfs,
+                                       ecfs);
+        delete remote_aor_pair;
+      }
     }
   }
   else

--- a/src/ut/handlers_test.cpp
+++ b/src/ut/handlers_test.cpp
@@ -182,8 +182,10 @@ TEST_F(AoRTimeoutTasksTest, MainlineTest)
       EXPECT_CALL(*stack, send_reply(_, 200, _));
       EXPECT_CALL(*store, get_aor_data(aor_id, _)).WillOnce(Return(aor));
       EXPECT_CALL(*store, set_aor_data(aor_id, aor, _, _, _, _)).WillOnce(Return(Store::OK));
+      EXPECT_CALL(*remote_store1, has_servers()).WillOnce(Return(true));
       EXPECT_CALL(*remote_store1, get_aor_data(aor_id, _)).WillOnce(Return(remote_aor1));
       EXPECT_CALL(*remote_store1, set_aor_data(aor_id, remote_aor1, _, _, _, _)).WillOnce(Return(Store::OK));
+      EXPECT_CALL(*remote_store2, has_servers()).WillOnce(Return(true));
       EXPECT_CALL(*remote_store2, get_aor_data(aor_id, _)).WillOnce(Return(remote_aor2));
       EXPECT_CALL(*remote_store2, set_aor_data(aor_id, remote_aor2, _, _, _, _)).WillOnce(Return(Store::OK));
   }
@@ -255,9 +257,11 @@ TEST_F(AoRTimeoutTasksTest, RemoteAoRNoBindingsTest)
       EXPECT_CALL(*stack, send_reply(_, 200, _));
       EXPECT_CALL(*store, get_aor_data(aor_id, _)).WillOnce(Return(aor));
       EXPECT_CALL(*store, set_aor_data(aor_id, aor, _, _, _, _)).WillOnce(Return(Store::OK));
+      EXPECT_CALL(*remote_store1, has_servers()).WillOnce(Return(true));
       EXPECT_CALL(*remote_store1, get_aor_data(aor_id, _)).WillOnce(Return(remote1_aor_pair));
       EXPECT_CALL(*remote_store1, set_aor_data(aor_id, remote1_aor_pair, _, _, _, _))
                    .WillOnce(Return(Store::OK));
+      EXPECT_CALL(*remote_store2, has_servers()).WillOnce(Return(true));
       EXPECT_CALL(*remote_store2, get_aor_data(aor_id, _)).WillOnce(Return(remote2_aor_pair));
       EXPECT_CALL(*remote_store2, set_aor_data(aor_id, remote2_aor_pair, _, _, _, _))
                    .WillOnce(Return(Store::OK));
@@ -291,10 +295,13 @@ TEST_F(AoRTimeoutTasksTest, LocalAoRNoBindingsTest)
     InSequence s;
       EXPECT_CALL(*stack, send_reply(_, 200, _));
       EXPECT_CALL(*store, get_aor_data(aor_id, _)).WillOnce(Return(aor_pair));
+      EXPECT_CALL(*remote_store1, has_servers()).WillOnce(Return(true));
       EXPECT_CALL(*remote_store1, get_aor_data(aor_id, _)).WillOnce(Return(remote1_aor1));
       EXPECT_CALL(*store, set_aor_data(aor_id, aor_pair, _, _, _, _)).WillOnce(Return(Store::OK));
+      EXPECT_CALL(*remote_store1, has_servers()).WillOnce(Return(true));
       EXPECT_CALL(*remote_store1, get_aor_data(aor_id, _)).WillOnce(Return(remote1_aor2));
       EXPECT_CALL(*remote_store1, set_aor_data(aor_id, remote1_aor2, _, _, _, _)).WillOnce(Return(Store::OK));
+      EXPECT_CALL(*remote_store2, has_servers()).WillOnce(Return(true));
       EXPECT_CALL(*remote_store2, get_aor_data(aor_id, _)).WillOnce(Return(remote2_aor));
       EXPECT_CALL(*remote_store2, set_aor_data(aor_id, remote2_aor, _, _, _, _)).WillOnce(Return(Store::OK));
   }
@@ -336,11 +343,15 @@ TEST_F(AoRTimeoutTasksTest, NoBindingsTest)
     InSequence s;
       EXPECT_CALL(*stack, send_reply(_, 200, _));
       EXPECT_CALL(*store, get_aor_data(aor_id, _)).WillOnce(Return(aor_pair));
+      EXPECT_CALL(*remote_store1, has_servers()).WillOnce(Return(true));
       EXPECT_CALL(*remote_store1, get_aor_data(aor_id, _)).WillOnce(Return(remote1_aor_pair1));
+      EXPECT_CALL(*remote_store2, has_servers()).WillOnce(Return(true));
       EXPECT_CALL(*remote_store2, get_aor_data(aor_id, _)).WillOnce(Return(remote2_aor_pair1));
       EXPECT_CALL(*store, set_aor_data(aor_id, aor_pair, _, _, _, _)).WillOnce(DoAll(SetArgReferee<3>(true), Return(Store::OK)));
+      EXPECT_CALL(*remote_store1, has_servers()).WillOnce(Return(true));
       EXPECT_CALL(*remote_store1, get_aor_data(aor_id, _)).WillOnce(Return(remote1_aor_pair2));
       EXPECT_CALL(*remote_store1, set_aor_data(aor_id, remote1_aor_pair2, _, _, _, _)).WillOnce(DoAll(SetArgReferee<3>(true), Return(Store::OK)));
+      EXPECT_CALL(*remote_store2, has_servers()).WillOnce(Return(true));
       EXPECT_CALL(*remote_store2, get_aor_data(aor_id, _)).WillOnce(Return(remote2_aor_pair2));
       EXPECT_CALL(*remote_store2, set_aor_data(aor_id, remote2_aor_pair2, _, _, _, _)).WillOnce(DoAll(SetArgReferee<3>(true), Return(Store::OK)));
       EXPECT_CALL(*mock_hss, update_registration_state(aor_id, "", HSSConnection::DEREG_TIMEOUT, 0));
@@ -369,8 +380,10 @@ TEST_F(AoRTimeoutTasksTest, NullAoRTest)
       EXPECT_CALL(*stack, send_reply(_, 200, _));
       EXPECT_CALL(*store, get_aor_data(aor_id, _)).WillOnce(Return(aor_pair));
       EXPECT_CALL(*store, set_aor_data(aor_id, _, _, _, _, _)).Times(0);
+      EXPECT_CALL(*remote_store1, has_servers()).WillOnce(Return(true));
       EXPECT_CALL(*remote_store1, get_aor_data(aor_id, _)).WillOnce(Return(remote1_aor_pair));
       EXPECT_CALL(*remote_store1, set_aor_data(aor_id, _, _, _, _, _)).Times(0);
+      EXPECT_CALL(*remote_store2, has_servers()).WillOnce(Return(true));
       EXPECT_CALL(*remote_store2, get_aor_data(aor_id, _)).WillOnce(Return(remote2_aor_pair));
       EXPECT_CALL(*remote_store2, set_aor_data(aor_id, _, _, _, _, _)).Times(0);
   }


### PR DESCRIPTION
Along with https://github.com/Metaswitch/cpp-common/pull/512, this fixes #1428.

I've run the UTs cleanly and the live tests.