### PR TITLE
[Reviewer: MIRW] Log the ralf server using trace instead of fprintf

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -681,7 +681,7 @@ static pj_status_t init_options(int argc, char* argv[], struct options* options)
 
     case 'G':
       options->ralf_server = std::string(pj_optarg);
-      fprintf(stdout, "Ralf server set to %s\n", pj_optarg);
+      TRC_INFO("Ralf server set to %s", pj_optarg);
       break;
 
     case OPT_RALF_THREADS:


### PR DESCRIPTION
Matt,

Very trivial fix.

In testing https://github.com/Metaswitch/sprout/pull/1471, I spotted we were actually logging something to stdout. All of the other main options we log using trace instead of fprintf - I think this was overlooked as the conversion from fprintf to trace was done at the same time as this option was added.

Tested by updating the VMWare rig with a deb built using make deb. We then see the following in access_current.txt

04-07-2016 16:23:06.746 UTC Info main.cpp:684: Ralf server set to ralf.vmware.obu-enfield.test:10888

instead of in sprout_out.log.