### PR TITLE
[Reviewer: Rob] Fix log-spam from CHECK_PJ_TRANSPORT_THREAD macro in Bono

### DIFF
--- a/include/connection_tracker.h
+++ b/include/connection_tracker.h
@@ -84,7 +84,7 @@ public:
   void unquiesce();
 
 private:
-  // This must be held when accessing connection_active, to avoid contention
+  // This must be held when accessing _connection_listeners, to avoid contention
   // between the transport thread and websocket threads.
   pthread_mutex_t _lock;
 

--- a/include/connection_tracker.h
+++ b/include/connection_tracker.h
@@ -84,6 +84,10 @@ public:
   void unquiesce();
 
 private:
+  // This must be held when accessing connection_active, to avoid contention
+  // between the transport thread and websocket threads.
+  pthread_mutex_t _lock;
+
   // A map of all the connections known to the connection manager, and their
   // state listeners.  This is a set of pjsip transports, but only includes
   // connection-based transports (not datagram transports).

--- a/src/connection_tracker.cpp
+++ b/src/connection_tracker.cpp
@@ -49,6 +49,7 @@ ConnectionTracker::ConnectionTracker(
   _quiescing(PJ_FALSE),
   _on_quiesced_handler(on_quiesced_handler)
 {
+  // Lock has always been MUTEX_RECURSIVE
   pthread_mutexattr_t attrs;
   pthread_mutexattr_init(&attrs);
   pthread_mutexattr_settype(&attrs, PTHREAD_MUTEX_RECURSIVE);
@@ -90,6 +91,7 @@ void ConnectionTracker::connection_state_update(pjsip_transport *tp,
   {
     TRC_DEBUG("Connection %p has been destroyed", tp);
 
+    pthread_mutex_lock(&_lock);
     // We expect to only be called on the PJSIP transport thread, and our data
     // race/locking safety is based on this assumption. Raise an error log if
     // this is not the case.
@@ -104,7 +106,10 @@ void ConnectionTracker::connection_state_update(pjsip_transport *tp,
       quiesce_complete = PJ_TRUE;
     }
 
+    pthread_mutex_unlock(&_lock);
+
     // If quiescing is now complete notify the quiescing manager.
+    // Done without the lock to avoid potential deadlock.
     if (quiesce_complete) {
       _on_quiesced_handler->connections_quiesced();
     }
@@ -120,11 +125,10 @@ void ConnectionTracker::connection_active(pjsip_transport *tp)
     pthread_mutex_lock(&_lock);
 
     // We expect to be called by only websocket transport threads, or the PJSIP
-    // transport thread. First check if we are on a websocket thread, then run
-    // the standard CHECK_PJ_TRANSPORT_THREAD macro if we aren't.
-    // Race/locking safety is based on this assumption. Raise an error log if
-    // the above is not the case.
-    if ((strcmp(pj_thread_get_name(pj_thread_this()),"websockets")) != 0)
+    // transport thread. We must NOT be called by the PJSIP worker thread.
+    // Race/locking safety is based on the above assumption. Raise an error log
+    // if the above is not the case.
+    if ((strcmp(pj_thread_get_name(pj_thread_this()), "websockets")) != 0)
     {
       CHECK_PJ_TRANSPORT_THREAD();
     }
@@ -165,6 +169,7 @@ void ConnectionTracker::quiesce()
 
   TRC_DEBUG("Start quiescing connections");
 
+  pthread_mutex_lock(&_lock);
   // We expect to only be called on the PJSIP transport thread, and our data
   // race/locking safety is based on this assumption. Raise an error log if
   // this is not the case.
@@ -196,7 +201,10 @@ void ConnectionTracker::quiesce()
     }
   }
 
+  pthread_mutex_unlock(&_lock);
+
   // If quiescing is now complete notify the quiescing manager.
+  // Done without the lock to avoid potential deadlock.
   if (quiesce_complete) {
     _on_quiesced_handler->connections_quiesced();
   }
@@ -207,6 +215,7 @@ void ConnectionTracker::unquiesce()
 {
   TRC_DEBUG("Unquiesce connections");
 
+  pthread_mutex_lock(&_lock);
   // We expect to only be called on the PJSIP transport thread, and our data
   // race/locking safety is based on this assumption. Raise an error log if
   // this is not the case.
@@ -220,4 +229,6 @@ void ConnectionTracker::unquiesce()
   // Note it is illegal to call this method if we're not quiescing.
   assert(_quiescing);
   _quiescing = PJ_FALSE;
+
+  pthread_mutex_unlock(&_lock);
 }


### PR DESCRIPTION
To avoid spam logs in Bono, a check is made in connections_active to see if it is being called on a websockets thread before running the check to see if it is the pjsip transport thread or not. 

To avoid races, the lock has been replaced in this function only. The macro in place in other functions should alert us if we need to replace the lock in any other locations. 

As the websockets thread should behave like a pjsip transport thread, deadlock should not be possible.

Tested on a live deployment, running live tests and connecting/disconnecting a webRTC client. No spurious log outputs were seen, and Sprout/Bono ran without crashes.