### PR TITLE
[Reviewer: Ellie] [INT-54] Changed bono alias to domain, to allow for routing to ibcf by domain

### DIFF
--- a/debian/bono.init.d
+++ b/debian/bono.init.d
@@ -120,6 +120,7 @@ get_settings()
         [ -r /etc/clearwater/user_settings ] && . /etc/clearwater/user_settings
 
         # Work out which features are enabled.
+        IBCF_ENABLED=Y
         if [ -d /etc/clearwater/features.d ]
         then
           for file in $(find /etc/clearwater/features.d -type f)
@@ -137,11 +138,10 @@ get_daemon_args()
         # Get the settings
         get_settings
 
-        if [ $ibcf_enabled = Y ]
+        if [ $IBCF_ENABLED = Y ]
         then
           [ -z "$trusted_peers" ] || ibcf_arg="--ibcf=$trusted_peers"
-          [ -n "$ibcf_domain" ] || ibcf_domain="ibcf.$home_domain"
-          $bono_alias_list = "$bono_alias_list,$ibcf_domain"
+          [ -z "$ibcf_domain" ] || $bono_alias_list = "$bono_alias_list,$ibcf_domain"
         fi
 
         [ -z "$ralf_hostname" ] || ralf_arg="--ralf=$ralf_hostname"

--- a/debian/bono.init.d
+++ b/debian/bono.init.d
@@ -100,6 +100,7 @@ get_settings()
         # Set up defaults and then pull in the settings for this node.
         sas_server=0.0.0.0
         signaling_dns_server=127.0.0.1
+        alias_list=""
         . /etc/clearwater/config
 
         # Set the upstream hostname to the sprout hostname only if it hasn't

--- a/debian/bono.init.d
+++ b/debian/bono.init.d
@@ -141,7 +141,7 @@ get_daemon_args()
         if [ $IBCF_ENABLED = Y ]
         then
           [ -z "$trusted_peers" ] || ibcf_arg="--ibcf=$trusted_peers"
-          [ -z "$ibcf_domain" ] || $bono_alias_list = "$bono_alias_list,$ibcf_domain"
+          [ -z "$ibcf_domain" ] || bono_alias_list="$bono_alias_list,$ibcf_domain"
         fi
 
         [ -z "$ralf_hostname" ] || ralf_arg="--ralf=$ralf_hostname"

--- a/debian/bono.init.d
+++ b/debian/bono.init.d
@@ -154,7 +154,7 @@ get_daemon_args()
 
         DAEMON_ARGS="--domain=$home_domain
                      --localhost=$local_ip,$public_hostname
-                     --alias=$public_ip
+                     --alias=ibcf.$home_domain
                      --pcscf=5060,5058
                      --webrtc-port=5062
                      --routing-proxy=$upstream_hostname,$upstream_port,$upstream_connections,$upstream_recycle_connections

--- a/debian/bono.init.d
+++ b/debian/bono.init.d
@@ -100,7 +100,7 @@ get_settings()
         # Set up defaults and then pull in the settings for this node.
         sas_server=0.0.0.0
         signaling_dns_server=127.0.0.1
-        alias_list=""
+        bono_alias_list=""
         . /etc/clearwater/config
 
         # Set the upstream hostname to the sprout hostname only if it hasn't
@@ -155,7 +155,7 @@ get_daemon_args()
 
         DAEMON_ARGS="--domain=$home_domain
                      --localhost=$local_ip,$public_hostname
-                     --alias=$public_ip,$public_hostname,$alias_list
+                     --alias=$public_ip,$public_hostname,$bono_alias_list
                      --pcscf=5060,5058
                      --webrtc-port=5062
                      --routing-proxy=$upstream_hostname,$upstream_port,$upstream_connections,$upstream_recycle_connections

--- a/debian/bono.init.d
+++ b/debian/bono.init.d
@@ -154,7 +154,7 @@ get_daemon_args()
 
         DAEMON_ARGS="--domain=$home_domain
                      --localhost=$local_ip,$public_hostname
-                     --alias=ibcf.$home_domain
+                     --alias=$public_ip,$public_hostname,$alias_list
                      --pcscf=5060,5058
                      --webrtc-port=5062
                      --routing-proxy=$upstream_hostname,$upstream_port,$upstream_connections,$upstream_recycle_connections

--- a/debian/bono.init.d
+++ b/debian/bono.init.d
@@ -141,6 +141,7 @@ get_daemon_args()
         then
           [ -z "$trusted_peers" ] || ibcf_arg="--ibcf=$trusted_peers"
           [ -n "$ibcf_domain" ] || ibcf_domain="ibcf.$home_domain"
+          $bono_alias_list = "$bono_alias_list,$ibcf_domain"
         fi
 
         [ -z "$ralf_hostname" ] || ralf_arg="--ralf=$ralf_hostname"
@@ -155,7 +156,7 @@ get_daemon_args()
 
         DAEMON_ARGS="--domain=$home_domain
                      --localhost=$local_ip,$public_hostname
-                     --alias=$public_ip,$public_hostname,$ibcf_domain
+                     --alias=$public_ip,$public_hostname,$bono_alias_list
                      --pcscf=5060,5058
                      --webrtc-port=5062
                      --routing-proxy=$upstream_hostname,$upstream_port,$upstream_connections,$upstream_recycle_connections

--- a/debian/bono.init.d
+++ b/debian/bono.init.d
@@ -120,7 +120,6 @@ get_settings()
         [ -r /etc/clearwater/user_settings ] && . /etc/clearwater/user_settings
 
         # Work out which features are enabled.
-        IBCF_ENABLED=Y
         if [ -d /etc/clearwater/features.d ]
         then
           for file in $(find /etc/clearwater/features.d -type f)
@@ -138,9 +137,10 @@ get_daemon_args()
         # Get the settings
         get_settings
 
-        if [ $IBCF_ENABLED = Y ]
+        if [ $ibcf_enabled = Y ]
         then
           [ -z "$trusted_peers" ] || ibcf_arg="--ibcf=$trusted_peers"
+          [ -n "$ibcf_domain" ] || ibcf_domain="ibcf.$home_domain"
         fi
 
         [ -z "$ralf_hostname" ] || ralf_arg="--ralf=$ralf_hostname"
@@ -155,7 +155,7 @@ get_daemon_args()
 
         DAEMON_ARGS="--domain=$home_domain
                      --localhost=$local_ip,$public_hostname
-                     --alias=$public_ip,$public_hostname,$bono_alias_list
+                     --alias=$public_ip,$public_hostname,$ibcf_domain
                      --pcscf=5060,5058
                      --webrtc-port=5062
                      --routing-proxy=$upstream_hostname,$upstream_port,$upstream_connections,$upstream_recycle_connections


### PR DESCRIPTION
Testing of a Clearwater deployment with an IBCF showed that whenever the IBCF was routed to via domain, rather than IP, the node would not remove its own route header and would hence attempt to route to itself.

@mirw suggested that this could be fixed by changing the alias argument in Bono's init.d configuration. I have changed it from the public IP to ibcf.<zone>, which is the expected IP to be used for a cluster IBCF domain entry.

I have tested this change and verified that it fixes the issue I encountered, without breaking the core Bono functionality. 

Please let me know whether you're happy with this change. Ellie, if you're not the right person for this or if you're too busy to take this right now, please pass it to the appropriate person (or let me know who to pass it to). Thank you