### PR TITLE
Build submodules with "make" rather than "make build"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ distclean: $(patsubst %, %_distclean, ${SUBMODULES}) sprout_distclean
 
 .PHONY: plugins-build
 plugins-build:
-	find plugins -mindepth 1 -maxdepth 1 -type d -exec ${MAKE} -C {} build \;
+	find plugins -mindepth 1 -maxdepth 1 -type d -exec ${MAKE} -C {} \;
 
 .PHONY: plugins-test
 plugins-test:


### PR DESCRIPTION
The root makefile builds submodules recursively by calling make build in each plugin directory. However, including cpp.mk provides a make all, but not a make build-target. To make these slightly more consistent, I propose simply calling make in the plugin directory for the build, allowing the plugin itself to specify the default target.