### PR TITLE
[Reviewer: RKD] Make TCP uplift configurable

### DIFF
--- a/include/cfgoptions.h
+++ b/include/cfgoptions.h
@@ -146,6 +146,7 @@ struct options
   bool                                 nonce_count_supported;
   std::string                          scscf_node_uri;
   bool                                 sas_signaling_if;
+  bool                                 disable_tcp_switch;
 };
 
 // Objects that must be shared with dynamically linked sproutlets must be

--- a/sprout-base.root/etc/init.d/sprout
+++ b/sprout-base.root/etc/init.d/sprout
@@ -176,6 +176,7 @@ get_daemon_args()
         [ "$override_npdi" != "Y" ] || override_npdi_arg="--override-npdi"
         [ "$force_third_party_reg_body" != "Y" ] || force_3pr_body_arg="--force-3pr-body"
         [ "$sas_use_signaling_interface" != "Y" ] || sas_signaling_if_arg="--sas-use-signaling-interface"
+        [ "$disable_tcp_switch" != "Y" ] || disable_tcp_switch_arg="--disable-tcp-switch"
 
         [ -z "$target_latency_us" ] || target_latency_us_arg="--target-latency-us=$target_latency_us"
         [ -z "$cass_target_latency_us" ] || cass_target_latency_us_arg="--cass-target-latency-us=$cass_target_latency_us"
@@ -214,6 +215,7 @@ get_daemon_args()
                      $authentication_arg
                      $user_phone_arg
                      $sas_signaling_if_arg
+                     $disable_tcp_switch_arg
                      $global_only_lookups_arg
                      $override_npdi_arg
                      $exception_max_ttl_arg

--- a/src/ut/basicproxy_test.cpp
+++ b/src/ut/basicproxy_test.cpp
@@ -2340,6 +2340,8 @@ TEST_F(BasicProxyTest, StatelessForwardLargeACKNoUplift)
   // switching to TCP doesn't happen.
   pjsip_tx_data* tdata;
 
+  // Set the disable TCP switch option in PJSIP so that uplift does not
+  // happen.
   pjsip_cfg_t* pjsip_config = pjsip_cfg();
   pjsip_config->endpt.disable_tcp_switch = true;
 

--- a/src/ut/basicproxy_test.cpp
+++ b/src/ut/basicproxy_test.cpp
@@ -2268,8 +2268,7 @@ TEST_F(BasicProxyTest, StatelessForwardACK)
 TEST_F(BasicProxyTest, StatelessForwardLargeACK)
 {
   // Tests stateless forwarding of a large ACK where the onward hop is
-  // over UDP.  We've disabled UDP-to-TCP uplift so this now tests that
-  // switching to TCP doesn't happen.
+  // over UDP.  This tests that switching to TCP works.
   pjsip_tx_data* tdata;
 
   // Create a TCP connection to the listening port.
@@ -2278,6 +2277,77 @@ TEST_F(BasicProxyTest, StatelessForwardLargeACK)
                                         "1.2.3.4",
                                         49152);
 
+  // Send an ACK with Route headers traversing the proxy, with a large message
+  // body.  The second Route header specifies UDP transport.
+  Message msg;
+  msg._method = "ACK";
+  msg._requri = "sip:bob@awaydomain";
+  msg._from = "alice";
+  msg._to = "bob";
+  msg._todomain = "awaydomain";
+  msg._via = tp->to_string(false);
+  msg._route = "Route: <sip:127.0.0.1;transport=TCP;lr>\r\nRoute: <sip:proxy1.awaydomain;transport=UDP;lr>";
+  msg._body = std::string(1300, '!');
+  inject_msg(msg.get_request(), tp);
+
+  // Request is forwarded to the node in the second Route header, over TCP
+  // not UDP.
+  ASSERT_EQ(1, txdata_count());
+  tdata = current_txdata();
+  expect_target("TCP", "10.10.20.1", 5060, tdata);
+  ReqMatcher("ACK").matches(tdata->msg);
+  free_txdata();
+
+  // Create a UDP flow and force this as a target for bob@homedomain.
+  TransportFlow* tp2 = new TransportFlow(TransportFlow::Protocol::UDP,
+                                        stack_data.scscf_port,
+                                        "5.6.7.8",
+                                        49322);
+  _basic_proxy->add_test_target("sip:bob@homedomain",
+                                "sip:bob@5.6.7.8:49322;transport=UDP",
+                                tp2->transport());
+
+  // Send an ACK with no Route headers directed at bob@homedomain, with a
+  // large message body.
+  msg._method = "ACK";
+  msg._requri = "sip:bob@homedomain";
+  msg._from = "alice";
+  msg._to = "bob";
+  msg._todomain = "homedomain";
+  msg._via = tp->to_string(false);
+  msg._body = std::string(1300, '!');
+  inject_msg(msg.get_request(), tp);
+
+  // Request is forwarded to the UDP flow, not switched to TCP.
+  ASSERT_EQ(1, txdata_count());
+  tdata = current_txdata();
+  tp2->expect_target(tdata);
+  ReqMatcher("ACK").matches(tdata->msg);
+  free_txdata();
+
+  _basic_proxy->remove_test_targets("sip:bob@homedomain");
+
+  delete tp2;
+  delete tp;
+
+}
+
+
+TEST_F(BasicProxyTest, StatelessForwardLargeACKNoUplift)
+{
+  // Tests stateless forwarding of a large ACK where the onward hop is
+  // over UDP.  We've disabled UDP-to-TCP uplift so this now tests that
+  // switching to TCP doesn't happen.
+  pjsip_tx_data* tdata;
+
+  pjsip_cfg_t* pjsip_config = pjsip_cfg();
+  pjsip_config->endpt.disable_tcp_switch = true;
+
+  // Create a TCP connection to the listening port.
+  TransportFlow* tp = new TransportFlow(TransportFlow::Protocol::TCP,
+                                        stack_data.scscf_port,
+                                        "1.2.3.4",
+                                        49152);
 
   // Send an ACK with Route headers traversing the proxy, with a large message
   // body.  The second Route header specifies UDP transport.


### PR DESCRIPTION
Make TCP uplift configurable via the _disable_tcp_switch_ option in local/shared config.

Tested live that the TRC_STATUS in main.cpp is hit when the new option is set.  Tested in UT that that we can set the PJSIP option at runtime.

PJSIP pull request to follow.