### PR TITLE
[Reviewer: RKD] Stop restund properly

### DIFF
--- a/debian/restund.init.d
+++ b/debian/restund.init.d
@@ -115,19 +115,8 @@ do_stop()
         #   1 if daemon was already stopped
         #   2 if daemon could not be stopped
         #   other if a failure occurred
-        start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --name $NAME
+        start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --name $NAME --exec $DAEMON
         RETVAL="$?"
-        [ "$RETVAL" = 2 ] && return 2
-        # Wait for children to finish too if this is a daemon that forks
-        # and if the daemon is only ever run from this initscript.
-        # If the above conditions are not satisfied then add some other code
-        # that waits for the process to drop all resources that could be
-        # needed by services started subsequently.  A last resort is to
-        # sleep for some time.
-        #start-stop-daemon --stop --quiet --oknodo --retry=0/30/KILL/5 --exec $DAEMON
-        [ "$?" = 2 ] && return 2
-        # Many daemons don't delete their pidfiles when they exit.
-        #rm -f $PIDFILE
         return "$RETVAL"
 }
 


### PR DESCRIPTION
If we don't specify the executable, start-stop-daemon will kill the init script.

This fixes issue #1509.

I've tested this live and verifies that this fixes this issue. I've tested both with and without a running restund, and checked that the PID of the restund process changed, and that there wasn't one left behind.