### PR TITLE
[Reviewer: Matt W] Log stdout and stderr to file when a daemon

### DIFF
--- a/debian/bono.logrotate
+++ b/debian/bono.logrotate
@@ -1,0 +1,12 @@
+/var/log/bono/bono_out.log /var/log/bono/bono_err.log {
+        rotate 4
+        weekly
+        minsize 1M
+        missingok
+        create 640 root adm
+        notifempty
+        compress
+        delaycompress
+        copytruncate
+}
+

--- a/debian/sprout-base.logrotate
+++ b/debian/sprout-base.logrotate
@@ -1,0 +1,12 @@
+/var/log/sprout/sprout_out.log /var/log/sprout/sprout_err.log {
+        rotate 4
+        weekly
+        minsize 1M
+        missingok
+        create 640 root adm
+        notifempty
+        compress
+        delaycompress
+        copytruncate
+}
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -240,6 +240,9 @@ const static int UNQUIESCE_SIGNAL = SIGUSR1;
 // Minimum value allowed by rfc4028, section 4
 const static int MIN_SESSION_EXPIRES = 90;
 
+const static char* STANDARD_OUT_FILE = "sprout_out.log";
+const static char* STANDARD_ERR_FILE = "sprout_err.log";
+
 static void usage(void)
 {
   puts("Options:\n"
@@ -1349,7 +1352,8 @@ int main(int argc, char* argv[])
 
   if (opt.daemon)
   {
-    int errnum = Utils::daemonize();
+    int errnum = Utils::daemonize(opt.log_directory + "/" + STANDARD_OUT_FILE,
+                                  opt.log_directory + "/" + STANDARD_ERR_FILE);
     if (errnum != 0)
     {
       TRC_ERROR("Failed to convert to daemon, %d (%s)", errnum, strerror(errnum));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -240,9 +240,6 @@ const static int UNQUIESCE_SIGNAL = SIGUSR1;
 // Minimum value allowed by rfc4028, section 4
 const static int MIN_SESSION_EXPIRES = 90;
 
-const static char* STANDARD_OUT_FILE = "sprout_out.log";
-const static char* STANDARD_ERR_FILE = "sprout_err.log";
-
 static void usage(void)
 {
   puts("Options:\n"
@@ -1350,10 +1347,28 @@ int main(int argc, char* argv[])
     return 1;
   }
 
+  // Work out the program name from argv[0], stripping anything before the final slash.
+  char* prog_name = argv[0];
+  char* slash_ptr = rindex(argv[0], '/');
+  if (slash_ptr != NULL)
+  {
+    prog_name = slash_ptr + 1;
+  }
+
   if (opt.daemon)
   {
-    int errnum = Utils::daemonize(opt.log_directory + "/" + STANDARD_OUT_FILE,
-                                  opt.log_directory + "/" + STANDARD_ERR_FILE);
+    int errnum;
+
+    if (opt.log_directory != "")
+    {
+      errnum = Utils::daemonize(opt.log_directory + "/" + prog_name + "_out.log",
+                                opt.log_directory + "/" + prog_name + "_err.log");
+    }
+    else
+    {
+      errnum = Utils::daemonize();
+    }
+
     if (errnum != 0)
     {
       TRC_ERROR("Failed to convert to daemon, %d (%s)", errnum, strerror(errnum));
@@ -1366,13 +1381,6 @@ int main(int argc, char* argv[])
 
   if ((opt.log_to_file) && (opt.log_directory != ""))
   {
-    // Work out the program name from argv[0], stripping anything before the final slash.
-    char* prog_name = argv[0];
-    char* slash_ptr = rindex(argv[0], '/');
-    if (slash_ptr != NULL)
-    {
-      prog_name = slash_ptr + 1;
-    }
     Log::setLogger(new Logger(opt.log_directory, prog_name));
 
     TRC_STATUS("Access logging enabled to %s", opt.log_directory.c_str());


### PR DESCRIPTION
Matt, this is the sprout half of the fix to #965.

We use the new function in https://github.com/Metaswitch/cpp-common/pull/531 to add a new logfile for standard out and standard error, and add a logrotate configuration for both files.