### PR TITLE
[Reviewer: RKD] Add ENT logs for UDP transport.

### DIFF
--- a/src/stack.cpp
+++ b/src/stack.cpp
@@ -341,7 +341,7 @@ pj_status_t create_tcp_listener_transport(int port, pj_str_t& host, pjsip_tpfact
   {
     CL_SPROUT_SIP_TCP_START_FAIL.log(port,
                                      PJUtils::pj_status_to_string(status).c_str());
-    TRC_ERROR("Failed to fill in TCP transport for port %d  (%s)",
+    TRC_ERROR("Failed to fill in TCP transport for port %d (%s)",
               port,
               PJUtils::pj_status_to_string(status).c_str());
 

--- a/src/stack.cpp
+++ b/src/stack.cpp
@@ -290,6 +290,9 @@ pj_status_t create_udp_transport(int port, pj_str_t& host)
   status = fill_transport_details(port, &addr, host, &published_name);
   if (status != PJ_SUCCESS)
   {
+    CL_SPROUT_SIP_UDP_INTERFACE_START_FAIL.log(port, PJUtils::pj_status_to_string(status).c_str());
+    TRC_ERROR("Failed to fill in UDP transport for port %d (%s)", port, PJUtils::pj_status_to_string(status).c_str());
+
     return status;
   }
 
@@ -336,6 +339,12 @@ pj_status_t create_tcp_listener_transport(int port, pj_str_t& host, pjsip_tpfact
   status = fill_transport_details(port, &addr, host, &published_name);
   if (status != PJ_SUCCESS)
   {
+    CL_SPROUT_SIP_TCP_START_FAIL.log(port,
+                                     PJUtils::pj_status_to_string(status).c_str());
+    TRC_ERROR("Failed to fill in TCP transport for port %d  (%s)",
+              port,
+              PJUtils::pj_status_to_string(status).c_str());
+
     return status;
   }
 
@@ -633,7 +642,7 @@ pj_status_t init_stack(const std::string& system_name,
   {
     std::list<std::string> domains;
     Utils::split_string(additional_home_domains, ',', domains, 0, true);
-    
+
     for (std::list<std::string>::iterator ii = domains.begin();
          ii != domains.end();
          ii++)


### PR DESCRIPTION
Make sure all failure paths have ENT logs for UDP transport creation.  (I added one for TCP as well because it was missing).