### PR TITLE
[Reviewer: Seb] Build memento with the cassndra connection pool

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -247,7 +247,7 @@ gemini-as.so_SOURCES := mobiletwinned.cpp sproutletappserver.cpp geminiasplugin.
 gemini-as.so_CPPFLAGS := ${PLUGIN_COMMON_CPPFLAGS} -I../modules/gemini/include
 gemini-as.so_LDFLAGS := ${PLUGIN_COMMON_LDFLAGS}
 
-memento-as.so_SOURCES := sproutletappserver.cpp mementoasplugin.cpp cassandra_store.cpp call_list_store.cpp mementosaslogger.cpp call_list_store_processor.cpp httpnotifier.cpp mementoappserver.cpp
+memento-as.so_SOURCES := sproutletappserver.cpp mementoasplugin.cpp cassandra_store.cpp cassandra_connection_pool.cpp call_list_store.cpp mementosaslogger.cpp call_list_store_processor.cpp httpnotifier.cpp mementoappserver.cpp
 memento-as.so_CPPFLAGS := ${PLUGIN_COMMON_CPPFLAGS} -I../modules/memento-as/include -I../modules/memento-as/modules/memento-common/include
 memento-as.so_LDFLAGS := ${PLUGIN_COMMON_LDFLAGS} -lthrift -lcassandra
 


### PR DESCRIPTION
This fixes the following error when trying to start sprout using commit [94ad54](https://github.com/Metaswitch/sprout/commit/94ad54da9be24b94e3f39d8bb32ae63aa9300c51)

26-09-2016 14:05:53.785 UTC Error pluginloader.cpp:148: Error loading Sproutlet plug-in /usr/share/clearwater/sprout/plugins/memento-as.so - /usr/share/clearwater/sprout/lib/libcassandra.so: undefined symbol: _ZN6apache6thrift12GlobalOutputE

The error happens because memento-as.so loads libcassandra.so, which depends on _ZN6apache6thrift12GlobalOutputE that should be provided by libthrift.so. Thrift used to be loaded by memento-as.so, but this stopped happening when we introduced the cassandra connection pooling stuff. 

Fix is to build memento-as.so with cassandra_connection_pool.so