### PR TITLE
[Reviewer: Ellie] Add ability for the I-CSCF to handle failed HSS lookups by routing to a transit function

### DIFF
--- a/include/cfgoptions.h
+++ b/include/cfgoptions.h
@@ -99,7 +99,7 @@ struct options
   std::vector<std::string>             enum_servers;
   std::string                          enum_suffix;
   std::string                          enum_file;
-  bool                                 fake_enum;
+  bool                                 default_tel_uri_translation;
   bool                                 analytics_enabled;
   std::string                          analytics_directory;
   int                                  reg_max_expires;

--- a/include/cfgoptions.h
+++ b/include/cfgoptions.h
@@ -99,6 +99,7 @@ struct options
   std::vector<std::string>             enum_servers;
   std::string                          enum_suffix;
   std::string                          enum_file;
+  bool                                 fake_enum;
   bool                                 analytics_enabled;
   std::string                          analytics_directory;
   int                                  reg_max_expires;

--- a/include/enumservice.h
+++ b/include/enumservice.h
@@ -81,6 +81,23 @@ public:
 };
 
 
+/// @class DummyEnumService
+///
+/// Provides an "ENUM service" which just translates tel:whatever to sip:whatever.
+class DummyEnumService : public EnumService
+{
+public:
+  DummyEnumService(std::string home_domain):
+    EnumService(),
+    _default_home_domain(home_domain)
+  {}
+  std::string lookup_uri_from_user(const std::string& user, SAS::TrailId trail) const;
+
+private:
+  std::string _default_home_domain;
+};
+
+
 /// @class JSONEnumService
 ///
 /// Provides an "ENUM service" based on configuration read from a JSON file.

--- a/sprout-base.root/etc/init.d/sprout
+++ b/sprout-base.root/etc/init.d/sprout
@@ -111,6 +111,9 @@ get_settings()
         signaling_dns_server=127.0.0.1
         scscf_node_uri=""
 
+        # Enable dummy ENUM by default for backwards compatibility
+        fake_enum="Y"
+
         # Set up defaults for user settings then pull in any overrides.
         # Sprout uses blocking look-up services, so must run multi-threaded.
         num_worker_threads=$(($(grep processor /proc/cpuinfo | wc -l) * 50))
@@ -161,6 +164,7 @@ get_daemon_args()
         [ -z "$enum_server" ] || enum_server_arg="--enum=$enum_server"
         [ -z "$enum_suffix" ] || enum_suffix_arg="--enum-suffix=$enum_suffix"
         [ -z "$enum_file" ] || enum_file_arg="--enum-file=$enum_file"
+        [ "$fake_enum" != "Y" ] || fake_enum_arg="--fake-enum"
 
         if [ $MMTEL_SERVICES_ENABLED = Y ]
         then
@@ -200,6 +204,7 @@ get_daemon_args()
                      $enum_server_arg
                      $enum_suffix_arg
                      $enum_file_arg
+                     $fake_enum_arg
                      --sas=$sas_server,$NAME@$public_hostname
                      --dns-server=$signaling_dns_server
                      --worker-threads=$num_worker_threads

--- a/sprout-base.root/etc/init.d/sprout
+++ b/sprout-base.root/etc/init.d/sprout
@@ -111,8 +111,8 @@ get_settings()
         signaling_dns_server=127.0.0.1
         scscf_node_uri=""
 
-        # Enable dummy ENUM by default for backwards compatibility
-        fake_enum="Y"
+        # Enable no-ENUM TEL URI translation fallback by default for backwards compatibility
+        default_tel_uri_translation="Y"
 
         # Set up defaults for user settings then pull in any overrides.
         # Sprout uses blocking look-up services, so must run multi-threaded.
@@ -164,7 +164,7 @@ get_daemon_args()
         [ -z "$enum_server" ] || enum_server_arg="--enum=$enum_server"
         [ -z "$enum_suffix" ] || enum_suffix_arg="--enum-suffix=$enum_suffix"
         [ -z "$enum_file" ] || enum_file_arg="--enum-file=$enum_file"
-        [ "$fake_enum" != "Y" ] || fake_enum_arg="--fake-enum"
+        [ "$default_tel_uri_translation" != "Y" ] || default_tel_uri_translation_arg="--default-tel-uri-translation"
 
         if [ $MMTEL_SERVICES_ENABLED = Y ]
         then
@@ -204,7 +204,7 @@ get_daemon_args()
                      $enum_server_arg
                      $enum_suffix_arg
                      $enum_file_arg
-                     $fake_enum_arg
+                     $default_tel_uri_translation_arg
                      --sas=$sas_server,$NAME@$public_hostname
                      --dns-server=$signaling_dns_server
                      --worker-threads=$num_worker_threads

--- a/src/bgcfsproutlet.cpp
+++ b/src/bgcfsproutlet.cpp
@@ -156,19 +156,19 @@ void BGCFSproutletTsx::on_rx_initial_request(pjsip_msg* req)
     bgcf_routes = _bgcf->get_route_from_number(routing_value, trail());
     routing_with_number = true;
   }
-  else if (uri_class == OFFNET_SIP_URI)
-  {
-    routing_value = PJUtils::pj_str_to_string(&((pjsip_sip_uri*)req_uri)->host);
-
-    // Find the downstream routes based on the domain.
-    bgcf_routes = _bgcf->get_route_from_domain(routing_value, trail());
-  }
   else if ((uri_class == LOCAL_PHONE_NUMBER) ||
            (uri_class == GLOBAL_PHONE_NUMBER))
   {
     // Find the downstream routes based on the domain - this only matches
     // any wild card routing set up
     routing_value = "";
+    bgcf_routes = _bgcf->get_route_from_domain(routing_value, trail());
+  }
+  else
+  {
+    routing_value = PJUtils::pj_str_to_string(&((pjsip_sip_uri*)req_uri)->host);
+
+    // Find the downstream routes based on the domain.
     bgcf_routes = _bgcf->get_route_from_domain(routing_value, trail());
   }
 

--- a/src/enumservice.cpp
+++ b/src/enumservice.cpp
@@ -66,7 +66,7 @@ std::string DummyEnumService::lookup_uri_from_user(const std::string &user, SAS:
   //
   // We do this in order to avoid needing to setup an ENUM server on test
   // systems just to allow local calls to work.
-  TRC_DEBUG("No ENUM server configured, perform default translation");
+  TRC_DEBUG("No ENUM server or ENUM file configured, perform default translation");
   SAS::Event event(trail, SASEvent::ENUM_NOT_ENABLED, 0);
   SAS::report_event(event);
 
@@ -76,12 +76,12 @@ std::string DummyEnumService::lookup_uri_from_user(const std::string &user, SAS:
   new_uri += user;
   new_uri += "@";
   new_uri += _default_home_domain;
-  TRC_DEBUG("Translate tel URI to SIP URI %s", new_uri.c_str());
+  TRC_DEBUG("Translate telephone number %s to SIP URI %s",
+            user.c_str(),
+            new_uri.c_str());
 
   return new_uri;
 }
-
-
 
 bool EnumService::parse_regex_replace(const std::string& regex_replace, boost::regex& regex, std::string& replace)
 {

--- a/src/enumservice.cpp
+++ b/src/enumservice.cpp
@@ -57,6 +57,31 @@
 const boost::regex EnumService::CHARS_TO_STRIP_FROM_UAS = boost::regex("([^0-9+]|(?<=.)[^0-9])");
 const boost::regex DNSEnumService::CHARS_TO_STRIP_FROM_DOMAIN = boost::regex("[^0-9]");
 
+std::string DummyEnumService::lookup_uri_from_user(const std::string &user, SAS::TrailId trail) const
+{
+  // If we have no ENUM server configured, we act as if all ENUM lookups
+  // return a successful response and perform the following mappings:
+  //  - tel:<number> to sip:<number>@<homedomain>
+  //  - sip:<number>@<homedomain> to itself
+  //
+  // We do this in order to avoid needing to setup an ENUM server on test
+  // systems just to allow local calls to work.
+  TRC_DEBUG("No ENUM server configured, perform default translation");
+  SAS::Event event(trail, SASEvent::ENUM_NOT_ENABLED, 0);
+  SAS::report_event(event);
+
+  std::string new_uri;
+
+  new_uri = "sip:";
+  new_uri += user;
+  new_uri += "@";
+  new_uri += _default_home_domain;
+  TRC_DEBUG("Translate tel URI to SIP URI %s", new_uri.c_str());
+
+  return new_uri;
+}
+
+
 
 bool EnumService::parse_regex_replace(const std::string& regex_replace, boost::regex& regex, std::string& replace)
 {

--- a/src/icscfsproutlet.cpp
+++ b/src/icscfsproutlet.cpp
@@ -646,8 +646,11 @@ void ICSCFSproutletTsx::on_rx_initial_request(pjsip_msg* req)
     }
     else
     {
-      // ENUM is not configured, so if the target is not in the HSS, the only
-      // thing we can do is assume it is off-net and pass it to the BGCF.
+      // The user is not in the HSS and ENUM is not configured. TS 24.229
+      // says that, as an alternative to ENUM, we can "forward the request to
+      // the transit functionality for subsequent routeing". Let's do that
+      // (currently, we assume the BGCF is the transit functionality, but that
+      // may be made configurable in future).
       route_to_bgcf(req);
       return;
     }

--- a/src/icscfsproutlet.cpp
+++ b/src/icscfsproutlet.cpp
@@ -651,6 +651,7 @@ void ICSCFSproutletTsx::on_rx_initial_request(pjsip_msg* req)
       // the transit functionality for subsequent routeing". Let's do that
       // (currently, we assume the BGCF is the transit functionality, but that
       // may be made configurable in future).
+      TRC_DEBUG("No ENUM service available - outing request directly to transit function (BGCF)");
       route_to_bgcf(req);
       return;
     }

--- a/src/icscfsproutlet.cpp
+++ b/src/icscfsproutlet.cpp
@@ -586,60 +586,70 @@ void ICSCFSproutletTsx::on_rx_initial_request(pjsip_msg* req)
                                                           do_billing);
     }
 
-    // If we still haven't found an S-CSCF, we can now try an ENUM lookup.
-    // We put this processing in a loop because in theory we may go round
-    // several times before finding an S-CSCF. In reality this is unlikely
-    // so we set MAX_ENUM_LOOKUPS to 2.
-    for (int ii = 0;
-         (ii < MAX_ENUM_LOOKUPS) && (scscf_not_found(status_code));
-         ++ii)
+    if (_icscf->_enum_service)
     {
-      if (PJSIP_URI_SCHEME_IS_TEL(uri))
+      // If we still haven't found an S-CSCF, we can now try an ENUM lookup.
+      // We put this processing in a loop because in theory we may go round
+      // several times before finding an S-CSCF. In reality this is unlikely
+      // so we set MAX_ENUM_LOOKUPS to 2.
+      for (int ii = 0;
+           (ii < MAX_ENUM_LOOKUPS) && (scscf_not_found(status_code));
+           ++ii)
       {
-        // Do an ENUM lookup and see if we should translate the TEL URI
-        pjsip_uri* original_req_uri = req->line.req.uri;
-        _icscf->translate_request_uri(req, get_pool(req), trail());
-        uri = req->line.req.uri;
-        URIClass uri_class = URIClassifier::classify_uri(uri, false);
-
-        std::string rn;
-
-        if ((uri_class == NP_DATA) ||
-            (uri_class == FINAL_NP_DATA))
+        if (PJSIP_URI_SCHEME_IS_TEL(uri))
         {
-          // We got number portability information from ENUM - drop out and route to the BGCF.
-          route_to_bgcf(req);
-          return;
-        }
-        else if (pjsip_uri_cmp(PJSIP_URI_IN_REQ_URI,
-                               original_req_uri,
-                               req->line.req.uri) != PJ_SUCCESS)
-        {
-          // The URI has changed, so make sure we do a LIR lookup on it.
-          impu = PJUtils::public_id_from_uri(req->line.req.uri);
-          ((ICSCFLIRouter *)_router)->change_impu(impu);
-        }
+          // Do an ENUM lookup and see if we should translate the TEL URI
+          pjsip_uri* original_req_uri = req->line.req.uri;
+          _icscf->translate_request_uri(req, get_pool(req), trail());
+          uri = req->line.req.uri;
+          URIClass uri_class = URIClassifier::classify_uri(uri, false);
 
-        // If we successfully translate the req URI and end up with either another TEL URI or a
-        // local SIP URI, we should look for an S-CSCF again.
-        if ((uri_class == LOCAL_PHONE_NUMBER) ||
-            (uri_class == GLOBAL_PHONE_NUMBER) ||
-            (uri_class == HOME_DOMAIN_SIP_URI))
-        {
-          // TEL or local SIP URI.  Look up the S-CSCF again.
-          status_code = (pjsip_status_code)_router->get_scscf(pool, scscf_sip_uri, do_billing);
+          std::string rn;
+
+          if ((uri_class == NP_DATA) ||
+              (uri_class == FINAL_NP_DATA))
+          {
+            // We got number portability information from ENUM - drop out and route to the BGCF.
+            route_to_bgcf(req);
+            return;
+          }
+          else if (pjsip_uri_cmp(PJSIP_URI_IN_REQ_URI,
+                                 original_req_uri,
+                                 req->line.req.uri) != PJ_SUCCESS)
+          {
+            // The URI has changed, so make sure we do a LIR lookup on it.
+            impu = PJUtils::public_id_from_uri(req->line.req.uri);
+            ((ICSCFLIRouter *)_router)->change_impu(impu);
+          }
+
+          // If we successfully translate the req URI and end up with either another TEL URI or a
+          // local SIP URI, we should look for an S-CSCF again.
+          if ((uri_class == LOCAL_PHONE_NUMBER) ||
+              (uri_class == GLOBAL_PHONE_NUMBER) ||
+              (uri_class == HOME_DOMAIN_SIP_URI))
+          {
+            // TEL or local SIP URI.  Look up the S-CSCF again.
+            status_code = (pjsip_status_code)_router->get_scscf(pool, scscf_sip_uri, do_billing);
+          }
+          else
+          {
+            // Number translated to off-switch.  Drop out of the loop.
+            ii = MAX_ENUM_LOOKUPS;
+          }
         }
         else
         {
-          // Number translated to off-switch.  Drop out of the loop.
+          // Can't translate the number, skip to the end of the loop.
           ii = MAX_ENUM_LOOKUPS;
         }
       }
-      else
-      {
-        // Can't translate the number, skip to the end of the loop.
-        ii = MAX_ENUM_LOOKUPS;
-      }
+    }
+    else
+    {
+      // ENUM is not configured, so if the target is not in the HSS, the only
+      // thing we can do is assume it is off-net and pass it to the BGCF.
+      route_to_bgcf(req);
+      return;
     }
   }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -151,6 +151,7 @@ enum OptionTypes
   OPT_SCSCF_NODE_URI,
   OPT_SAS_USE_SIGNALING_IF,
   OPT_DISABLE_TCP_SWITCH,
+  OPT_FAKE_ENUM,
 };
 
 
@@ -180,6 +181,7 @@ const static struct pj_getopt_option long_opt[] =
   { "enum",                         required_argument, 0, 'E'},
   { "enum-suffix",                  required_argument, 0, 'x'},
   { "enum-file",                    required_argument, 0, 'f'},
+  { "fake-enum",                    required_argument, 0, OPT_FAKE_ENUM},
   { "enforce-user-phone",           no_argument,       0, 'u'},
   { "enforce-global-only-lookups",  no_argument,       0, 'g'},
   { "reg-max-expires",              required_argument, 0, 'e'},
@@ -307,6 +309,8 @@ static void usage(void)
        " -x, --enum-suffix <suffix> Suffix appended to ENUM domains (default: .e164.arpa)\n"
        " -f, --enum-file <file>     JSON ENUM config file (can't be enabled at same time as\n"
        "                            -E)\n"
+       "     --fake-enum            If no ENUM file or server is configured, fake ENUM lookups\n"
+       "                            by converting tel:+1234 to sip:+1234@homedomain\n"
        " -u, --enforce-user-phone   Controls whether ENUM lookups are only done on SIP URIs if they\n"
        "                            contain the SIP URI parameter user=phone (defaults to false)\n"
        " -g, --enforce-global-only-lookups\n"
@@ -715,6 +719,11 @@ static pj_status_t init_options(int argc, char* argv[], struct options* options)
     case 'f':
       options->enum_file = std::string(pj_optarg);
       TRC_INFO("ENUM file set to %s", pj_optarg);
+      break;
+
+    case OPT_FAKE_ENUM:
+      options->fake_enum = true;
+      TRC_INFO("Dummy ENUM lookups available as a fallback");
       break;
 
     case 'u':
@@ -1294,6 +1303,7 @@ int main(int argc, char* argv[])
   opt.external_icscf_uri = "";
   opt.auth_enabled = PJ_FALSE;
   opt.enum_suffix = ".e164.arpa";
+  opt.fake_enum = false;
 
   // If changing this default for reg_max_expires, note that
   // debian/homestead.init.d in the homestead repository also defaults

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -151,7 +151,7 @@ enum OptionTypes
   OPT_SCSCF_NODE_URI,
   OPT_SAS_USE_SIGNALING_IF,
   OPT_DISABLE_TCP_SWITCH,
-  OPT_FAKE_ENUM,
+  OPT_DEFAULT_TEL_URI_TRANSLATION,
 };
 
 
@@ -181,7 +181,7 @@ const static struct pj_getopt_option long_opt[] =
   { "enum",                         required_argument, 0, 'E'},
   { "enum-suffix",                  required_argument, 0, 'x'},
   { "enum-file",                    required_argument, 0, 'f'},
-  { "fake-enum",                    required_argument, 0, OPT_FAKE_ENUM},
+  { "default-tel-uri-translation",  required_argument, 0, OPT_DEFAULT_TEL_URI_TRANSLATION},
   { "enforce-user-phone",           no_argument,       0, 'u'},
   { "enforce-global-only-lookups",  no_argument,       0, 'g'},
   { "reg-max-expires",              required_argument, 0, 'e'},
@@ -309,8 +309,9 @@ static void usage(void)
        " -x, --enum-suffix <suffix> Suffix appended to ENUM domains (default: .e164.arpa)\n"
        " -f, --enum-file <file>     JSON ENUM config file (can't be enabled at same time as\n"
        "                            -E)\n"
-       "     --fake-enum            If no ENUM file or server is configured, fake ENUM lookups\n"
-       "                            by converting tel:+1234 to sip:+1234@homedomain\n"
+       "     --default-tel-uri-translation\n"
+       "                            If no ENUM file or server is configured, always\n"
+       "                            convert tel:+1234 to sip:+1234@homedomain\n"
        " -u, --enforce-user-phone   Controls whether ENUM lookups are only done on SIP URIs if they\n"
        "                            contain the SIP URI parameter user=phone (defaults to false)\n"
        " -g, --enforce-global-only-lookups\n"
@@ -721,9 +722,9 @@ static pj_status_t init_options(int argc, char* argv[], struct options* options)
       TRC_INFO("ENUM file set to %s", pj_optarg);
       break;
 
-    case OPT_FAKE_ENUM:
-      options->fake_enum = true;
-      TRC_INFO("Dummy ENUM lookups available as a fallback");
+    case OPT_DEFAULT_TEL_URI_TRANSLATION:
+      options->default_tel_uri_translation = true;
+      TRC_INFO("Default TEL->SIP URI translation available as a fallback if no ENUM is configured");
       break;
 
     case 'u':
@@ -1303,7 +1304,7 @@ int main(int argc, char* argv[])
   opt.external_icscf_uri = "";
   opt.auth_enabled = PJ_FALSE;
   opt.enum_suffix = ".e164.arpa";
-  opt.fake_enum = false;
+  opt.default_tel_uri_translation = false;
 
   // If changing this default for reg_max_expires, note that
   // debian/homestead.init.d in the homestead repository also defaults
@@ -1816,9 +1817,9 @@ int main(int argc, char* argv[])
       TRC_STATUS("Reading from an ENUM file");
       enum_service = new JSONEnumService(opt.enum_file);
     }
-    else if (opt.fake_enum)
+    else if (opt.default_tel_uri_translation)
     {
-      TRC_STATUS("Setting up fake ENUM service");
+      TRC_STATUS("Setting up ENUM service to do default TEL->SIP URI translation");
       enum_service = new DummyEnumService(opt.home_domain);
     }
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1806,6 +1806,11 @@ int main(int argc, char* argv[])
       TRC_STATUS("Reading from an ENUM file");
       enum_service = new JSONEnumService(opt.enum_file);
     }
+    else if (opt.fake_enum)
+    {
+      TRC_STATUS("Setting up fake ENUM service");
+      enum_service = new DummyEnumService(opt.home_domain);
+    }
   }
 
   HttpStack* http_stack = HttpStack::get_instance();

--- a/src/pjutils.cpp
+++ b/src/pjutils.cpp
@@ -2182,14 +2182,11 @@ static std::string query_enum(pjsip_msg* req,
 
   if (enum_service != NULL)
   {
-    // ENUM is enabled.
-    TRC_DEBUG("ENUM is enabled");
-
     // Perform an ENUM lookup if we have a tel URI, or if we have
     // a SIP URI which is being treated as a phone number.
     pj_str_t pj_user = PJUtils::user_from_uri(uri);
     user = PJUtils::pj_str_to_string(&pj_user);
-    TRC_DEBUG("Performing ENUM lookup for user %s", user.c_str());
+    TRC_DEBUG("Performing ENUM translation for user %s", user.c_str());
     new_uri = enum_service->lookup_uri_from_user(user, trail);
   }
   else

--- a/src/scscfsproutlet.cpp
+++ b/src/scscfsproutlet.cpp
@@ -1155,37 +1155,47 @@ void SCSCFSproutletTsx::apply_originating_services(pjsip_msg* req)
       add_to_dialog(req, false, ACR::NODE_ROLE_ORIGINATING);
     }
 
-    // Attempt to translate the RequestURI using ENUM or an alternative
-    // database.
-    _scscf->translate_request_uri(req, get_pool(req), trail());
-
-    URIClass uri_class = URIClassifier::classify_uri(req->line.req.uri);
-    std::string new_uri_str = PJUtils::uri_to_string(PJSIP_URI_IN_REQ_URI, req->line.req.uri);
-    TRC_INFO("New URI string is %s", new_uri_str.c_str());
-
-    if ((uri_class == LOCAL_PHONE_NUMBER) ||
-        (uri_class == GLOBAL_PHONE_NUMBER) ||
-        (uri_class == NP_DATA) ||
-        (uri_class == FINAL_NP_DATA))
+    if (_scscf->_enum_service)
     {
-      TRC_DEBUG("Routing to BGCF");
-      SAS::Event event(trail(), SASEvent::PHONE_ROUTING_TO_BGCF, 0);
-      event.add_var_param(new_uri_str);
-      SAS::report_event(event);
-      route_to_bgcf(req);
-    }
-    else if (uri_class == OFFNET_SIP_URI)
-    {
-      // Destination is off-net, so route to the BGCF.
-      TRC_DEBUG("Routing to BGCF");
-      SAS::Event event(trail(), SASEvent::OFFNET_ROUTING_TO_BGCF, 0);
-      event.add_var_param(new_uri_str);
-      SAS::report_event(event);
-      route_to_bgcf(req);
+      // Attempt to translate the RequestURI using ENUM or an alternative
+      // database.
+      _scscf->translate_request_uri(req, get_pool(req), trail());
+
+      URIClass uri_class = URIClassifier::classify_uri(req->line.req.uri);
+      std::string new_uri_str = PJUtils::uri_to_string(PJSIP_URI_IN_REQ_URI, req->line.req.uri);
+      TRC_INFO("New URI string is %s", new_uri_str.c_str());
+
+      if ((uri_class == LOCAL_PHONE_NUMBER) ||
+          (uri_class == GLOBAL_PHONE_NUMBER) ||
+          (uri_class == NP_DATA) ||
+          (uri_class == FINAL_NP_DATA))
+      {
+        TRC_DEBUG("Routing to BGCF");
+        SAS::Event event(trail(), SASEvent::PHONE_ROUTING_TO_BGCF, 0);
+        event.add_var_param(new_uri_str);
+        SAS::report_event(event);
+        route_to_bgcf(req);
+      }
+      else if (uri_class == OFFNET_SIP_URI)
+      {
+        // Destination is off-net, so route to the BGCF.
+        TRC_DEBUG("Routing to BGCF");
+        SAS::Event event(trail(), SASEvent::OFFNET_ROUTING_TO_BGCF, 0);
+        event.add_var_param(new_uri_str);
+        SAS::report_event(event);
+        route_to_bgcf(req);
+      }
+      else
+      {
+        // Destination is on-net so route to the I-CSCF.
+        route_to_icscf(req);
+      }
     }
     else
     {
-      // Destination is on-net so route to the I-CSCF.
+      // ENUM is not configured so we have no way to tell if this request is
+      // on-net or off-net. Route it to the I-CSCF, which should be able to
+      // look it up in the HSS.
       route_to_icscf(req);
     }
   }

--- a/src/scscfsproutlet.cpp
+++ b/src/scscfsproutlet.cpp
@@ -1196,6 +1196,7 @@ void SCSCFSproutletTsx::apply_originating_services(pjsip_msg* req)
       // ENUM is not configured so we have no way to tell if this request is
       // on-net or off-net. Route it to the I-CSCF, which should be able to
       // look it up in the HSS.
+      TRC_DEBUG("No ENUM lookup available - routing to I-CSCF");
       route_to_icscf(req);
     }
   }

--- a/src/ut/enumservice_test.cpp
+++ b/src/ut/enumservice_test.cpp
@@ -67,6 +67,7 @@ class EnumServiceTest : public ::testing::Test
 };
 
 class JSONEnumServiceTest : public EnumServiceTest {};
+class DummyEnumServiceTest : public EnumServiceTest {};
 class DNSEnumServiceTest : public EnumServiceTest
 {
   DNSEnumServiceTest() : EnumServiceTest()
@@ -104,6 +105,14 @@ private:
   string _in; //^ input
   string _out; //^ expected output
 };
+
+
+TEST_F(DummyEnumServiceTest, SimpleTests)
+{
+  DummyEnumService enum_("ut.cw-ngv.com");
+
+  ET("+15108580277", "sip:+15108580277@ut.cw-ngv.com").test(enum_);
+}
 
 
 TEST_F(JSONEnumServiceTest, SimpleTests)


### PR DESCRIPTION
TS 24.229 says "Upon an unsuccessful user location query when the response from the HSS indicates that the user does not exist, and if the Request-URI is a tel URI containing a public telecommunications number as specified in RFC 3966 [22], the I-CSCF may support a local configuration option that indicates whether or not request routeing is to be attempted. If the local configuration option indicates that request routeing is to be attempted, then the I-CSCF shall perform one of the following procedures based on local operator policy:
1)	forward the request to the transit functionality for subsequent routeing; or

...[ENUM lookup alternatives follow]"

I thought that would be useful functionality to have, so I've implemented a mode where you can turn off ENUM entirely and the I-CSCF will route calls it can't find in the HSS to the 'transit functionality' (currently always assumed to be the BGCF).

(I had to pick something for the S-CSCF to do when ENUM was turned off - always routing to the I-CSCF seemed sensible.)

I've tested by setting "default_tel_uri_translation=N" and "enforce_user_phone=Y", configuring `sip:+12425550000@rkd2.cw-ngv.com` and `tel:+12425550000` in my HSS, and checking that:

* calls to `sip:+12425550000@rkd2.cw-ngv.com` reach the UE
* calls to `sip:+12425550000@rkd2.cw-ngv.com;user=phone` reach the UE
* calls to `tel:+12425550000` reach the UE
* calls to `sip:+12425550003@rkd2.cw-ngv.com` go to the BGCF, as that isn't configured in the HSS
* calls to `sip:+12425550003@rkd2.cw-ngv.com;user=phone` go to the BGCF, as the I-CSCF converts it to `tel:+12425550003` and that isn't configured in the HSS
* calls to `tel:+12425550003` go to the BGCF, as that isn't configured in the HSS
