### PR TITLE
Switch from Python version of bracket_ipv6_address to C++ version

### DIFF
--- a/restund.root/usr/share/clearwater/infrastructure/scripts/restund
+++ b/restund.root/usr/share/clearwater/infrastructure/scripts/restund
@@ -6,10 +6,10 @@
 if [ -n "$local_ip" ] && [ -n "$home_domain" ] && [ -n "$public_ip" ]
 then
   # Add square brackets around the address iff it is an IPv6 address
-  bracketed_ip=$(python /usr/share/clearwater/bin/bracket_ipv6_address.py $local_ip)
+  bracketed_ip=$(/usr/share/clearwater/bin/bracket-ipv6-address $local_ip)
 
   # Set up local_ipv*, defaulting the entry that is not applicable.
-  if /usr/share/clearwater/bin/is_address_ipv6.py $local_ip
+  if /usr/share/clearwater/bin/is-address-ipv6 $local_ip
   then
     local_ipv4=127.0.0.1
     local_ipv6=$local_ip
@@ -19,7 +19,7 @@ then
   fi
 
   # Set up public_ipv4 if we're using an IPv4 address, or default it if not.
-  if /usr/share/clearwater/bin/is_address_ipv6.py $public_ip
+  if /usr/share/clearwater/bin/is-address-ipv6 $public_ip
   then
     public_ipv4=127.0.0.1
   else

--- a/sprout-base.root/etc/init.d/sprout
+++ b/sprout-base.root/etc/init.d/sprout
@@ -138,7 +138,7 @@ get_settings()
         # IP address needs to be surrounded by square brackets if it is IPv6.
         if [ ! -f /etc/clearwater/cluster_settings ]
         then
-          cluster_ip=$(python /usr/share/clearwater/bin/bracket_ipv6_address.py $local_ip)
+          cluster_ip=$(/usr/share/clearwater/bin/bracket-ipv6-address $local_ip)
           echo "servers=$cluster_ip:11211" > /etc/clearwater/cluster_settings
         fi
 

--- a/sprout-base.root/usr/share/clearwater/bin/poll_sprout_http.sh
+++ b/sprout-base.root/usr/share/clearwater/bin/poll_sprout_http.sh
@@ -40,7 +40,7 @@ scscf=5054
 # If we have S-CSCF configured, check it.
 rc=0
 if [ "$scscf" != "0" ] ; then
-  http_ip=$(/usr/share/clearwater/bin/bracket_ipv6_address.py $local_ip)
+  http_ip=$(/usr/share/clearwater/bin/bracket-ipv6-address $local_ip)
   /usr/share/clearwater/bin/poll-http $http_ip:9888
   rc=$?
 fi


### PR DESCRIPTION
Same as https://github.com/Metaswitch/clearwater-infrastructure/pull/332, but for this repo.