### PR TITLE
[Reviewer: RJW2] Privacy header now splits on semicolons rather than commas.

### DIFF
--- a/include/custom_headers.h
+++ b/include/custom_headers.h
@@ -44,21 +44,11 @@
 
 extern "C" {
 #include <pjsip.h>
+#include <pjsip/print_util.h>
 }
 
 // Main entry point
 pj_status_t register_custom_headers();
-
-// Utility macro from sip_parser.c
-#define copy_advance(buf,str)                   \
-  do {                                          \
-    if ((str).slen >= (endbuf-buf)) return -1;  \
-    pj_memcpy(buf, (str).ptr, (str).slen);      \
-    buf += (str).slen;                          \
-  } while (0)
-
-// Function pointer from pjsip for overloading header print and clone methods.
-typedef int (*pjsip_hdr_print_fptr)(void *hdr, char *buf, pj_size_t len);
 
 /// Custom header structures.
 

--- a/include/custom_headers.h
+++ b/include/custom_headers.h
@@ -57,6 +57,9 @@ pj_status_t register_custom_headers();
     buf += (str).slen;                          \
   } while (0)
 
+// Function pointer from pjsip for overloading header print and clone methods.
+typedef int (*pjsip_hdr_print_fptr)(void *hdr, char *buf, pj_size_t len);
+
 /// Custom header structures.
 
 enum session_refresher_t
@@ -111,6 +114,7 @@ typedef struct pjsip_reject_contact_hdr {
 /// Utility functions (parse, create, init, clone, print_on)
 
 // Privacy
+pjsip_generic_array_hdr* pjsip_privacy_hdr_create( pj_pool_t *pool, const pj_str_t *hnames);
 pjsip_hdr* parse_hdr_privacy(pjsip_parse_ctx* ctx);
 
 // Assocciated URI

--- a/src/custom_headers.cpp
+++ b/src/custom_headers.cpp
@@ -53,34 +53,25 @@ extern "C" {
 /// generic array header, however it splits on commas. We therefore override
 /// the default parser and print function in the generic array header with a
 /// custom constructor.
-
-static int pjsip_privacy_hdr_print( pjsip_generic_array_hdr *hdr,
+static int pjsip_privacy_hdr_print(pjsip_generic_array_hdr *hdr,
                       char *buf, pj_size_t size)
 {
-    return pjsip_generic_array_hdr_delimited_print(hdr, buf, size, "; ",2);
+  return pjsip_generic_array_hdr_delimited_print(hdr, buf, size, "; ", 2);
 }
 
-
-pjsip_generic_array_hdr* pjsip_privacy_hdr_init( pj_pool_t *pool,
-                                   void *mem,
-                                   const pj_str_t *hnames)
-{
-    pjsip_generic_array_hdr *hdr = pjsip_generic_array_hdr_init(pool, mem,hnames);
-    hdr->vptr->print_on = (pjsip_hdr_print_fptr) &pjsip_privacy_hdr_print;
-    return hdr;
-}
-
-pjsip_generic_array_hdr* pjsip_privacy_hdr_create( pj_pool_t *pool,
+pjsip_generic_array_hdr* pjsip_privacy_hdr_create(pj_pool_t *pool,
                                  const pj_str_t *hnames)
 {
-    void *mem = pj_pool_alloc(pool, sizeof(pjsip_generic_array_hdr));
-    return pjsip_privacy_hdr_init(pool, mem, hnames);
+  void *mem = pj_pool_alloc(pool, sizeof(pjsip_generic_array_hdr));
+  pjsip_generic_array_hdr *hdr = pjsip_generic_array_hdr_init(pool, mem,hnames);
+  hdr->vptr->print_on = (pjsip_hdr_print_fptr) &pjsip_privacy_hdr_print;
+  return hdr;
 }
 
 // LCOV_EXCL_START
 pjsip_hdr* parse_hdr_privacy(pjsip_parse_ctx* ctx)
 {
-  const pjsip_parser_const_t* pconst=pjsip_parser_const();
+  const pjsip_parser_const_t* pconst = pjsip_parser_const();
   pjsip_generic_array_hdr *privacy = pjsip_privacy_hdr_create(ctx->pool, &STR_PRIVACY);
   pjsip_parse_generic_delimited_array_hdr(privacy, ctx->scanner,';',
                               &(pconst->pjsip_NOT_SEMICOLON_OR_NEWLINE));

--- a/src/custom_headers.cpp
+++ b/src/custom_headers.cpp
@@ -46,16 +46,44 @@ extern "C" {
 #include "constants.h"
 #include "custom_headers.h"
 
-/// Custom parser for Privacy header.  This is registered with PJSIP below
+/// Custom parser for Privacy header. This is registered with PJSIP below
 /// in register_custom_headers().
 ///
-/// The Privacy header is a simple comma-separated list of values so we use
-/// the built-in PJSIP parser code.
+/// The privacy header is delimited by semicolons. We want to use pjsip's
+/// generic array header, however it splits on commas. We therefore override
+/// the default parser and print function in the generic array header with a
+/// custom constructor.
+
+static int pjsip_privacy_hdr_print( pjsip_generic_array_hdr *hdr,
+                      char *buf, pj_size_t size)
+{
+    return pjsip_generic_array_hdr_delimited_print(hdr, buf, size, "; ",2);
+}
+
+
+pjsip_generic_array_hdr* pjsip_privacy_hdr_init( pj_pool_t *pool,
+                                   void *mem,
+                                   const pj_str_t *hnames)
+{
+    pjsip_generic_array_hdr *hdr = pjsip_generic_array_hdr_init(pool, mem,hnames);
+    hdr->vptr->print_on = (pjsip_hdr_print_fptr) &pjsip_privacy_hdr_print;
+    return hdr;
+}
+
+pjsip_generic_array_hdr* pjsip_privacy_hdr_create( pj_pool_t *pool,
+                                 const pj_str_t *hnames)
+{
+    void *mem = pj_pool_alloc(pool, sizeof(pjsip_generic_array_hdr));
+    return pjsip_privacy_hdr_init(pool, mem, hnames);
+}
+
 // LCOV_EXCL_START
 pjsip_hdr* parse_hdr_privacy(pjsip_parse_ctx* ctx)
 {
-  pjsip_generic_array_hdr *privacy = pjsip_generic_array_hdr_create(ctx->pool, &STR_PRIVACY);
-  pjsip_parse_generic_array_hdr_imp(privacy, ctx->scanner);
+  const pjsip_parser_const_t* pconst=pjsip_parser_const();
+  pjsip_generic_array_hdr *privacy = pjsip_privacy_hdr_create(ctx->pool, &STR_PRIVACY);
+  pjsip_parse_generic_delimited_array_hdr(privacy, ctx->scanner,';',
+                              &(pconst->pjsip_NOT_SEMICOLON_OR_NEWLINE));
   return (pjsip_hdr*)privacy;
 }
 // LCOV_EXCL_STOP

--- a/src/custom_headers.cpp
+++ b/src/custom_headers.cpp
@@ -56,7 +56,8 @@ extern "C" {
 static int pjsip_privacy_hdr_print(pjsip_generic_array_hdr *hdr,
                       char *buf, pj_size_t size)
 {
-  return pjsip_generic_array_hdr_delimited_print(hdr, buf, size, "; ", 2);
+  pj_str_t semicolon_delimiter = {"; ", 2};
+  return pjsip_delimited_array_hdr_print(hdr, buf, size, &semicolon_delimiter);
 }
 
 pjsip_generic_array_hdr* pjsip_privacy_hdr_create(pj_pool_t *pool,
@@ -73,7 +74,7 @@ pjsip_hdr* parse_hdr_privacy(pjsip_parse_ctx* ctx)
 {
   const pjsip_parser_const_t* pconst = pjsip_parser_const();
   pjsip_generic_array_hdr *privacy = pjsip_privacy_hdr_create(ctx->pool, &STR_PRIVACY);
-  pjsip_parse_generic_delimited_array_hdr(privacy, ctx->scanner,';',
+  pjsip_parse_delimited_array_hdr(privacy, ctx->scanner,';',
                               &(pconst->pjsip_NOT_SEMICOLON_OR_NEWLINE));
   return (pjsip_hdr*)privacy;
 }

--- a/src/mmtel.cpp
+++ b/src/mmtel.cpp
@@ -45,6 +45,7 @@
 #include "mmtelsasevent.h"
 #include "mmtel.h"
 #include "constants.h"
+#include "custom_headers.h"
 
 using namespace rapidxml;
 
@@ -555,7 +556,7 @@ void MmtelTsx::build_privacy_header(pjsip_msg* req, pj_pool_t* pool, int privacy
     return;
   }
 
-  pjsip_generic_array_hdr *new_header = pjsip_generic_array_hdr_create(pool, &privacy_hdr_name);
+  pjsip_generic_array_hdr *new_header = pjsip_privacy_hdr_create(pool, &privacy_hdr_name);
 
   if (privacy_fields & PRIVACY_H_ID)
   {

--- a/src/ut/scscf_test.cpp
+++ b/src/ut/scscf_test.cpp
@@ -5741,7 +5741,7 @@ TEST_F(SCSCFTest, ExpiredChain)
   doAsOriginated(string(buf, len), true);
 }
 
-#if 0
+
 // Test a simple MMTEL flow.
 TEST_F(SCSCFTest, MmtelFlow)
 {
@@ -5834,8 +5834,8 @@ TEST_F(SCSCFTest, MmtelFlow)
   tpAS1.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:6505551234@homedomain", r1.uri());
   EXPECT_THAT(get_headers(out, "Route"),
-              testing::MatchesRegex("Route: <sip:5\\.2\\.3\\.4:56787;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr>"));
-  EXPECT_EQ("Privacy: id, header, user", get_headers(out, "Privacy"));
+              testing::MatchesRegex("Route: <sip:5\\.2\\.3\\.4:56787;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;service=scscf>"));
+  EXPECT_EQ("Privacy: id; header; user", get_headers(out, "Privacy"));
 
   // ---------- AS1 turns it around (acting as proxy)
   const pj_str_t STR_ROUTE = pj_str("Route");
@@ -5862,12 +5862,12 @@ TEST_F(SCSCFTest, MmtelFlow)
   tpBono.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob", r1.uri());
   EXPECT_EQ("", get_headers(out, "Route"));
-  EXPECT_EQ("Privacy: id, header, user", get_headers(out, "Privacy"));
+  EXPECT_EQ("Privacy: id; header; user", get_headers(out, "Privacy"));
 
   free_txdata();
 }
 
-
+#if 0
 /// Test MMTEL-then-external-AS flows (both orig and term).
 //
 // Flow:


### PR DESCRIPTION
Modified the privacy header code to use a semicolon delimiter rather than commas, see issue #1514. The changes are:

1) Added parse and print functions for a privacy header to custom_headers.cpp and custom_headers.h
2) Modified the mmtel code to call the privacy header constructor rather than construct a generic array header.
This commit must be used in conjunction with the corresponding privacy_header branch of pjsip, for which a corresponding pull request will be made