### PR TITLE
Fix bug in script stopping sipp-stress

### DIFF
--- a/debian/clearwater-sip-stress.init.d
+++ b/debian/clearwater-sip-stress.init.d
@@ -109,7 +109,7 @@ do_stop()
         done
 
         # Kill any remaining clearwater-sip-stress or sipp instances
-        pkill $DAEMON >/dev/null 2>&1
+        pkill $NAME >/dev/null 2>&1
         pkill sipp >/dev/null 2>&1
 
         return $RC

--- a/debian/clearwater-sip-stress.init.d
+++ b/debian/clearwater-sip-stress.init.d
@@ -109,7 +109,7 @@ do_stop()
         done
 
         # Kill any remaining clearwater-sip-stress or sipp instances
-        pkill clearwater-sip-stress >/dev/null 2>&1
+        pkill $DAEMON >/dev/null 2>&1
         pkill sipp >/dev/null 2>&1
 
         return $RC


### PR DESCRIPTION
The clearwater-sip-stress script does not correctly kill the sip-stress process in the case that it is not caught when killing processes in the relevant pidfile. This pull request covers fixing this problem.