### PR TITLE
[Reviewer: Matt] Minor perf-test fixes

### DIFF
--- a/clearwater-sip-perf.root/usr/share/clearwater/bin/sip-perf
+++ b/clearwater-sip-perf.root/usr/share/clearwater/bin/sip-perf
@@ -9,6 +9,13 @@ ulimit -Sn 100000
 # Read in config.
 . /etc/clearwater/config
 
+stress_target=$home_domain:5060
+
+if [ -n "$1" ]
+then
+ stress_target=$1
+fi
+
 # Calculate the number of users.
 num_users=$(($(wc -l < /usr/share/clearwater/sip-perf/users.csv) - 1))
 
@@ -21,5 +28,5 @@ export TERM=dumb
 
 # Actually run sipp.
 logger -p daemon.error -t sip-perf Starting SIP performance test
-nice -n-20 /usr/share/clearwater/bin/sipp -i $local_ip -sf /var/log/clearwater-sipp/sip-perf.xml $home_domain:5060 -t tn -s $home_domain -inf /usr/share/clearwater/sip-perf/users.csv -users $num_users -m $num_users -default_behaviors all,-bye -max_socket 65000 -trace_stat -trace_rtt -trace_counts -trace_err -max_reconnect -1 -reconnect_sleep 0 -reconnect_close 0 -send_timeout 4000 -recv_timeout 12000 -nostdin >> /var/log/clearwater-sipp/sip-perf.out 2>&1
+nice -n-20 /usr/share/clearwater/bin/sipp -i $local_ip -sf /var/log/clearwater-sipp/sip-perf.xml $stress_target -t tn -s $home_domain -inf /usr/share/clearwater/sip-perf/users.csv -users $num_users -m $num_users -default_behaviors all,-bye -max_socket 65000 -trace_stat -trace_rtt -trace_counts -trace_err -max_reconnect -1 -reconnect_sleep 0 -reconnect_close 0 -send_timeout 4000 -recv_timeout 12000 -nostdin >> /var/log/clearwater-sipp/sip-perf.out 2>&1
 logger -p daemon.error -t sip-perf Completed SIP performance test

--- a/clearwater-sip-perf.root/usr/share/clearwater/sip-perf/sip-perf.xml
+++ b/clearwater-sip-perf.root/usr/share/clearwater/sip-perf/sip-perf.xml
@@ -254,6 +254,7 @@
   <nop hide="true">
     <action>
       <assignstr assign_to="uas_via" value="[last_Via:]" />
+      <assignstr assign_to="uas_rr" value="[last_Record-Route:]" />
     </action>
   </nop>
 
@@ -268,6 +269,7 @@
   <nop hide="true">
     <action>
       <assignstr assign_to="uas_via" value="[last_Via:]" />
+      <assignstr assign_to="uas_rr" value="[last_Record-Route:]" />
     </action>
   </nop>
 
@@ -277,7 +279,7 @@
     <![CDATA[
       SIP/2.0 100 Trying
       [$uas_via]
-      [last_Record-Route:]
+      [$uas_rr]
       Call-ID: [$my_dn]-[$call_repeat]///[call_id]
       From: <sip:[$peer_dn]@[service]>;tag=[pid]SIPpTag00[call_number]1234
       To: <sip:[$my_dn]@[service]>
@@ -291,7 +293,7 @@
     <![CDATA[
       SIP/2.0 180 Ringing
       [$uas_via]
-      [last_Record-Route:]
+      [$uas_rr]
       Call-ID: [$my_dn]-[$call_repeat]///[call_id]
       From: <sip:[$peer_dn]@[service]>;tag=[pid]SIPpTag00[call_number]1234
       To: <sip:[$my_dn]@[service]>;tag=[pid]SIPpTag00[call_number]4321

--- a/clearwater-sip-stress.root/usr/share/clearwater/sip-stress/sip-stress.xml
+++ b/clearwater-sip-stress.root/usr/share/clearwater/sip-stress/sip-stress.xml
@@ -286,6 +286,7 @@
   <nop hide="true">
     <action>
       <assignstr assign_to="uas_via" value="[last_Via:]" />
+      <assignstr assign_to="uas_rr" value="[last_Record-Route:]" />
     </action>
   </nop>
 
@@ -300,6 +301,7 @@
   <nop hide="true">
     <action>
       <assignstr assign_to="uas_via" value="[last_Via:]" />
+      <assignstr assign_to="uas_rr" value="[last_Record-Route:]" />
     </action>
   </nop>
 
@@ -310,7 +312,7 @@
 
       SIP/2.0 100 Trying
       [$uas_via]
-      [last_Record-Route:]
+      [$uas_rr]
       Call-ID: [$my_dn]-[$call_repeat]///[call_id]
       From: <sip:[$peer_dn]@[service]>;tag=[pid]SIPpTag00[call_number]1234
       To: <sip:[$my_dn]@[service]>
@@ -325,7 +327,7 @@
 
       SIP/2.0 180 Ringing
       [$uas_via]
-      [last_Record-Route:]
+      [$uas_rr]
       Call-ID: [$my_dn]-[$call_repeat]///[call_id]
       From: <sip:[$peer_dn]@[service]>;tag=[pid]SIPpTag00[call_number]1234
       To: <sip:[$my_dn]@[service]>;tag=[pid]SIPpTag00[call_number]4321

--- a/debian/control
+++ b/debian/control
@@ -203,7 +203,6 @@ Description: Exposes SIP stress statistics over the clearwater statistics interf
 Package: clearwater-sip-perf
 Architecture: any
 Depends: clearwater-infrastructure, clearwater-tcp-scalability, clearwater-sipp
-Conflicts: sprout, bono, restund
 Suggests: clearwater-logging, clearwater-snmpd
 Description: Runs SIP performance tests against Clearwater
 


### PR DESCRIPTION
I ran clearwater-sip-perf on an all-in-one node - here are the fixes I needed to make that work.

* clearwater-sip-perf was marked as conflicting with sprout/bono/restund, but actually it runs fine.
* the home domain (example.com) doesn't resolve on an AIO node, so I gave sip-perf an optional argument which is the IP to run stress on.
* if a 100 Trying came in after the INVITE, we'd use its Record-Route headers on subsequent messages - but as 100s aren't end-to-end this meant in-dialog messages got misrouted. We already had some stuff to make this work for Via headers which I've just extended.