### PR TITLE
[Reviewer: rob] Extend the AsCommunicationTracker to include the failure reason in ENT logs.

### DIFF
--- a/include/as_communication_tracker.h
+++ b/include/as_communication_tracker.h
@@ -57,7 +57,7 @@ public:
   ///
   /// The object takes ownership of the alarm and the logs passed to it.
   AsCommunicationTracker(Alarm* alarm,
-                         const PDLog1<const char*>* as_failed_log,
+                         const PDLog2<const char*, const char*>* as_failed_log,
                          const PDLog1<const char*>* as_ok_log);
 
   /// Destructor.
@@ -71,7 +71,10 @@ public:
   /// Method to be called when communication to an Application Server fails.
   ///
   /// @param as_uri - The URI of the AS in question.
-  virtual void on_failure(const std::string& as_uri);
+  /// @param reason - A short string describing the reason the AS has been
+  ///                 treated as failed. For example "Transport error" or
+  ///                 "SIP 500 response received"
+  virtual void on_failure(const std::string& as_uri, const std::string& reason);
 
 private:
   // A lock that protects all member variables of this class.
@@ -92,11 +95,13 @@ private:
   // failing.
   Alarm* _alarm;
 
-  // Logs that are raised when communications are considered to have failed,
-  // and when they are considered to be OK.
+  // Logs that are raised when communications are considered to have failed, and
+  // when they are considered to be OK.
   //
-  // Each log takes the URI of the AS as a parameter.
-  const PDLog1<const char*>* _as_failed_log;
+  // The failed log has two parameters: the URI of the AS, and the reason the AS
+  // is being treated as failed.  The success log takes one parameter: the URI
+  // of the AS.
+  const PDLog2<const char*, const char*>* _as_failed_log;
   const PDLog1<const char*>* _as_ok_log;
 
   /// Check if any application servers are healthy. If so, log them and

--- a/include/scscfsproutlet.h
+++ b/include/scscfsproutlet.h
@@ -157,8 +157,11 @@ private:
   /// Record that communication with an AS failed.
   ///
   /// @param uri               - The URI of the AS.
+  /// @param reason            - Textual representation of the reason the AS is
+  ///                            being treated as failed.
   /// @param default_handling  - The AS's default handling.
   void track_app_serv_comm_failure(const std::string& uri,
+                                   const std::string& reason,
                                    DefaultHandling default_handling);
 
   /// Record that communication with an AS succeeded.
@@ -344,6 +347,12 @@ private:
   /// through this API, not by inspecting _acr directly, since the ACR may be
   /// owned by the AsChain as a whole.  May return NULL in some cases.
   ACR* get_acr();
+
+  /// Get a string representation of why a fork failed.
+  ///
+  /// @param fork_id  - The fork's number.
+  /// @param sip_code - The reported SIP return code
+  std::string fork_failure_reason_as_string(int fork_id, int sip_code);
 
   /// Pointer to the parent SCSCFSproutlet object - used for various operations
   /// that require access to global configuration or services.

--- a/include/sprout_pd_definitions.h
+++ b/include/sprout_pd_definitions.h
@@ -437,11 +437,11 @@ static const PDLog CL_SPROUT_BGCF_FILE_INVALID
   "If you are expecting to route calls off-net, follow the documentation to create routes in /etc/clearwater/bgcf.json. Otherwise, delete this file."
 );
 
-static const PDLog1<const char *> CL_SPROUT_SESS_TERM_AS_COMM_FAILURE
+static const PDLog2<const char *, const char*> CL_SPROUT_SESS_TERM_AS_COMM_FAILURE
 (
   PDLogBase::CL_SPROUT_ID + 48,
   PDLOG_ERR,
-  "Sprout is currently unable to successfully communicate with an Application Server that uses session terminated default handling. The server's URI is: %s",
+  "Sprout is currently unable to successfully communicate with an Application Server that uses session terminated default handling. The server's URI is: %s. Failure reason: %s",
   "Communication is failing to an Application Server",
   "Probable major loss of service. The precise impact will vary depending on the role of this Application Server.",
   "Investigate why communication to this Application Server is failing. It might be due to failure of the AS, misconfiguration of Initial Filter Criteria, or network / DNS problems"
@@ -457,11 +457,11 @@ static const PDLog1<const char *> CL_SPROUT_SESS_TERM_AS_COMM_SUCCESS
   "No action"
 );
 
-static const PDLog1<const char *> CL_SPROUT_SESS_CONT_AS_COMM_FAILURE
+static const PDLog2<const char *, const char*> CL_SPROUT_SESS_CONT_AS_COMM_FAILURE
 (
   PDLogBase::CL_SPROUT_ID + 50,
   PDLOG_ERR,
-  "Sprout is currently unable to successfully communicate with an Application Server that uses session continued default handling. The server's URI is %s",
+  "Sprout is currently unable to successfully communicate with an Application Server that uses session continued default handling. The server's URI is %s. Failure reason: %s",
   "Communication is failing to <URI>",
   "Probable minor degradation of service, or loss of a supplemental service. The precise impact will vary depending on the role of the Application Server in the deployment.",
   "Investigate why communication to this Application Server is failing. It might be due to failure of the AS, misconfiguration of Initial Filter Criteria, or network / DNS problems"

--- a/src/as_communication_tracker.cpp
+++ b/src/as_communication_tracker.cpp
@@ -37,7 +37,7 @@
 #include "as_communication_tracker.h"
 
 AsCommunicationTracker::AsCommunicationTracker(Alarm* alarm,
-                                               const PDLog1<const char*>* as_failed_log,
+                                               const PDLog2<const char*, const char*>* as_failed_log,
                                                const PDLog1<const char*>* as_ok_log) :
   _next_check_time_ms(current_time_ms() + NEXT_CHECK_INTERVAL_MS),
   _alarm(alarm),
@@ -61,7 +61,8 @@ void AsCommunicationTracker::on_success(const std::string& as_uri)
 }
 
 
-void AsCommunicationTracker::on_failure(const std::string& as_uri)
+void AsCommunicationTracker::on_failure(const std::string& as_uri,
+                                        const std::string& reason)
 {
   TRC_DEBUG("Communication with AS %s failed", as_uri.c_str());
 
@@ -88,7 +89,7 @@ void AsCommunicationTracker::on_failure(const std::string& as_uri)
     // This is the first time we've spotted that the AS has failed, so log this
     // fact.
     TRC_DEBUG("First failure for this AS - generate log");
-    _as_failed_log->log(as_uri.c_str());
+    _as_failed_log->log(as_uri.c_str(), reason.c_str());
     _as_failures[as_uri] = 1;
   }
   pthread_mutex_unlock(&_lock);

--- a/src/scscfsproutlet.cpp
+++ b/src/scscfsproutlet.cpp
@@ -325,6 +325,7 @@ ACR* SCSCFSproutlet::get_acr(SAS::TrailId trail,
 
 
 void SCSCFSproutlet::track_app_serv_comm_failure(const std::string& uri,
+                                                 const std::string& reason,
                                                  DefaultHandling default_handling)
 {
   AsCommunicationTracker* as_tracker = (default_handling == SESSION_CONTINUED) ?
@@ -332,7 +333,7 @@ void SCSCFSproutlet::track_app_serv_comm_failure(const std::string& uri,
                                        _sess_term_as_tracker;
   if (as_tracker != NULL)
   {
-    as_tracker->on_failure(uri);
+    as_tracker->on_failure(uri, reason);
   }
 }
 
@@ -610,6 +611,7 @@ void SCSCFSproutletTsx::on_rx_response(pjsip_msg* rsp, int fork_id)
         // Default handling will be triggered. Track this as a failed
         // communication.
         _scscf->track_app_serv_comm_failure(_as_chain_link.uri(),
+                                            fork_failure_reason_as_string(fork_id, st_code),
                                             _as_chain_link.default_handling());
 
         if (_as_chain_link.default_handling() == SESSION_CONTINUED)
@@ -1798,6 +1800,7 @@ void SCSCFSproutletTsx::on_timer_expiry(void* context)
   {
     // The AS has timed out so track this as a communication failure.
     _scscf->track_app_serv_comm_failure(_as_chain_link.uri(),
+                                        "Default Handling Timeout",
                                         _as_chain_link.default_handling());
 
     // The request was routed to a downstream AS, so cancel any outstanding
@@ -1979,4 +1982,35 @@ ACR* SCSCFSproutletTsx::get_acr()
   {
     return _failed_ood_acr;
   }
+}
+
+std::string SCSCFSproutletTsx::fork_failure_reason_as_string(int fork_id, int sip_code)
+{
+  ForkState fs = fork_state(fork_id);
+  std::string reason;
+
+  switch (fs.error_state)
+  {
+  case TIMEOUT:
+    reason = "SIP Timeout";
+    break;
+
+  case TRANSPORT_ERROR:
+    reason = "Transport error";
+    break;
+
+  case NONE:
+    reason = "SIP " + std::to_string(sip_code) + " response received";
+    break;
+
+  default:
+    // LCOV_EXCL_START - hitting this branch implies a logic error which we
+    // don't expect to hit in UT.
+    TRC_ERROR("Unknown ForkErrorState: %d", fs.error_state);
+    reason = "Unknown";
+    break;
+    // LCOV_EXCL_STOP
+  }
+
+  return reason;
 }

--- a/src/scscfsproutlet.cpp
+++ b/src/scscfsproutlet.cpp
@@ -1800,7 +1800,7 @@ void SCSCFSproutletTsx::on_timer_expiry(void* context)
   {
     // The AS has timed out so track this as a communication failure.
     _scscf->track_app_serv_comm_failure(_as_chain_link.uri(),
-                                        "Default Handling Timeout",
+                                        "Default handling timeout",
                                         _as_chain_link.default_handling());
 
     // The request was routed to a downstream AS, so cancel any outstanding
@@ -1992,7 +1992,7 @@ std::string SCSCFSproutletTsx::fork_failure_reason_as_string(int fork_id, int si
   switch (fs.error_state)
   {
   case TIMEOUT:
-    reason = "SIP Timeout";
+    reason = "SIP timeout";
     break;
 
   case TRANSPORT_ERROR:

--- a/src/ut/as_communication_tracker_test.cpp
+++ b/src/ut/as_communication_tracker_test.cpp
@@ -47,11 +47,18 @@ using ::testing::StrEq;
 using ::testing::AtLeast;
 using ::testing::Mock;
 
-class MockLog : public PDLog1<const char*>
+class MockLog1 : public PDLog1<const char*>
 {
 public:
-  MockLog() : PDLog1(1, 2, "", "", "", "") {};
+  MockLog1() : PDLog1(1, 2, "", "", "", "") {};
   MOCK_CONST_METHOD1(log, void(const char*));
+};
+
+class MockLog2 : public PDLog2<const char*, const char*>
+{
+public:
+  MockLog2() : PDLog2(1, 2, "", "", "", "") {};
+  MOCK_CONST_METHOD2(log, void(const char*, const char*));
 };
 
 class AsCommunicationTrackerTest : public ::testing::Test
@@ -59,15 +66,15 @@ class AsCommunicationTrackerTest : public ::testing::Test
 public:
   AsCommunicationTracker* _comm_tracker;
   MockAlarm* _mock_alarm;
-  const MockLog* _mock_error_log;
-  const MockLog* _mock_ok_log;
+  const MockLog2* _mock_error_log;
+  const MockLog1* _mock_ok_log;
 
   void SetUp()
   {
     AlarmManager am;
     _mock_alarm = new MockAlarm(&am);
-    _mock_error_log = new MockLog();
-    _mock_ok_log = new MockLog();
+    _mock_error_log = new MockLog2();
+    _mock_ok_log = new MockLog1();
     _comm_tracker = new AsCommunicationTracker(_mock_alarm,
                                                _mock_error_log,
                                                _mock_ok_log);
@@ -124,15 +131,16 @@ TEST_F(AsCommunicationTrackerTest, SuccessIsIdempotent)
 }
 
 
-// Test that a single AS failure raises the alarm and produces a log. When the
-// AS is healthy again, the alarm is cleared and an "OK" log is produced.
+// Test that a single AS failure raises the alarm and produces a log that
+// includes the failure reason. When the AS is healthy again, the alarm is
+// cleared and an "OK" log is produced.
 TEST_F(AsCommunicationTrackerTest, SingleAsFailure)
 {
   // The AS fails.
   EXPECT_CALL(*_mock_alarm, set());
-  EXPECT_CALL(*_mock_error_log, log(StrEq(AS1)));
+  EXPECT_CALL(*_mock_error_log, log(StrEq(AS1), StrEq("Some failure reason")));
   advance_time();
-  _comm_tracker->on_failure(AS1);
+  _comm_tracker->on_failure(AS1, "Some failure reason");
 
   // The AS starts succeeding again.
   EXPECT_CALL(*_mock_alarm, clear()).Times(AtLeast(1));
@@ -152,20 +160,20 @@ TEST_F(AsCommunicationTrackerTest, OngoingAsFailure)
 {
   // The AS fails.
   EXPECT_CALL(*_mock_alarm, set());
-  EXPECT_CALL(*_mock_error_log, log(_));
-  _comm_tracker->on_failure(AS1);
+  EXPECT_CALL(*_mock_error_log, log(_, _));
+  _comm_tracker->on_failure(AS1, "Timeout");
 
   // The AS is still failed.
   advance_time();
-  _comm_tracker->on_failure(AS1);
+  _comm_tracker->on_failure(AS1, "Timeout");
   advance_time();
-  _comm_tracker->on_failure(AS1);
+  _comm_tracker->on_failure(AS1, "Timeout");
   advance_time();
-  _comm_tracker->on_failure(AS1);
+  _comm_tracker->on_failure(AS1, "Timeout");
   advance_time();
-  _comm_tracker->on_failure(AS1);
+  _comm_tracker->on_failure(AS1, "Timeout");
   advance_time();
-  _comm_tracker->on_failure(AS1);
+  _comm_tracker->on_failure(AS1, "Timeout");
 
   // The AS succeeds.
   EXPECT_CALL(*_mock_alarm, clear()).Times(AtLeast(1));
@@ -185,8 +193,8 @@ TEST_F(AsCommunicationTrackerTest, FailSucceedFailSucceed)
 {
   // The AS fails.
   EXPECT_CALL(*_mock_alarm, set());
-  EXPECT_CALL(*_mock_error_log, log(_));
-  _comm_tracker->on_failure(AS1);
+  EXPECT_CALL(*_mock_error_log, log(_, _));
+  _comm_tracker->on_failure(AS1, "Timeout");
 
   // The AS succeeds.
   Mock::VerifyAndClearExpectations(_mock_alarm);
@@ -204,9 +212,9 @@ TEST_F(AsCommunicationTrackerTest, FailSucceedFailSucceed)
 
   // The AS fails again.
   EXPECT_CALL(*_mock_alarm, set());
-  EXPECT_CALL(*_mock_error_log, log(_));
+  EXPECT_CALL(*_mock_error_log, log(_, _));
   advance_time();
-  _comm_tracker->on_failure(AS1);
+  _comm_tracker->on_failure(AS1, "Timeout");
 
   // The AS succeeds again.
   EXPECT_CALL(*_mock_alarm, clear()).Times(AtLeast(1));
@@ -225,47 +233,48 @@ TEST_F(AsCommunicationTrackerTest, FailSucceedFailSucceed)
 // - The alarm is raised when any ASs start failing and only cleared when all
 //   succeed.
 // - Each AS has its own log and that the "error" and "OK" logs are generated
-//   when *that AS* fails or recovers (independent of the other AS).
+//   when *that AS* fails or recovers (independent of the other AS). The error
+//   logs contain the error cause that is specific to that AS.
 TEST_F(AsCommunicationTrackerTest, MultipleAsFailures)
 {
   // AS1 fails. AS2 is OK.
   EXPECT_CALL(*_mock_alarm, set());
-  EXPECT_CALL(*_mock_error_log, log(StrEq(AS1)));
-  _comm_tracker->on_failure(AS1);
+  EXPECT_CALL(*_mock_error_log, log(StrEq(AS1), StrEq("Timeout")));
+  _comm_tracker->on_failure(AS1, "Timeout");
   _comm_tracker->on_success(AS2);
 
   advance_time();
-  _comm_tracker->on_failure(AS1);
+  _comm_tracker->on_failure(AS1, "Timeout");
   _comm_tracker->on_success(AS2);
 
   advance_time();
-  _comm_tracker->on_failure(AS1);
+  _comm_tracker->on_failure(AS1, "Timeout");
   _comm_tracker->on_success(AS2);
 
   // AS2 starts to fail. AS1 still failed.
-  EXPECT_CALL(*_mock_error_log, log(StrEq(AS2)));
+  EXPECT_CALL(*_mock_error_log, log(StrEq(AS2), StrEq("Transport Error")));
   advance_time();
-  _comm_tracker->on_failure(AS1);
-  _comm_tracker->on_failure(AS2);
+  _comm_tracker->on_failure(AS1, "Timeout");
+  _comm_tracker->on_failure(AS2, "Transport Error");
 
   advance_time();
-  _comm_tracker->on_failure(AS1);
-  _comm_tracker->on_failure(AS2);
+  _comm_tracker->on_failure(AS1, "Timeout");
+  _comm_tracker->on_failure(AS2, "Transport Error");
 
   advance_time();
-  _comm_tracker->on_failure(AS1);
-  _comm_tracker->on_failure(AS2);
+  _comm_tracker->on_failure(AS1, "Timeout");
+  _comm_tracker->on_failure(AS2, "Transport Error");
 
   // AS1 recovers. AS2 still failed.
   EXPECT_CALL(*_mock_ok_log, log(StrEq(AS1)));
 
   advance_time();
   _comm_tracker->on_success(AS1);
-  _comm_tracker->on_failure(AS2);
+  _comm_tracker->on_failure(AS2, "Transport Error");
 
   advance_time();
   _comm_tracker->on_success(AS1);
-  _comm_tracker->on_failure(AS2);
+  _comm_tracker->on_failure(AS2, "Transport Error");
 
   // Both ASs now Ok.
   EXPECT_CALL(*_mock_alarm, clear()).Times(AtLeast(1));

--- a/src/ut/mock_as_communication_tracker.h
+++ b/src/ut/mock_as_communication_tracker.h
@@ -46,7 +46,7 @@ public:
   ~MockAsCommunicationTracker() {}
 
   MOCK_METHOD1(on_success, void(const std::string&));
-  MOCK_METHOD1(on_failure, void(const std::string&));
+  MOCK_METHOD2(on_failure, void(const std::string&, const std::string&));
 };
 
 #endif

--- a/src/ut/scscf_test.cpp
+++ b/src/ut/scscf_test.cpp
@@ -67,6 +67,7 @@ using testing::HasSubstr;
 using testing::Not;
 using testing::_;
 using testing::NiceMock;
+using testing::HasSubstr;
 
 namespace SP
 {
@@ -3254,7 +3255,7 @@ TEST_F(SCSCFTest, DefaultHandlingTerminate)
                                 "  </ApplicationServer>\n"
                                 "  </InitialFilterCriteria>\n"
                                 "</ServiceProfile></IMSSubscription>");
-  EXPECT_CALL(*_sess_term_comm_tracker, on_failure(_));
+  EXPECT_CALL(*_sess_term_comm_tracker, on_failure(_, HasSubstr("408")));
 
   TransportFlow tpBono(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.99.88.11", 12345);
   TransportFlow tpAS1(TransportFlow::Protocol::UDP, stack_data.scscf_port, "1.2.3.4", 56789);
@@ -3347,7 +3348,7 @@ TEST_F(SCSCFTest, DISABLED_DefaultHandlingTerminateTimeout)
                                 "  </ApplicationServer>\n"
                                 "  </InitialFilterCriteria>\n"
                                 "</ServiceProfile></IMSSubscription>");
-  EXPECT_CALL(*_sess_term_comm_tracker, on_failure(_));
+  EXPECT_CALL(*_sess_term_comm_tracker, on_failure(_, HasSubstr("timeout")));
 
   TransportFlow tpCaller(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.99.88.11", 12345);
   TransportFlow tpAS1(TransportFlow::Protocol::TCP, stack_data.scscf_port, "1.2.3.4", 56789);
@@ -3530,6 +3531,7 @@ TEST_F(SCSCFTest, DefaultHandlingContinueRecordRouting)
                                 "  </InitialFilterCriteria>\n"
                                 "</ServiceProfile></IMSSubscription>");
 
+  EXPECT_CALL(*_sess_cont_comm_tracker, on_failure(_, HasSubstr("Transport"))).Times(2);
   TransportFlow tpBono(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.99.88.11", 12345);
 
   Message msg;
@@ -3657,7 +3659,7 @@ TEST_F(SCSCFTest, DefaultHandlingContinueNonResponsive)
                                 "  </ApplicationServer>\n"
                                 "  </InitialFilterCriteria>\n"
                                 "</ServiceProfile></IMSSubscription>");
-  EXPECT_CALL(*_sess_cont_comm_tracker, on_failure(StrEq("sip:1.2.3.4:56789;transport=UDP")));
+  EXPECT_CALL(*_sess_cont_comm_tracker, on_failure(StrEq("sip:1.2.3.4:56789;transport=UDP"), _));
 
   TransportFlow tpBono(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.99.88.11", 12345);
   TransportFlow tpAS1(TransportFlow::Protocol::UDP, stack_data.scscf_port, "1.2.3.4", 56789);
@@ -3746,7 +3748,7 @@ TEST_F(SCSCFTest, DefaultHandlingContinueImmediateError)
 
   // This flow counts as an unsuccessful AS communication, as a 100 trying does
   // not cause an AS to be treated as responsive.
-  EXPECT_CALL(*_sess_cont_comm_tracker, on_failure(_));
+  EXPECT_CALL(*_sess_cont_comm_tracker, on_failure(_, HasSubstr("500")));
 
   TransportFlow tpBono(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.99.88.11", 12345);
   TransportFlow tpAS1(TransportFlow::Protocol::UDP, stack_data.scscf_port, "1.2.3.4", 56789);
@@ -3840,7 +3842,7 @@ TEST_F(SCSCFTest, DefaultHandlingContinue100ThenError)
 
   // This flow counts as an unsuccessful AS communication, as a 100 trying does
   // not cause an AS to be treated as responsive.
-  EXPECT_CALL(*_sess_cont_comm_tracker, on_failure(_));
+  EXPECT_CALL(*_sess_cont_comm_tracker, on_failure(_, _));
 
   TransportFlow tpBono(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.99.88.11", 12345);
   TransportFlow tpAS1(TransportFlow::Protocol::UDP, stack_data.scscf_port, "1.2.3.4", 56789);
@@ -4180,7 +4182,7 @@ TEST_F(SCSCFTest, DefaultHandlingContinueTimeout)
                                 "  </ApplicationServer>\n"
                                 "  </InitialFilterCriteria>\n"
                                 "</ServiceProfile></IMSSubscription>");
-  EXPECT_CALL(*_sess_cont_comm_tracker, on_failure(_));
+  EXPECT_CALL(*_sess_cont_comm_tracker, on_failure(_, HasSubstr("timeout")));
 
   TransportFlow tpCaller(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.99.88.11", 12345);
   TransportFlow tpAS1(TransportFlow::Protocol::TCP, stack_data.scscf_port, "1.2.3.4", 56789);
@@ -4267,7 +4269,7 @@ TEST_F(SCSCFTest, DefaultHandlingContinueDisabled)
                                 "  </ApplicationServer>\n"
                                 "  </InitialFilterCriteria>\n"
                                 "</ServiceProfile></IMSSubscription>");
-  EXPECT_CALL(*_sess_cont_comm_tracker, on_failure(_));
+  EXPECT_CALL(*_sess_cont_comm_tracker, on_failure(_, _));
 
   TransportFlow tpCaller(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.99.88.11", 12345);
   TransportFlow tpAS1(TransportFlow::Protocol::TCP, stack_data.scscf_port, "1.2.3.4", 56789);


### PR DESCRIPTION
At present we have an `AsCommunicationTracker` class that is notified of successful and failed AS communication attempts and raises alarms and ENT logs appropriately. This PR extends this class to allow the user to pass a textual description of the cause of the failure so it can be output in ENT logs, and changes the S-CSCF to supply this description. 

Tested in UT. 