### PR TITLE
[Reviewer: RKD] Send a 500 when we fail to store a nonce

### DIFF
--- a/src/authentication.cpp
+++ b/src/authentication.cpp
@@ -605,6 +605,16 @@ void create_challenge(pjsip_digest_credential* credentials,
       TRC_DEBUG("Sending %s to Chronos to set AV timer", chronos_body.c_str());
       chronos->send_post(timer_id, 30, "/authentication-timeout", chronos_body, get_trail(rdata));
     }
+    else
+    {
+      // We've failed to store the nonce in memcached, so we have no hope of
+      // successfuly authenticating any repsonse to a 401 Unauthorized.  Send
+      // a 503 Servce Unavailable instead.
+      TRC_DEBUG("Failed to store nonce in memcached.");
+      tdata->msg->line.status.code = PJSIP_SC_SERVICE_UNAVAILABLE;
+      tdata->msg->line.status.reason = *pjsip_get_status_text(PJSIP_SC_SERVICE_UNAVAILABLE);
+      pjsip_tx_data_invalidate_msg(tdata);
+    }
 
     delete av;
   }

--- a/src/authentication.cpp
+++ b/src/authentication.cpp
@@ -608,11 +608,14 @@ void create_challenge(pjsip_digest_credential* credentials,
     else
     {
       // We've failed to store the nonce in memcached, so we have no hope of
-      // successfuly authenticating any repsonse to a 401 Unauthorized.  Send
-      // a 503 Servce Unavailable instead.
-      TRC_DEBUG("Failed to store nonce in memcached.");
-      tdata->msg->line.status.code = PJSIP_SC_SERVICE_UNAVAILABLE;
-      tdata->msg->line.status.reason = *pjsip_get_status_text(PJSIP_SC_SERVICE_UNAVAILABLE);
+      // successfully authenticating any repsonse to a 401 Unauthorized.  Send
+      // a 500 Server Internal Error instead.
+      TRC_DEBUG("Failed to store nonce in memcached");
+      tdata->msg->line.status.code = PJSIP_SC_INTERNAL_SERVER_ERROR;
+      tdata->msg->line.status.reason = *pjsip_get_status_text(PJSIP_SC_INTERNAL_SERVER_ERROR);
+
+      // This function causes us to rebuild the response with the changes we've
+      // just made.
       pjsip_tx_data_invalidate_msg(tdata);
     }
 
@@ -639,6 +642,8 @@ void create_challenge(pjsip_digest_credential* credentials,
       SAS::report_event(event);
     }
 
+    // This function causes us to rebuild the response with the changes we've
+    // just made.
     pjsip_tx_data_invalidate_msg(tdata);
   }
 }


### PR DESCRIPTION
When we fail to do an IMPI SET in memcached we have no hope of processing a challenge response so, send a 503 so we don't get into a REGISTER/401/REGISTER/401 loop.

Tested live and fixes #1404 