### PR TITLE
[Reviewer: Graeme] Add start and end markers when bono statelessly rejects a request

### DIFF
--- a/src/bono.cpp
+++ b/src/bono.cpp
@@ -740,8 +740,8 @@ static int proxy_verify_request(pjsip_rx_data *rdata)
 /// Rejects a request statelessly.
 static void reject_request(pjsip_rx_data* rdata, int status_code)
 {
-  // Log start and end markers. These are need for the failed request to appear
-  // in SAS.
+  // Log start and end markers. These are needed for the failed request to
+  // appear in SAS.
   SAS::Marker start_marker(get_trail(rdata), MARKER_ID_START, 1u);
   SAS::report_marker(start_marker);
   SAS::Marker end_marker(get_trail(rdata), MARKER_ID_END, 1u);

--- a/src/bono.cpp
+++ b/src/bono.cpp
@@ -740,6 +740,13 @@ static int proxy_verify_request(pjsip_rx_data *rdata)
 /// Rejects a request statelessly.
 static void reject_request(pjsip_rx_data* rdata, int status_code)
 {
+  // Log start and end markers. These are need for the failed request to appear
+  // in SAS.
+  SAS::Marker start_marker(get_trail(rdata), MARKER_ID_START, 1u);
+  SAS::report_marker(start_marker);
+  SAS::Marker end_marker(get_trail(rdata), MARKER_ID_END, 1u);
+  SAS::report_marker(end_marker);
+
   pj_status_t status;
 
   ACR* acr = cscf_acr_factory->get_acr(get_trail(rdata),


### PR DESCRIPTION
When bono statelessly rejects a request it does not add start and end time markersm, which means the trace cannot be displayed in SAS. 

I've tested this by hacking clearwater-live-test to make a call without registering the caller (which causes bono to statelessly reject with a 403). Before the change the call did not appear in SAS results but after the change it did. 