### PR TITLE
[Reviewer: Adam] Track the time from INVITE to 180 Ringing

### DIFF
--- a/include/scscfsproutlet.h
+++ b/include/scscfsproutlet.h
@@ -172,6 +172,11 @@ private:
   void track_app_serv_comm_success(const std::string& uri,
                                    DefaultHandling default_handling);
 
+  /// Record the time an INVITE took to reach ringing state.
+  ///
+  /// @param ringing_us Time spent until a 180 Ringing, in microseconds.
+  void track_ringing_time(uint64_t ringing_us);
+
   /// Translate RequestURI using ENUM service if appropriate.
   void translate_request_uri(pjsip_msg* req, pj_pool_t* pool, SAS::TrailId trail);
 
@@ -223,6 +228,7 @@ private:
   SNMP::CounterTable* _routed_by_preloaded_route_tbl = NULL;
   SNMP::CounterTable* _invites_cancelled_before_1xx_tbl = NULL;
   SNMP::CounterTable* _invites_cancelled_after_1xx_tbl = NULL;
+  SNMP::EventAccumulatorTable* _ringing_time_tbl = NULL;
 
   AsCommunicationTracker* _sess_term_as_tracker;
   AsCommunicationTracker* _sess_cont_as_tracker;
@@ -409,6 +415,9 @@ private:
   /// correct stats can be updated.
   pjsip_method_e _req_type;
   bool _seen_1xx;
+
+  /// Track the time when we received this request for statistics purposes.
+  uint64_t _tsx_start_time;
 
   static const int MAX_FORKING = 10;
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -76,7 +76,6 @@ SPROUT_COMMON_SOURCES := logger.cpp \
                          exception_handler.cpp \
                          snmp_agent.cpp \
                          snmp_continuous_accumulator_table.cpp \
-                         snmp_event_accumulator_table.cpp \
                          sip_string_to_request_type.cpp \
                          snmp_row.cpp \
                          snmp_ip_row.cpp \
@@ -94,6 +93,7 @@ sprout_SOURCES := ${SPROUT_COMMON_SOURCES} \
                   snmp_ip_count_table.cpp \
                   snmp_success_fail_count_table.cpp \
                   snmp_success_fail_count_by_request_type_table.cpp \
+                  snmp_event_accumulator_table.cpp \
                   pdlog.cpp \
                   main.cpp
 

--- a/src/scscfsproutlet.cpp
+++ b/src/scscfsproutlet.cpp
@@ -432,7 +432,9 @@ void SCSCFSproutletTsx::on_rx_initial_request(pjsip_msg* req)
   pjsip_status_code status_code = PJSIP_SC_OK;
 
   // Store off the time we received this request, for statistics purposes.
-  _tsx_start_time = Utils::get_time();
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC_COARSE, &ts);
+  _tsx_start_time = ((uint64_t)ts.tv_sec * 1000000) + (ts.tv_nsec / 1000);
 
   // Work out if we should be auto-registering the user based on this
   // request and if we are, also work out the IMPI to register them with.
@@ -684,7 +686,9 @@ void SCSCFSproutletTsx::on_rx_response(pjsip_msg* rsp, int fork_id)
         _req_type == PJSIP_INVITE_METHOD &&
         st_code == PJSIP_SC_RINGING)
     {
-      uint64_t ringing_us = (Utils::get_time() - _tsx_start_time) * 1000;
+      struct timespec ts;
+      clock_gettime(CLOCK_MONOTONIC_COARSE, &ts);
+      uint64_t ringing_us = ((uint64_t)ts.tv_sec * 1000000) + (ts.tv_nsec / 1000) - _tsx_start_time;
       _scscf->track_ringing_time(ringing_us);
     }
 

--- a/src/scscfsproutlet.cpp
+++ b/src/scscfsproutlet.cpp
@@ -99,6 +99,9 @@ SCSCFSproutlet::SCSCFSproutlet(const std::string& scscf_name,
                                                                  "1.2.826.0.1.1578918.9.3.32");
   _invites_cancelled_after_1xx_tbl = SNMP::CounterTable::create("invites_cancelled_after_1xx",
                                                                 "1.2.826.0.1.1578918.9.3.33");
+  _ringing_time_tbl = SNMP::EventAccumulatorTable::create("scscf_ringing_time",
+                                                          "1.2.826.0.1.1578918.9.3.34");
+
 }
 
 
@@ -352,6 +355,10 @@ void SCSCFSproutlet::track_app_serv_comm_success(const std::string& uri,
   }
 }
 
+void SCSCFSproutlet::track_ringing_time(uint64_t ringing_us)
+{
+  _ringing_time_tbl->accumulate(ringing_us);
+}
 
 SCSCFSproutletTsx::SCSCFSproutletTsx(SproutletTsxHelper* helper,
                                      SCSCFSproutlet* scscf,
@@ -373,6 +380,7 @@ SCSCFSproutletTsx::SCSCFSproutletTsx(SproutletTsxHelper* helper,
   _record_routed(false),
   _req_type(req_type),
   _seen_1xx(false),
+  _tsx_start_time(0),
   _impi(),
   _auto_reg(false),
   _se_helper(stack_data.default_session_expires)
@@ -422,6 +430,9 @@ void SCSCFSproutletTsx::on_rx_initial_request(pjsip_msg* req)
   TRC_INFO("S-CSCF received initial request");
 
   pjsip_status_code status_code = PJSIP_SC_OK;
+
+  // Store off the time we received this request, for statistics purposes.
+  _tsx_start_time = Utils::get_time();
 
   // Work out if we should be auto-registering the user based on this
   // request and if we are, also work out the IMPI to register them with.
@@ -665,6 +676,18 @@ void SCSCFSproutletTsx::on_rx_response(pjsip_msg* rsp, int fork_id)
 
   if (rsp != NULL)
   {
+    // If this is a 180 Ringing response being sent to a caller (not to an app
+    // server or originating S-CSCF), calculate the time it's taken to get to
+    // the ringing point and update our statistics.
+    if (_session_case->is_originating() &&
+        _as_chain_link.complete() &&
+        _req_type == PJSIP_INVITE_METHOD &&
+        st_code == PJSIP_SC_RINGING)
+    {
+      uint64_t ringing_us = (Utils::get_time() - _tsx_start_time) * 1000;
+      _scscf->track_ringing_time(ringing_us);
+    }
+
     // Forward the response upstream.  The proxy layer will aggregate responses
     // if required.
     send_response(rsp);

--- a/src/ut/fakesnmp.cpp
+++ b/src/ut/fakesnmp.cpp
@@ -81,6 +81,8 @@ AuthenticationStatsTables FAKE_AUTHENTICATION_STATS_TABLES =
 };
 
 // Alternative implementations is some functions, so we aren't calling real SNMP code in UT
+EventAccumulatorTable* EventAccumulatorTable::create(std::string name, std::string oid) { return new FakeEventAccumulatorTable(); };
+
 CounterTable* CounterTable::create(std::string name, std::string oid) { return new FakeCounterTable(); };
 
 IPCountTable* IPCountTable::create(std::string name, std::string oid) { return new FakeIPCountTable(); };


### PR DESCRIPTION
I'm going to live test by:

- making a single call
- checking that the stats are updated, and that the recorded latency approximately matches the latency in SAS
- running the live tests and checking that this stat still looks sensible

I'll load up the MIB and use snmptable to check this, so I check that the MIB and the stat match.