### PR TITLE
[Reviewer: EM] Disable ability to configure chronos

### DIFF
--- a/include/cfgoptions.h
+++ b/include/cfgoptions.h
@@ -91,7 +91,6 @@ struct options
   std::string                          sas_system_name;
   std::string                          hss_server;
   std::string                          xdm_server;
-  std::string                          chronos_service;
   std::string                          store_servers;
   std::string                          remote_store_servers;
   std::string                          ralf_server;

--- a/sprout-base.root/etc/init.d/sprout
+++ b/sprout-base.root/etc/init.d/sprout
@@ -109,7 +109,6 @@ get_settings()
         alias_list=""
         default_session_expires=600
         signaling_dns_server=127.0.0.1
-        chronos_hostname=127.0.0.1:7253
 
         # Set up defaults for user settings then pull in any overrides.
         # Sprout uses blocking look-up services, so must run multi-threaded.
@@ -191,7 +190,6 @@ get_daemon_args()
                      --memstore=/etc/clearwater/cluster_settings
                      --remote-memstore=/etc/clearwater/remote_cluster_settings
                      --hss=$hs_hostname
-                     --chronos=$chronos_hostname
                      --sprout-hostname=$sprout_hostname
                      $xdms_hostname_arg
                      $ralf_arg

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1854,7 +1854,7 @@ int main(int argc, char* argv[])
       chronos_callback_host = "[::1]:" + port_str;
     }
 
-    std::string chronos_service = "localhost:7253";
+    std::string chronos_service = "127.0.0.1:7253";
     TRC_STATUS("Creating connection to Chronos %s using %s as the callback URI",
                chronos_service.c_str(),
                chronos_callback_host.c_str());


### PR DESCRIPTION
This configuration option was undocumented, and isn't supported, so we just hardcode localhost:7253

This fixes #1463