### PR TITLE
[Reviewer: RKD] Add cassandra hostname option for memento plugin

### DIFF
--- a/sprout-base.root/etc/init.d/sprout
+++ b/sprout-base.root/etc/init.d/sprout
@@ -243,6 +243,11 @@ get_daemon_args()
           DAEMON_ARGS="$DAEMON_ARGS --call-list-ttl=$call_list_ttl"
         fi
 
+        if [ -n "$memento" ] && [ -n "$cassandra_hostname" ]
+        then
+          DAEMON_ARGS="$DAEMON_ARGS --plugin-option=memento,cassandra,$cassandra_hostname"
+        fi
+
         # TODO improve this so we don't have to have the same parameters
         # repeated for each Sproutlet
         [ "$icscf" = "" ]                         || DAEMON_ARGS="$DAEMON_ARGS --icscf=$icscf"

--- a/src/mementoasplugin.cpp
+++ b/src/mementoasplugin.cpp
@@ -107,8 +107,7 @@ bool MementoPlugin::load(struct options& opt, std::list<Sproutlet*>& sproutlets)
                                                     "Memcached");
 
       // If the memento cassandra hostname option is set, use that instead of "localhost".
-      if ((opt.plugin_options.count("memento")) &&
-          (opt.plugin_options.find("memento")->second.count("cassandra")))
+      if (opt.plugin_options["memento"].count("cassandra"))
       {
         cassandra = opt.plugin_options.find("memento")->second.find("cassandra")->second;
       }

--- a/src/mementoasplugin.cpp
+++ b/src/mementoasplugin.cpp
@@ -84,6 +84,7 @@ MementoPlugin::~MementoPlugin()
 bool MementoPlugin::load(struct options& opt, std::list<Sproutlet*>& sproutlets)
 {
   bool plugin_loaded = true;
+  std::string cassandra = "localhost";
 
   if (opt.enabled_memento)
   {
@@ -105,8 +106,15 @@ bool MementoPlugin::load(struct options& opt, std::list<Sproutlet*>& sproutlets)
                                                     "Memento",
                                                     "Memcached");
 
+      // If the memento cassandra hostname option is set, use that instead of "localhost".
+      if ((opt.plugin_options.count("memento")) &&
+          (opt.plugin_options.find("memento")->second.count("cassandra")))
+      {
+        cassandra = opt.plugin_options.find("memento")->second.find("cassandra")->second;
+      }
+
       _call_list_store = new CallListStore::Store();
-      _call_list_store->configure_connection("localhost", 9160, _cass_comm_monitor);
+      _call_list_store->configure_connection(cassandra, 9160, _cass_comm_monitor);
 
       _memento = new MementoAppServer(opt.prefix_memento,
                                       _call_list_store,


### PR DESCRIPTION
If we're using memento and `cassandra_hostname` is set, add it to memento's plugin options.  When the memento plugin connects to cassandra, use `cassandra_hostname` (if it is set) in preference to `localhost`.

Tested that the plugin can connect to a remote cassandra using the live tests.