### PR TITLE
[Reviewer Alex] Only session_expires with record_route

### DIFF
--- a/include/scscfsproutlet.h
+++ b/include/scscfsproutlet.h
@@ -313,7 +313,7 @@ private:
   bool lookup_ifcs(std::string public_id,
                    Ifcs& ifcs);
 
-  /// Record-Route the S-CSCF sproutlet into a dialog.  The third parameter
+  /// Add the S-CSCF sproutlet into a dialog.  The third parameter
   /// passed may be attached to the Record-Route and can be used to recover the
   /// billing role that is in use on subsequent in-dialog messages.
   ///
@@ -321,9 +321,9 @@ private:
   /// @param billing_rr   - Whether to add a `billing-role` parameter to the RR
   /// @param billing_role - The contents of the `billing-role` (ignored if
   ///                       `billing_rr` is false)
-  void add_record_route(pjsip_msg* msg,
-                        bool billing_rr,
-                        ACR::NodeRole billing_role);
+  void add_to_dialog(pjsip_msg* msg,
+                     bool billing_rr,
+                     ACR::NodeRole billing_role);
 
   /// Retrieve the billing role for the incoming message.  This should have been
   /// set during session initiation.

--- a/src/scscfsproutlet.cpp
+++ b/src/scscfsproutlet.cpp
@@ -424,8 +424,6 @@ void SCSCFSproutletTsx::on_rx_initial_request(pjsip_msg* req)
 
   pjsip_status_code status_code = PJSIP_SC_OK;
 
-  _se_helper.process_request(req, get_pool(req), trail());
-
   // Work out if we should be auto-registering the user based on this
   // request and if we are, also work out the IMPI to register them with.
   const pjsip_route_hdr* top_route = route_hdr();
@@ -514,6 +512,8 @@ void SCSCFSproutletTsx::on_rx_in_dialog_request(pjsip_msg* req)
 {
   TRC_INFO("S-CSCF received in-dialog request");
 
+  // We must be record-routed to be in the dialog
+  _record_routed = true;
   _se_helper.process_request(req, get_pool(req), trail());
 
   // Create an ACR for this request and pass the request to it.
@@ -544,7 +544,10 @@ void SCSCFSproutletTsx::on_rx_response(pjsip_msg* rsp, int fork_id)
 {
   TRC_INFO("S-CSCF received response");
 
-  _se_helper.process_response(rsp, get_pool(rsp), trail());
+  if (_record_routed)
+  {
+    _se_helper.process_response(rsp, get_pool(rsp), trail());
+  }
 
   // Pass the received response to the ACR.
   // @TODO - timestamp from response???
@@ -921,7 +924,7 @@ pjsip_status_code SCSCFSproutletTsx::determine_served_user(pjsip_msg* req)
           if (stack_data.record_route_on_diversion)
           {
             TRC_DEBUG("Add service to dialog - originating Cdiv");
-            add_record_route(req, false, ACR::NODE_ROLE_ORIGINATING);
+            add_to_dialog(req, false, ACR::NODE_ROLE_ORIGINATING);
           }
         }
         else
@@ -941,11 +944,11 @@ pjsip_status_code SCSCFSproutletTsx::determine_served_user(pjsip_msg* req)
         TRC_DEBUG("Add service to dialog - AS hop");
         if (_session_case->is_terminating())
         {
-          add_record_route(req, false, ACR::NODE_ROLE_TERMINATING);
+          add_to_dialog(req, false, ACR::NODE_ROLE_TERMINATING);
         }
         else
         {
-          add_record_route(req, false, ACR::NODE_ROLE_ORIGINATING);
+          add_to_dialog(req, false, ACR::NODE_ROLE_ORIGINATING);
         }
       }
     }
@@ -971,7 +974,7 @@ pjsip_status_code SCSCFSproutletTsx::determine_served_user(pjsip_msg* req)
         if (stack_data.record_route_on_initiation_of_terminating)
         {
           TRC_DEBUG("Single Record-Route - initiation of terminating handling");
-          add_record_route(req, false, ACR::NODE_ROLE_TERMINATING);
+          add_to_dialog(req, false, ACR::NODE_ROLE_TERMINATING);
         }
       }
       else if (_session_case->is_originating())
@@ -979,7 +982,7 @@ pjsip_status_code SCSCFSproutletTsx::determine_served_user(pjsip_msg* req)
         if (stack_data.record_route_on_initiation_of_originating)
         {
           TRC_DEBUG("Single Record-Route - initiation of originating handling");
-          add_record_route(req, true, ACR::NODE_ROLE_ORIGINATING);
+          add_to_dialog(req, true, ACR::NODE_ROLE_ORIGINATING);
           acr->override_session_id(PJUtils::pj_str_to_string(&PJSIP_MSG_CID_HDR(req)->id));
         }
       }
@@ -1146,7 +1149,7 @@ void SCSCFSproutletTsx::apply_originating_services(pjsip_msg* req)
     if (stack_data.record_route_on_completion_of_originating)
     {
       TRC_DEBUG("Add service to dialog - end of originating handling");
-      add_record_route(req, false, ACR::NODE_ROLE_ORIGINATING);
+      add_to_dialog(req, false, ACR::NODE_ROLE_ORIGINATING);
     }
 
     // Attempt to translate the RequestURI using ENUM or an alternative
@@ -1217,7 +1220,7 @@ void SCSCFSproutletTsx::apply_terminating_services(pjsip_msg* req)
     if (stack_data.record_route_on_completion_of_terminating)
     {
       TRC_DEBUG("Add service to dialog - end of terminating handling");
-      add_record_route(req, true, ACR::NODE_ROLE_TERMINATING);
+      add_to_dialog(req, true, ACR::NODE_ROLE_TERMINATING);
 
       ACR* acr = _as_chain_link.acr();
       if (acr != NULL)
@@ -1683,14 +1686,15 @@ bool SCSCFSproutletTsx::lookup_ifcs(std::string public_id, Ifcs& ifcs)
 }
 
 
-/// Record-Route the S-CSCF sproutlet into a dialog.  The parameter passed will
+/// Add the S-CSCF sproutlet into a dialog.  The parameter passed will
 /// be attached to the Record-Route and can be used to recover the billing
 /// role that is in use on subsequent in-dialog messages.
-void SCSCFSproutletTsx::add_record_route(pjsip_msg* msg,
-                                         bool billing_rr,
-                                         ACR::NodeRole billing_role)
+void SCSCFSproutletTsx::add_to_dialog(pjsip_msg* msg,
+                                      bool billing_rr,
+                                      ACR::NodeRole billing_role)
 {
   pj_pool_t* pool = get_pool(msg);
+  _se_helper.process_request(msg, pool, trail());
 
   pjsip_route_hdr* rr = NULL;
   if (!_record_routed)

--- a/src/ut/scscf_test.cpp
+++ b/src/ut/scscf_test.cpp
@@ -8270,3 +8270,130 @@ TEST_F(SCSCFTest, TestSessionExpires)
   rsp_hdrs.push_back(HeaderMatcher("Session-Expires", "Session-Expires: .*"));
   doSuccessfulFlow(msg, testing::MatchesRegex(".*wuntootreefower.*"), hdrs, false, rsp_hdrs);
 }
+
+TEST_F(SCSCFTest, TestSessionExpiresInDialog)
+{
+  SCOPED_TRACE("");
+  _hss_connection->set_impu_result("sip:6505551000@homedomain", "call", HSSConnection::STATE_REGISTERED, "");
+
+  // Send an UPDATE in-dialog request to which we should always add RR and SE.
+  // Then check that if the UAS strips the SE, that Sprout tells the UAC to be
+  // the refresher. This ensures that our response processing is correct.
+  Message msg;
+  msg._extra = "Supported: timer";
+  msg._in_dialog = true;
+
+  list<HeaderMatcher> hdrs;
+  hdrs.push_back(HeaderMatcher("Record-Route", "Record-Route:.*"));
+  hdrs.push_back(HeaderMatcher("Session-Expires", "Session-Expires:.*"));
+
+  list<HeaderMatcher> rsp_hdrs;
+  rsp_hdrs.push_back(HeaderMatcher("Session-Expires"));
+  rsp_hdrs.push_back(HeaderMatcher("Record-Route"));
+}
+
+TEST_F(SCSCFTest, TestSessionExpiresAStoAS)
+{
+  SCOPED_TRACE("");
+  register_uri(_sdm, _hss_connection, "6505551234", "homedomain", "sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob");
+  _hss_connection->set_impu_result("sip:6505551000@homedomain", "call", HSSConnection::STATE_REGISTERED,
+                                R"(<IMSSubscription><ServiceProfile>
+                                <PublicIdentity><Identity>sip:6505551000@homedomain</Identity></PublicIdentity>
+                                  <InitialFilterCriteria>
+                                    <Priority>2</Priority>
+                                    <TriggerPoint>
+                                    <ConditionTypeCNF>0</ConditionTypeCNF>
+                                    <SPT>
+                                      <ConditionNegated>0</ConditionNegated>
+                                      <Group>0</Group>
+                                      <Method>INVITE</Method>
+                                      <Extension></Extension>
+                                    </SPT>
+                                  </TriggerPoint>
+                                  <ApplicationServer>
+                                    <ServerName>sip:4.2.3.4:56788;transport=UDP</ServerName>
+                                    <DefaultHandling>0</DefaultHandling>
+                                  </ApplicationServer>
+                                  </InitialFilterCriteria>
+                                  <InitialFilterCriteria>
+                                    <Priority>1</Priority>
+                                    <TriggerPoint>
+                                    <ConditionTypeCNF>0</ConditionTypeCNF>
+                                    <SPT>
+                                      <ConditionNegated>0</ConditionNegated>
+                                      <Group>0</Group>
+                                      <Method>INVITE</Method>
+                                      <Extension></Extension>
+                                    </SPT>
+                                  </TriggerPoint>
+                                  <ApplicationServer>
+                                    <ServerName>sip:1.2.3.4:56789;transport=UDP</ServerName>
+                                    <DefaultHandling>0</DefaultHandling>
+                                  </ApplicationServer>
+                                  </InitialFilterCriteria>
+                                </ServiceProfile></IMSSubscription>)");
+
+  TransportFlow tpAS1(TransportFlow::Protocol::UDP, stack_data.scscf_port, "1.2.3.4", 56789);
+  TransportFlow tpAS2(TransportFlow::Protocol::UDP, stack_data.scscf_port, "4.2.3.4", 56788);
+
+
+  // Send an INVITE
+  Message msg;
+  msg._via = "10.99.88.11:12345;transport=TCP";
+  msg._to = "6505551234@homedomain";
+  msg._todomain = "";
+  msg._route = "Route: <sip:homedomain;orig>";
+  msg._requri = "sip:6505551234@homedomain";
+  msg._method = "INVITE";
+
+  pjsip_msg* out;
+  inject_msg(msg.get_request());
+
+  // INVITE passed to AS1
+  SCOPED_TRACE("INVITE (1)");
+  ASSERT_EQ(2, txdata_count());
+  free_txdata();
+  out = current_txdata()->msg;
+  ReqMatcher r1("INVITE");
+  ASSERT_NO_FATAL_FAILURE(r1.matches(out));
+
+  ASSERT_TRUE(!get_headers(out, "Record-Route").empty());
+  ASSERT_TRUE(!get_headers(out, "Session-Expires").empty());
+
+
+  // AS proxies INVITE back.
+  const pj_str_t STR_ROUTE = pj_str("Route");
+  const pj_str_t STR_REC_ROUTE = pj_str("Record-Route");
+  const pj_str_t STR_SESS_EXP = pj_str("Session-Expires");
+  pjsip_hdr* hdr = (pjsip_hdr*)pjsip_msg_find_hdr_by_name(out, &STR_ROUTE, NULL);
+  pjsip_hdr* rr_hdr = (pjsip_hdr*)pjsip_msg_find_hdr_by_name(out, &STR_REC_ROUTE, NULL);
+  pjsip_hdr* se_hdr = (pjsip_hdr*)pjsip_msg_find_hdr_by_name(out, &STR_SESS_EXP, NULL);
+  pj_list_erase(rr_hdr);
+  pj_list_erase(se_hdr);
+
+  if (hdr)
+  {
+    pj_list_erase(hdr);
+  }
+
+  inject_msg(out, &tpAS1);
+  free_txdata();
+
+  // 100 Trying goes back to AS1
+  out = current_txdata()->msg;
+  RespMatcher(100).matches(out);
+  tpAS1.expect_target(current_txdata(), true);  // Requests always come back on same transport
+  msg.set_route(out);
+  free_txdata();
+
+  // INVITE passed on to AS2
+  SCOPED_TRACE("INVITE (2)");
+  out = current_txdata()->msg;
+  ASSERT_NO_FATAL_FAILURE(r1.matches(out));
+  tpAS2.expect_target(current_txdata(), false);
+
+  // Should not RR between AS's and therefore shouldn't SE
+  ASSERT_TRUE(get_headers(out, "Record-Route").empty());
+  ASSERT_TRUE(get_headers(out, "Session-Expires").empty());
+}
+

--- a/src/ut/scscf_test.cpp
+++ b/src/ut/scscf_test.cpp
@@ -8274,6 +8274,7 @@ TEST_F(SCSCFTest, TestSessionExpires)
 TEST_F(SCSCFTest, TestSessionExpiresInDialog)
 {
   SCOPED_TRACE("");
+  register_uri(_sdm, _hss_connection, "6505551234", "homedomain", "sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob");
   _hss_connection->set_impu_result("sip:6505551000@homedomain", "call", HSSConnection::STATE_REGISTERED, "");
 
   // Send an UPDATE in-dialog request to which we should always add RR and SE.
@@ -8284,15 +8285,17 @@ TEST_F(SCSCFTest, TestSessionExpiresInDialog)
   msg._in_dialog = true;
 
   list<HeaderMatcher> hdrs;
-  hdrs.push_back(HeaderMatcher("Record-Route", "Record-Route:.*"));
+  hdrs.push_back(HeaderMatcher("Record-Route"));
   hdrs.push_back(HeaderMatcher("Session-Expires", "Session-Expires:.*"));
 
   list<HeaderMatcher> rsp_hdrs;
-  rsp_hdrs.push_back(HeaderMatcher("Session-Expires"));
+  rsp_hdrs.push_back(HeaderMatcher("Session-Expires", "Session-Expires:.*;refresher=uac"));
   rsp_hdrs.push_back(HeaderMatcher("Record-Route"));
+
+  doSuccessfulFlow(msg, testing::MatchesRegex(".*homedomain.*"), hdrs, false, rsp_hdrs);
 }
 
-TEST_F(SCSCFTest, TestSessionExpiresAStoAS)
+TEST_F(SCSCFTest, TestSessionExpiresWhenNoRecordRoute)
 {
   SCOPED_TRACE("");
   register_uri(_sdm, _hss_connection, "6505551234", "homedomain", "sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob");


### PR DESCRIPTION
This is a fix to some slightly confusing behavior where we occasionally add a session expires header without record-routing ourselves into the dialog. Doing so, while not 'wrong', led to some confusing issues in the field.

I've added some UTs for the correct behavior which now pass. No live testing performed yet. 