### PR TITLE
[Reviewer: Graeme] Map HSS responses to SIP failure codes correctly

### DIFF
--- a/include/hss_sip_mapping.h
+++ b/include/hss_sip_mapping.h
@@ -1,0 +1,55 @@
+/**
+ * @file hss_sip_mapping.h Map HSS responses to SIP responses
+ *
+ * Project Clearwater - IMS in the Cloud
+ * Copyright (C) 2016  Metaswitch Networks Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version, along with the "Special Exception" for use of
+ * the program along with SSL, set forth below. This program is distributed
+ * in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * The author can be reached by email at clearwater@metaswitch.com or by
+ * post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+ *
+ * Special Exception
+ * Metaswitch Networks Ltd  grants you permission to copy, modify,
+ * propagate, and distribute a work formed by combining OpenSSL with The
+ * Software, or a work derivative of such a combination, even if such
+ * copying, modification, propagation, or distribution would otherwise
+ * violate the terms of the GPL. You must comply with the GPL in all
+ * respects for all of the code used other than OpenSSL.
+ * "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+ * Project and licensed under the OpenSSL Licenses, or a work based on such
+ * software and licensed under the OpenSSL Licenses.
+ * "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+ * under which the OpenSSL Project distributes the OpenSSL toolkit software,
+ * as those licenses appear in the file LICENSE-OPENSSL.
+ */
+
+
+#ifndef HSS_SIP_MAPPING_H__
+#define HSS_SIP_MAPPING_H__
+
+extern "C" {
+#include <pjsip.h>
+}
+
+#include "acr.h"
+
+bool process_hss_sip_failure(HTTPCode http_code,
+                             std::string& reg_state,
+                             pjsip_rx_data* rdata,
+                             struct stack_data_struct& stack_data,
+                             ACR* acr,
+                             const char* type);
+
+#endif
+

--- a/include/hss_sip_mapping.h
+++ b/include/hss_sip_mapping.h
@@ -44,12 +44,19 @@ extern "C" {
 
 #include "acr.h"
 
+/// Process failures following making a request to the HSS
+//
+// If the response from the HSS represents a failure to register, then an
+// appropriate SIP response will be sent to the provided request.
+// @param sip_msg_type Type of SIP Message being responded to for logging
+// purposes
+// @returns true if the response was a failure that has been handled, else
+// false.
 bool process_hss_sip_failure(HTTPCode http_code,
                              std::string& reg_state,
                              pjsip_rx_data* rdata,
                              struct stack_data_struct& stack_data,
                              ACR* acr,
-                             const char* type);
+                             const char* sip_msg_type);
 
 #endif
-

--- a/src/Makefile
+++ b/src/Makefile
@@ -14,6 +14,7 @@ SPROUT_COMMON_SOURCES := logger.cpp \
                          bono.cpp \
                          registration_utils.cpp \
                          registrar.cpp \
+                         hss_sip_mapping.cpp \
                          authentication.cpp \
                          options.cpp \
                          connection_pool.cpp \

--- a/src/hss_sip_mapping.cpp
+++ b/src/hss_sip_mapping.cpp
@@ -1,0 +1,112 @@
+/*
+ * @file hss_sip_mapping.cpp
+ *
+ * Project Clearwater - IMS in the Cloud
+ * Copyright (C) 2016  Metaswitch Networks Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version, along with the "Special Exception" for use of
+ * the program along with SSL, set forth below. This program is distributed
+ * in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * The author can be reached by email at clearwater@metaswitch.com or by
+ * post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+ *
+ * Special Exception
+ * Metaswitch Networks Ltd  grants you permission to copy, modify,
+ * propagate, and distribute a work formed by combining OpenSSL with The
+ * Software, or a work derivative of such a combination, even if such
+ * copying, modification, propagation, or distribution would otherwise
+ * violate the terms of the GPL. You must comply with the GPL in all
+ * respects for all of the code used other than OpenSSL.
+ * "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+ * Project and licensed under the OpenSSL Licenses, or a work based on such
+ * software and licensed under the OpenSSL Licenses.
+ * "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+ * under which the OpenSSL Project distributes the OpenSSL toolkit software,
+ * as those licenses appear in the file LICENSE-OPENSSL.
+ */
+
+#include "hss_sip_mapping.h"
+
+#include "hssconnection.h"
+#include "pjutils.h"
+#include "stack.h"
+
+bool process_hss_sip_failure(HTTPCode http_code,
+                             std::string& regstate,
+                             pjsip_rx_data* rdata,
+                             struct stack_data_struct& stack_data,
+                             ACR* acr,
+                             const char* type)
+{
+  int st_code = PJSIP_SC_OK;
+
+  if ((http_code != HTTP_OK) || (regstate != HSSConnection::STATE_REGISTERED))
+  {
+    // We failed to register this subscriber at the HSS. This may be because
+    // the HSS is unavilable, the public identity doesn't exist, the public
+    // identity doesn't belong to the private identity, or there was an error
+    // communicating with the HSS.
+
+    if (http_code == HTTP_OK)
+    {
+      TRC_ERROR("Rejecting %s request following failure to register on the HSS: %s",
+                type, regstate.c_str());
+
+      st_code = PJSIP_SC_SERVER_TIMEOUT;
+    }
+    else if (http_code == HTTP_NOT_FOUND)
+    {
+      // The client shouldn't retry when the subscriber isn't present in the
+      // HSS; reject with a 403 in this case.
+      TRC_ERROR("Rejecting %s request as subscriber not present on the HSS",
+                type);
+
+      st_code = PJSIP_SC_FORBIDDEN;
+    }
+    else if (http_code == HTTP_SERVER_UNAVAILABLE ||
+             http_code == HTTP_GATEWAY_TIMEOUT)
+    {
+      // The HSS is unavailable - the client should retry on timeout but no
+      // other Clearwater nodes should (as Sprout will already have retried on
+      // timeout). Reject with a 504 (503 is used for overload).
+      TRC_ERROR("Rejecting %s request as unable to contact HSS: %d",
+                type, http_code);
+
+      st_code = PJSIP_SC_SERVER_TIMEOUT;
+    }
+    else if (http_code == HTTP_SERVER_ERROR)
+    {
+      // This is either a server error on the HSS, or a error decoding the
+      // response
+      TRC_ERROR("Rejecting %s request following error communicating with the HSS",
+                type);
+
+      st_code = PJSIP_SC_INTERNAL_SERVER_ERROR;
+    }
+    else
+    {
+      TRC_ERROR("Rejecting %s request following response %d from HSS",
+                type, http_code);
+    }
+
+    PJUtils::respond_stateless(stack_data.endpt,
+                               rdata,
+                               st_code,
+                               NULL,
+                               NULL,
+                               NULL,
+                               acr);
+  }
+
+  return st_code != PJSIP_SC_OK;
+}
+

--- a/src/registrar.cpp
+++ b/src/registrar.cpp
@@ -56,6 +56,7 @@ extern "C" {
 #include "stack.h"
 #include "memcachedstore.h"
 #include "hssconnection.h"
+#include "hss_sip_mapping.h"
 #include "registrar.h"
 #include "registration_utils.h"
 #include "constants.h"
@@ -627,39 +628,19 @@ void process_register_request(pjsip_rx_data* rdata)
                                                       ccfs,
                                                       ecfs,
                                                       trail);
-  if ((http_code != HTTP_OK) || (regstate != HSSConnection::STATE_REGISTERED))
+
+  if (process_hss_sip_failure(http_code,
+                              regstate,
+                              rdata,
+                              stack_data,
+                              acr,
+                              "REGISTER"))
   {
-    // We failed to register this subscriber at the HSS.  This indicates that the
-    // HSS is unavailable, the public identity doesn't exist or the public
-    // identity doesn't belong to the private identity.
-
-    // The client shouldn't retry when the subscriber isn't present in the
-    // HSS; reject with a 403 in this case.
-    //
-    // The client should retry on timeout but no other Clearwater nodes should
-    // (as Sprout will already have retried on timeout). Reject with a 504
-    // (503 is used for overload).
-    st_code = PJSIP_SC_SERVER_TIMEOUT;
-
-    if (http_code == HTTP_NOT_FOUND)
-    {
-      st_code = PJSIP_SC_FORBIDDEN;
-    }
-
-    TRC_ERROR("Rejecting register request with invalid public/private identity");
-
     SAS::Event event(trail, SASEvent::REGISTER_FAILED_INVALIDPUBPRIV, 0);
     event.add_var_param(public_id);
     event.add_var_param(private_id);
     SAS::report_event(event);
 
-    PJUtils::respond_stateless(stack_data.endpt,
-                               rdata,
-                               st_code,
-                               NULL,
-                               NULL,
-                               NULL,
-                               acr);
     acr->send();
     delete acr;
 

--- a/src/ut/registrar_test.cpp
+++ b/src/ut/registrar_test.cpp
@@ -1582,6 +1582,25 @@ TEST_F(RegistrarTest, DeRegAssociatedUrisNotFound)
   EXPECT_EQ(1,((SNMP::FakeSuccessFailCountTable*)SNMP::FAKE_REGISTRATION_STATS_TABLES.de_reg_tbl)->_failures); 
 }
 
+/// Homestead fails to interpret URI request
+TEST_F(RegistrarTest, AssociatedUriFails)
+{
+  Message msg;
+  msg._user = "6505550232";
+  _hss_connection->set_rc("/impu/sip%3A6505550232%40homedomain/reg-data",
+                          500);
+
+  inject_msg(msg.get());
+  ASSERT_EQ(1, txdata_count());
+  pjsip_msg* out = current_txdata()->msg;
+  EXPECT_EQ(500, out->line.status.code);
+  EXPECT_EQ("Internal Server Error", str_pj(out->line.status.reason));
+  EXPECT_EQ(1,((SNMP::FakeSuccessFailCountTable*)SNMP::FAKE_REGISTRATION_STATS_TABLES.init_reg_tbl)->_attempts);
+  EXPECT_EQ(1,((SNMP::FakeSuccessFailCountTable*)SNMP::FAKE_REGISTRATION_STATS_TABLES.init_reg_tbl)->_failures);
+
+  _hss_connection->delete_rc("/impu/sip%3A6505550232%40homedomain/reg-data");
+}
+
 /// Homestead fails associated URI request
 TEST_F(RegistrarTest, AssociatedUrisTimeOut)
 {

--- a/src/ut/subscription_test.cpp
+++ b/src/ut/subscription_test.cpp
@@ -521,7 +521,7 @@ TEST_F(SubscriptionTest, CorrectAcceptsHeader)
   check_subscriptions("sip:6505550231@homedomain", 1u);
 }
 
-/// Homestead fails associated URI request
+/// Homestead fails associated URI request as the subscriber doesn't exist
 TEST_F(SubscriptionTest, ErrorAssociatedUris)
 {
   SubscribeMessage msg;
@@ -536,6 +536,24 @@ TEST_F(SubscriptionTest, ErrorAssociatedUris)
 }
 
 /// Homestead fails associated URI request
+TEST_F(SubscriptionTest, AssociatedUrisFailure)
+{
+  SubscribeMessage msg;
+  msg._user = "6505550232";
+  _hss_connection->set_rc("/impu/sip%3A6505550232%40homedomain/reg-data",
+                          500);
+
+  inject_msg(msg.get());
+  ASSERT_EQ(1, txdata_count());
+  pjsip_msg* out = current_txdata()->msg;
+  EXPECT_EQ(500, out->line.status.code);
+  EXPECT_EQ("Internal Server Error", str_pj(out->line.status.reason));
+  check_subscriptions("sip:6505550232@homedomain", 0u);
+
+  _hss_connection->delete_rc("/impu/sip%3A6505550232%40homedomain/reg-data");
+}
+
+/// Homestead times out associated URI request
 TEST_F(SubscriptionTest, AssociatedUrisTimeOut)
 {
   SubscribeMessage msg;


### PR DESCRIPTION
Treat a server failure (either caused by a failure by the HSS or by a failure
to decode the response) as a SIP 500 Internal Server Error.

Log an appropriate message instead of assuming all failures are caused by
incorrect registration details, including the return code and HSS response
where appropriate.

This fixes #1453 

I've checked that all the UTs pass, and that the two new UTs fail without this code.