### PR TITLE
[Reviewer: Ellie] Remove existing Route headers before the BGCF adds them

### DIFF
--- a/src/bgcfsproutlet.cpp
+++ b/src/bgcfsproutlet.cpp
@@ -43,6 +43,7 @@
 #include "log.h"
 #include "sproutsasevent.h"
 #include "bgcfsproutlet.h"
+#include "constants.h"
 #include <fstream>
 
 /// BGCFSproutlet constructor.
@@ -174,6 +175,10 @@ void BGCFSproutletTsx::on_rx_initial_request(pjsip_msg* req)
 
   if (!bgcf_routes.empty())
   {
+    // The BGCF should be in control of what routes get added - delete existing
+    // ones first.
+    PJUtils::remove_hdr(req, &STR_ROUTE);
+
     for (std::vector<std::string>::iterator ii = bgcf_routes.begin();
          ii != bgcf_routes.end();
          ++ii)

--- a/src/ut/bgcf_test.cpp
+++ b/src/ut/bgcf_test.cpp
@@ -426,3 +426,20 @@ TEST_F(BGCFTest, TestInvalidBGCFRouteNameAddrMix)
   list<HeaderMatcher> hdrs;
   doFailureFlow(msg, 500);
 }
+
+// If the BGCF receives a request with pre-loaded Route headers, it should
+// remove them before applying its own routes.
+TEST_F(BGCFTest, OverrideRoutes)
+{
+  SCOPED_TRACE("");
+  BGCFMessage msg;
+  msg._to = "12345";
+  msg._todomain = "domainvalid";
+  msg._route = "Route: <sip:bgcf.homedomain>\nRoute: <sip:1.2.3.4;lr>";
+  add_host_mapping("domainvalid", "10.9.8.7");
+  list<HeaderMatcher> hdrs;
+
+  // Check that the preloaded 1.2.3.4 route has now gone.
+  hdrs.push_back(HeaderMatcher("Route", "Route: <sip:10.0.0.1:5060;transport=TCP;lr>"));
+  doSuccessfulFlow(msg, testing::MatchesRegex("sip:12345@domainvalid"), hdrs);
+}


### PR DESCRIPTION
In my testing, I hit a case where a message arrived at the BGCF with Route headers still attached. This meant that when the BGCF added Route headers, the message still followed the pre-existing ones.

I don't think that's sensible behaviour, so I've added code to strip all existing Route headers when we start adding BGCF routes. I've tested that this works.

I'll talk to you tomorrow about the exact flow that triggered this, for background.