### PR TITLE
[Reviewer: Graeme] Always present I-CSCF stats

### DIFF
--- a/include/bgcfsproutlet.h
+++ b/include/bgcfsproutlet.h
@@ -73,6 +73,8 @@ public:
                 BgcfService* bgcf_service,
                 EnumService* enum_service,
                 ACRFactory* acr_factory,
+                SNMP::SuccessFailCountByRequestTypeTable* incoming_sip_transactions_tbl,
+                SNMP::SuccessFailCountByRequestTypeTable* outgoing_sip_transactions_tbl,
                 bool override_npdi);
   ~BGCFSproutlet();
 

--- a/include/icscfsproutlet.h
+++ b/include/icscfsproutlet.h
@@ -75,6 +75,8 @@ public:
                  ACRFactory* acr_factory,
                  SCSCFSelector* scscf_selector,
                  EnumService* enum_service,
+                 SNMP::SuccessFailCountByRequestTypeTable* incoming_sip_transactions_tbl,
+                 SNMP::SuccessFailCountByRequestTypeTable* outgoing_sip_transactions_tbl,
                  bool override_npdi);
 
   virtual ~ICSCFSproutlet();

--- a/include/scscfsproutlet.h
+++ b/include/scscfsproutlet.h
@@ -87,6 +87,8 @@ public:
                  HSSConnection* hss,
                  EnumService* enum_service,
                  ACRFactory* acr_factory,
+                 SNMP::SuccessFailCountByRequestTypeTable* incoming_sip_transactions_tbl,
+                 SNMP::SuccessFailCountByRequestTypeTable* outgoing_sip_transactions_tbl,
                  bool override_npdi,
                  int session_continued_timeout = DEFAULT_SESSION_CONTINUED_TIMEOUT,
                  int session_terminated_timeout = DEFAULT_SESSION_TERMINATED_TIMEOUT,

--- a/include/sproutlet.h
+++ b/include/sproutlet.h
@@ -562,11 +562,7 @@ class Sproutlet
 {
 public:
   /// Virtual destructor.
-  virtual ~Sproutlet()
-  {
-    delete _incoming_sip_transactions_tbl;
-    delete _outgoing_sip_transactions_tbl;
-  }
+  virtual ~Sproutlet() {}
 
   SNMP::SuccessFailCountByRequestTypeTable* _incoming_sip_transactions_tbl;
   SNMP::SuccessFailCountByRequestTypeTable* _outgoing_sip_transactions_tbl;
@@ -607,7 +603,7 @@ protected:
             int port,
             const std::string& service_host="",
             SNMP::SuccessFailCountByRequestTypeTable* incoming_sip_transactions_tbl = NULL,
-            SNMP::SuccessFailCountByRequestTypeTable* outgoing_sip_transactions_tbl = NULL):
+            SNMP::SuccessFailCountByRequestTypeTable* outgoing_sip_transactions_tbl = NULL) :
     _incoming_sip_transactions_tbl(incoming_sip_transactions_tbl),
     _outgoing_sip_transactions_tbl(outgoing_sip_transactions_tbl),
     _service_name(service_name),

--- a/include/sproutlet.h
+++ b/include/sproutlet.h
@@ -562,11 +562,15 @@ class Sproutlet
 {
 public:
   /// Virtual destructor.
-  virtual ~Sproutlet() {}
+  virtual ~Sproutlet()
+  {
+    delete _incoming_sip_transactions_tbl;
+    delete _outgoing_sip_transactions_tbl;
+  }
 
-  SNMP::SuccessFailCountByRequestTypeTable* _incoming_sip_transactions_tbl = NULL;
-  SNMP::SuccessFailCountByRequestTypeTable* _outgoing_sip_transactions_tbl = NULL;
-  
+  SNMP::SuccessFailCountByRequestTypeTable* _incoming_sip_transactions_tbl;
+  SNMP::SuccessFailCountByRequestTypeTable* _outgoing_sip_transactions_tbl;
+
   /// Called when the system determines the service should be invoked for a
   /// received request.  The Sproutlet can either return NULL indicating it
   /// does not want to process the request, or create a suitable object
@@ -601,7 +605,11 @@ protected:
   /// Constructor.
   Sproutlet(const std::string& service_name,
             int port,
-            const std::string& service_host="") :
+            const std::string& service_host="",
+            SNMP::SuccessFailCountByRequestTypeTable* incoming_sip_transactions_tbl = NULL,
+            SNMP::SuccessFailCountByRequestTypeTable* outgoing_sip_transactions_tbl = NULL):
+    _incoming_sip_transactions_tbl(incoming_sip_transactions_tbl),
+    _outgoing_sip_transactions_tbl(outgoing_sip_transactions_tbl),
     _service_name(service_name),
     _port(port),
     _service_host(service_host)

--- a/src/bgcfplugin.cpp
+++ b/src/bgcfplugin.cpp
@@ -58,6 +58,8 @@ private:
   BGCFSproutlet* _bgcf_sproutlet;
   ACRFactory* _acr_factory;
   BgcfService* _bgcf_service;
+  SNMP::SuccessFailCountByRequestTypeTable* _incoming_sip_transactions_tbl;
+  SNMP::SuccessFailCountByRequestTypeTable* _outgoing_sip_transactions_tbl;
 };
 
 /// Export the plug-in using the magic symbol "sproutlet_plugin"
@@ -69,12 +71,16 @@ BGCFPlugin sproutlet_plugin;
 BGCFPlugin::BGCFPlugin() :
   _bgcf_sproutlet(NULL),
   _acr_factory(NULL),
-  _bgcf_service(NULL)
+  _bgcf_service(NULL),
+  _incoming_sip_transactions_tbl(NULL),
+  _outgoing_sip_transactions_tbl(NULL)
 {
 }
 
 BGCFPlugin::~BGCFPlugin()
 {
+  delete _incoming_sip_transactions_tbl;
+  delete _outgoing_sip_transactions_tbl;
 }
 
 /// Loads the BGCF plug-in, returning the supported Sproutlets.
@@ -82,6 +88,13 @@ bool BGCFPlugin::load(struct options& opt, std::list<Sproutlet*>& sproutlets)
 {
   bool plugin_loaded = true;
 
+  // Create the SNMP tables here - they should exist based on whether the
+  // plugin is loaded, not whether the Sproutlet is enabled, in order to
+  // simplify SNMP polling of multiple differently-configured Sprout nodes.
+  _incoming_sip_transactions_tbl = SNMP::SuccessFailCountByRequestTypeTable::create("bgcf_incoming_sip_transactions",
+                                                                                    "1.2.826.0.1.1578918.9.3.22");
+  _outgoing_sip_transactions_tbl = SNMP::SuccessFailCountByRequestTypeTable::create("bgcf_outgoing_sip_transactions",
+                                                                                    "1.2.826.0.1.1578918.9.3.23");
   if (opt.enabled_bgcf)
   {
     // Create BGCF service required for the BGCF Sproutlet.
@@ -98,6 +111,8 @@ bool BGCFPlugin::load(struct options& opt, std::list<Sproutlet*>& sproutlets)
                                         _bgcf_service,
                                         enum_service,
                                         _acr_factory,
+                                        _incoming_sip_transactions_tbl,
+                                        _outgoing_sip_transactions_tbl,
                                         opt.override_npdi);
 
     sproutlets.push_back(_bgcf_sproutlet);

--- a/src/bgcfsproutlet.cpp
+++ b/src/bgcfsproutlet.cpp
@@ -68,8 +68,6 @@ BGCFSproutlet::BGCFSproutlet(const std::string& bgcf_name,
 /// BGCFSproutlet destructor.
 BGCFSproutlet::~BGCFSproutlet()
 {
-  delete _incoming_sip_transactions_tbl;
-  delete _outgoing_sip_transactions_tbl;
 }
 
 

--- a/src/bgcfsproutlet.cpp
+++ b/src/bgcfsproutlet.cpp
@@ -51,17 +51,15 @@ BGCFSproutlet::BGCFSproutlet(const std::string& bgcf_name,
                              BgcfService* bgcf_service,
                              EnumService* enum_service,
                              ACRFactory* acr_factory,
+                             SNMP::SuccessFailCountByRequestTypeTable* incoming_sip_transactions_tbl,
+                             SNMP::SuccessFailCountByRequestTypeTable* outgoing_sip_transactions_tbl,
                              bool override_npdi) :
-  Sproutlet(bgcf_name, port),
+  Sproutlet(bgcf_name, port, "", incoming_sip_transactions_tbl, outgoing_sip_transactions_tbl),
   _bgcf_service(bgcf_service),
   _enum_service(enum_service),
   _acr_factory(acr_factory),
   _override_npdi(override_npdi)
 {
-  _incoming_sip_transactions_tbl = SNMP::SuccessFailCountByRequestTypeTable::create("bgcf_incoming_sip_transactions",
-                                                                                    "1.2.826.0.1.1578918.9.3.22");
-  _outgoing_sip_transactions_tbl = SNMP::SuccessFailCountByRequestTypeTable::create("bgcf_outgoing_sip_transactions",
-                                                                                    "1.2.826.0.1.1578918.9.3.23");
 }
 
 

--- a/src/icscfplugin.cpp
+++ b/src/icscfplugin.cpp
@@ -58,6 +58,8 @@ private:
   ICSCFSproutlet* _icscf_sproutlet;
   ACRFactory* _acr_factory;
   SCSCFSelector* _scscf_selector;
+  SNMP::SuccessFailCountByRequestTypeTable* _incoming_sip_transactions_tbl;
+  SNMP::SuccessFailCountByRequestTypeTable* _outgoing_sip_transactions_tbl;
 };
 
 /// Export the plug-in using the magic symbol "sproutlet_plugin"
@@ -84,13 +86,10 @@ bool ICSCFPlugin::load(struct options& opt, std::list<Sproutlet*>& sproutlets)
   // Create the SNMP tables here - they should exist based on whether the
   // plugin is loaded, not whether the Sproutlet is enabled, in order to
   // simplify SNMP polling of multiple differently-configured Sprout nodes.
-  //
-  // We'll leak these objects if the Sproutlet isn't enabled - this is a small,
-  // fixed-size leak so we don't need to worry about it.
-  SNMP::SuccessFailCountByRequestTypeTable* incoming_sip_transactions_tbl = SNMP::SuccessFailCountByRequestTypeTable::create("icscf_incoming_sip_transactions",
-                                                                                                                             "1.2.826.0.1.1578918.9.3.18");
-  SNMP::SuccessFailCountByRequestTypeTable* outgoing_sip_transactions_tbl = SNMP::SuccessFailCountByRequestTypeTable::create("icscf_outgoing_sip_transactions",
-                                                                                                                             "1.2.826.0.1.1578918.9.3.19");
+  _incoming_sip_transactions_tbl = SNMP::SuccessFailCountByRequestTypeTable::create("icscf_incoming_sip_transactions",
+                                                                                    "1.2.826.0.1.1578918.9.3.18");
+  _outgoing_sip_transactions_tbl = SNMP::SuccessFailCountByRequestTypeTable::create("icscf_outgoing_sip_transactions",
+                                                                                    "1.2.826.0.1.1578918.9.3.19");
 
   if (opt.enabled_icscf)
   {
@@ -110,8 +109,8 @@ bool ICSCFPlugin::load(struct options& opt, std::list<Sproutlet*>& sproutlets)
                                           _acr_factory,
                                           _scscf_selector,
                                           enum_service,
-                                          incoming_sip_transactions_tbl,
-                                          outgoing_sip_transactions_tbl,
+                                          _incoming_sip_transactions_tbl,
+                                          _outgoing_sip_transactions_tbl,
                                           opt.override_npdi);
     _icscf_sproutlet->init();
 
@@ -127,4 +126,6 @@ void ICSCFPlugin::unload()
   delete _icscf_sproutlet;
   delete _acr_factory;
   delete _scscf_selector;
+  delete _incoming_sip_transactions_tbl;
+  delete _outgoing_sip_transactions_tbl;
 }

--- a/src/icscfplugin.cpp
+++ b/src/icscfplugin.cpp
@@ -80,6 +80,13 @@ ICSCFPlugin::~ICSCFPlugin()
 bool ICSCFPlugin::load(struct options& opt, std::list<Sproutlet*>& sproutlets)
 {
   bool plugin_loaded = true;
+
+  // Create the SNMP tables here - they should exist based on whether the
+  // plugin is loaded, not whether the Sproutlet is enabled, in order to
+  // simplify SNMP polling of multiple differently-configured Sprout nodes.
+  //
+  // We'll leak these objects if the Sproutlet isn't enabled - this is a small,
+  // fixed-size leak so we don't need to worry about it.
   SNMP::SuccessFailCountByRequestTypeTable* incoming_sip_transactions_tbl = SNMP::SuccessFailCountByRequestTypeTable::create("icscf_incoming_sip_transactions",
                                                                                                                              "1.2.826.0.1.1578918.9.3.18");
   SNMP::SuccessFailCountByRequestTypeTable* outgoing_sip_transactions_tbl = SNMP::SuccessFailCountByRequestTypeTable::create("icscf_outgoing_sip_transactions",

--- a/src/icscfplugin.cpp
+++ b/src/icscfplugin.cpp
@@ -80,6 +80,10 @@ ICSCFPlugin::~ICSCFPlugin()
 bool ICSCFPlugin::load(struct options& opt, std::list<Sproutlet*>& sproutlets)
 {
   bool plugin_loaded = true;
+  SNMP::SuccessFailCountByRequestTypeTable* incoming_sip_transactions_tbl = SNMP::SuccessFailCountByRequestTypeTable::create("icscf_incoming_sip_transactions",
+                                                                                                                             "1.2.826.0.1.1578918.9.3.18");
+  SNMP::SuccessFailCountByRequestTypeTable* outgoing_sip_transactions_tbl = SNMP::SuccessFailCountByRequestTypeTable::create("icscf_outgoing_sip_transactions",
+                                                                                                                             "1.2.826.0.1.1578918.9.3.19");
 
   if (opt.enabled_icscf)
   {
@@ -99,6 +103,8 @@ bool ICSCFPlugin::load(struct options& opt, std::list<Sproutlet*>& sproutlets)
                                           _acr_factory,
                                           _scscf_selector,
                                           enum_service,
+                                          incoming_sip_transactions_tbl,
+                                          outgoing_sip_transactions_tbl,
                                           opt.override_npdi);
     _icscf_sproutlet->init();
 

--- a/src/icscfsproutlet.cpp
+++ b/src/icscfsproutlet.cpp
@@ -70,8 +70,10 @@ ICSCFSproutlet::ICSCFSproutlet(const std::string& icscf_name,
                                ACRFactory* acr_factory,
                                SCSCFSelector* scscf_selector,
                                EnumService* enum_service,
+                               SNMP::SuccessFailCountByRequestTypeTable* incoming_sip_transactions_tbl,
+                               SNMP::SuccessFailCountByRequestTypeTable* outgoing_sip_transactions_tbl,
                                bool override_npdi) :
-  Sproutlet(icscf_name, port),
+  Sproutlet(icscf_name, port, "", incoming_sip_transactions_tbl, outgoing_sip_transactions_tbl),
   _bgcf_uri(NULL),
   _hss(hss),
   _scscf_selector(scscf_selector),
@@ -80,18 +82,12 @@ ICSCFSproutlet::ICSCFSproutlet(const std::string& icscf_name,
   _override_npdi(override_npdi),
   _bgcf_uri_str(bgcf_uri)
 {
-  _incoming_sip_transactions_tbl = SNMP::SuccessFailCountByRequestTypeTable::create("icscf_incoming_sip_transactions",
-                                                                                    "1.2.826.0.1.1578918.9.3.18");
-  _outgoing_sip_transactions_tbl = SNMP::SuccessFailCountByRequestTypeTable::create("icscf_outgoing_sip_transactions",
-                                                                                    "1.2.826.0.1.1578918.9.3.19");
 }
 
 
 /// Destructor.
 ICSCFSproutlet::~ICSCFSproutlet()
 {
-  delete _incoming_sip_transactions_tbl;
-  delete _outgoing_sip_transactions_tbl;
 }
 
 bool ICSCFSproutlet::init()

--- a/src/scscfsproutlet.cpp
+++ b/src/scscfsproutlet.cpp
@@ -107,8 +107,6 @@ SCSCFSproutlet::SCSCFSproutlet(const std::string& scscf_name,
 SCSCFSproutlet::~SCSCFSproutlet()
 {
   delete _as_chain_table;
-  delete _incoming_sip_transactions_tbl;
-  delete _outgoing_sip_transactions_tbl;
   delete _routed_by_preloaded_route_tbl;
   delete _invites_cancelled_before_1xx_tbl;
   delete _invites_cancelled_after_1xx_tbl;

--- a/src/scscfsproutlet.cpp
+++ b/src/scscfsproutlet.cpp
@@ -65,12 +65,14 @@ SCSCFSproutlet::SCSCFSproutlet(const std::string& scscf_name,
                                HSSConnection* hss,
                                EnumService* enum_service,
                                ACRFactory* acr_factory,
+                               SNMP::SuccessFailCountByRequestTypeTable* incoming_sip_transactions_tbl,
+                               SNMP::SuccessFailCountByRequestTypeTable* outgoing_sip_transactions_tbl,
                                bool override_npdi,
                                int session_continued_timeout_ms,
                                int session_terminated_timeout_ms,
                                AsCommunicationTracker* sess_term_as_tracker,
                                AsCommunicationTracker* sess_cont_as_tracker) :
-  Sproutlet(scscf_name, port),
+  Sproutlet(scscf_name, port, "", incoming_sip_transactions_tbl, outgoing_sip_transactions_tbl),
   _scscf_cluster_uri(NULL),
   _scscf_node_uri(NULL),
   _icscf_uri(NULL),
@@ -90,10 +92,6 @@ SCSCFSproutlet::SCSCFSproutlet(const std::string& scscf_name,
   _sess_term_as_tracker(sess_term_as_tracker),
   _sess_cont_as_tracker(sess_cont_as_tracker)
 {
-  _incoming_sip_transactions_tbl = SNMP::SuccessFailCountByRequestTypeTable::create("scscf_incoming_sip_transactions",
-                                                                                    "1.2.826.0.1.1578918.9.3.20");
-  _outgoing_sip_transactions_tbl = SNMP::SuccessFailCountByRequestTypeTable::create("scscf_outgoing_sip_transactions",
-                                                                                    "1.2.826.0.1.1578918.9.3.21");
   _routed_by_preloaded_route_tbl = SNMP::CounterTable::create("scscf_routed_by_preloaded_route",
                                                               "1.2.826.0.1.1578918.9.3.26");
   _invites_cancelled_before_1xx_tbl = SNMP::CounterTable::create("invites_cancelled_before_1xx",

--- a/src/ut/bgcf_test.cpp
+++ b/src/ut/bgcf_test.cpp
@@ -208,6 +208,8 @@ public:
                                         _bgcf_service,
                                         _enum_service,
                                         _acr_factory,
+                                        nullptr,
+                                        nullptr,
                                         false);
 
     // Create the SproutletProxy.

--- a/src/ut/icscfsproutlet_test.cpp
+++ b/src/ut/icscfsproutlet_test.cpp
@@ -79,6 +79,8 @@ public:
                                           _acr_factory,
                                           _scscf_selector,
                                           _enum_service,
+                                          NULL,
+                                          NULL,
                                           false);
     _icscf_sproutlet->init();
     std::list<Sproutlet*> sproutlets;

--- a/src/ut/scscf_test.cpp
+++ b/src/ut/scscf_test.cpp
@@ -286,6 +286,8 @@ public:
                                           _hss_connection,
                                           _enum_service,
                                           _acr_factory,
+                                          &SNMP::FAKE_INCOMING_SIP_TRANSACTIONS_TABLE,
+                                          &SNMP::FAKE_OUTGOING_SIP_TRANSACTIONS_TABLE,
                                           false,
                                           3000, // Session continue timeout - different from default
                                           6000, // Session terminated timeout - different from default
@@ -300,6 +302,8 @@ public:
                                         _bgcf_service,
                                         _enum_service,
                                         _acr_factory,
+                                        nullptr,
+                                        nullptr,
                                         false);
 
     // Create the MMTEL AppServer.

--- a/src/ut/scscf_test.cpp
+++ b/src/ut/scscf_test.cpp
@@ -306,8 +306,8 @@ public:
     _mmtel = new Mmtel("mmtel", _xdm_connection);
     _mmtel_sproutlet = new SproutletAppServerShim(_mmtel,
                                                   5058,
-                                                  &SNMP::FAKE_INCOMING_SIP_TRANSACTIONS_TABLE,
-                                                  &SNMP::FAKE_OUTGOING_SIP_TRANSACTIONS_TABLE,
+                                                  NULL,
+                                                  NULL,
                                                   "mmtel.homedomain");
 
     // Create the SproutletProxy.

--- a/src/ut/scscf_test.cpp
+++ b/src/ut/scscf_test.cpp
@@ -306,8 +306,8 @@ public:
     _mmtel = new Mmtel("mmtel", _xdm_connection);
     _mmtel_sproutlet = new SproutletAppServerShim(_mmtel,
                                                   5058,
-                                                  NULL,
-                                                  NULL,
+                                                  &SNMP::FAKE_INCOMING_SIP_TRANSACTIONS_TABLE,
+                                                  &SNMP::FAKE_OUTGOING_SIP_TRANSACTIONS_TABLE,
                                                   "mmtel.homedomain");
 
     // Create the SproutletProxy.


### PR DESCRIPTION
This change means that we always expose I-CSCF transaction stats, even if I-CSCF functionality is disabled. This gives a more consistent experience when polling differently-configured Sprout nodes for stats.

If this looks OK I'll make the same change for S-CSCF and BGCF, but not MMTel (as we never expect that to be enabled in production).