### PR TITLE
[Reviewer: Ellie] Add an --allow-fallback-ifcs option to enable more wildcard use-cases

### DIFF
--- a/include/cfgoptions.h
+++ b/include/cfgoptions.h
@@ -149,6 +149,7 @@ struct options
   bool                                 sas_signaling_if;
   bool                                 disable_tcp_switch;
   std::string                          chronos_hostname;
+  bool                                 allow_fallback_ifcs;
 };
 
 // Objects that must be shared with dynamically linked sproutlets must be

--- a/include/hssconnection.h
+++ b/include/hssconnection.h
@@ -68,7 +68,8 @@ public:
                 SNMP::EventAccumulatorTable* homestead_uar_latency_tbl,
                 SNMP::EventAccumulatorTable* homestead_lir_latency_tbl,
                 CommunicationMonitor* comm_monitor,
-                std::string scscf_uri);
+                std::string scscf_uri,
+                bool fallback_if_no_matching_ifc = false);
   virtual ~HSSConnection();
 
   HTTPCode get_auth_vector(const std::string& private_user_id,
@@ -172,6 +173,7 @@ private:
   SNMP::EventAccumulatorTable* _uar_latency_tbl;
   SNMP::EventAccumulatorTable* _lir_latency_tbl;
   std::string _scscf_uri;
+  bool _fallback_if_no_matching_ifc;
 };
 
 #endif

--- a/sprout-base.root/etc/init.d/sprout
+++ b/sprout-base.root/etc/init.d/sprout
@@ -190,6 +190,7 @@ get_daemon_args()
         [ -z "$exception_max_ttl" ] || exception_max_ttl_arg="--exception-max-ttl=$exception_max_ttl"
         [ -z "$max_session_expires" ] || max_session_expires_arg="--max-session-expires=$max_session_expires"
         [ -z "$chronos_hostname" ] || chronos_hostname_arg="--chronos-hostname=$chronos_hostname"
+        [ -z "$allow_fallback_ifcs" ] || allow_fallback_ifcs_arg="--allow-fallback-ifcs"
 
         DAEMON_ARGS="
                      --domain=$home_domain
@@ -227,6 +228,7 @@ get_daemon_args()
                      $override_npdi_arg
                      $exception_max_ttl_arg
                      $force_3pr_body_arg
+                     $allow_fallback_ifcs_arg
                      --http-address=$local_ip
                      --http-port=9888
                      --analytics=$log_directory

--- a/src/hssconnection.cpp
+++ b/src/hssconnection.cpp
@@ -369,6 +369,10 @@ bool decode_homestead_xml(const std::string public_user_identity,
 
         associated_uris.push_back(uri);
         ifcs_map[uri] = ifc;
+        if (public_id == sp->first_node("PublicIdentity"))
+        {
+          ifcs_map[public_user_identity] = ifc;
+        }
 
         if (!found_aliases)
         {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -152,6 +152,7 @@ enum OptionTypes
   OPT_DISABLE_TCP_SWITCH,
   OPT_DEFAULT_TEL_URI_TRANSLATION,
   OPT_CHRONOS_HOSTNAME,
+  OPT_ALLOW_FALLBACK_IFCS,
 };
 
 
@@ -234,6 +235,7 @@ const static struct pj_getopt_option long_opt[] =
   { "sas-use-signaling-interface",  no_argument,       0, OPT_SAS_USE_SIGNALING_IF},
   { "disable-tcp-switch",           no_argument,       0, OPT_DISABLE_TCP_SWITCH},
   { "chronos-hostname",             required_argument, 0, OPT_CHRONOS_HOSTNAME},
+  { "allow-fallback-ifcs",          no_argument,       0, OPT_ALLOW_FALLBACK_IFCS},
   { NULL,                           0,                 0, 0}
 };
 
@@ -429,6 +431,8 @@ static void usage(void)
        "     --chronos-hostname <hostname>\n"
        "                            Specify the hostname of a remote Chronos cluster. If unset the default\n"
        "                            is to use localhost, using localhost as the callback URL.\n"
+       "     --allow-fallback-ifcs  If no Identity elements match for Initial Filter Criteria, use the\n"
+       "                            first IFC returned as a fallback.\n"
        " -N, --plugin-option <plugin>,<name>,<value>\n"
        "                            Provide an option value to a plugin.\n"
        " -F, --log-file <directory>\n"
@@ -1102,6 +1106,11 @@ static pj_status_t init_options(int argc, char* argv[], struct options* options)
       options->disable_tcp_switch = true;
       break;
 
+    case OPT_ALLOW_FALLBACK_IFCS:
+      TRC_STATUS("IFC fallback enabled");
+      options->allow_fallback_ifcs = true;
+      break;
+
     case 'N':
       {
         std::vector<std::string> fields;
@@ -1364,6 +1373,7 @@ int main(int argc, char* argv[])
   opt.scscf_node_uri = "";
   opt.sas_signaling_if = false;
   opt.disable_tcp_switch = false;
+  opt.allow_fallback_ifcs = false;
 
   // Initialise ENT logging before making "Started" log
   PDLogStatic::init(argv[0]);
@@ -1802,7 +1812,8 @@ int main(int argc, char* argv[])
                                        homestead_uar_latency_table,
                                        homestead_lir_latency_table,
                                        hss_comm_monitor,
-                                       opt.uri_scscf);
+                                       opt.uri_scscf,
+                                       opt.allow_fallback_ifcs);
   }
 
   // Create ENUM service.

--- a/src/ut/fakehssconnection.cpp
+++ b/src/ut/fakehssconnection.cpp
@@ -60,6 +60,10 @@ FakeHSSConnection::~FakeHSSConnection()
   flush_all();
 }
 
+void FakeHSSConnection::allow_fallback_ifcs()
+{
+  _fallback_if_no_matching_ifc = true;
+}
 
 void FakeHSSConnection::flush_all()
 {

--- a/src/ut/fakehssconnection.hpp
+++ b/src/ut/fakehssconnection.hpp
@@ -61,6 +61,7 @@ public:
   void set_rc(const std::string& url, long rc);
   void delete_rc(const std::string& url);
   bool url_was_requested(const std::string& url, const std::string& body);
+  void allow_fallback_ifcs();
 
 private:
   long get_json_object(const std::string& path, rapidjson::Document*& object, SAS::TrailId trail);

--- a/src/ut/scscf_test.cpp
+++ b/src/ut/scscf_test.cpp
@@ -1401,6 +1401,81 @@ TEST_F(SCSCFTest, TestTerminatingTelURI)
 }
 
 
+TEST_F(SCSCFTest, TestTelURIWildcard)
+{
+  _hss_connection->set_impu_result("tel:6505551235", "call", "REGISTERED",
+                                "<IMSSubscription><ServiceProfile>\n"
+                                "<PublicIdentity><Identity>tel:65055512!*!</Identity></PublicIdentity>"
+                                "  <InitialFilterCriteria>\n"
+                                "    <Priority>1</Priority>\n"
+                                "    <TriggerPoint>\n"
+                                "    <ConditionTypeCNF>0</ConditionTypeCNF>\n"
+                                "    <SPT>\n"
+                                "      <ConditionNegated>0</ConditionNegated>\n"
+                                "      <Group>0</Group>\n"
+                                "      <Method>INVITE</Method>\n"
+                                "      <Extension></Extension>\n"
+                                "    </SPT>\n"
+                                "  </TriggerPoint>\n"
+                                "  <ApplicationServer>\n"
+                                "    <ServerName>sip:1.2.3.4:56789;transport=UDP</ServerName>\n"
+                                "    <DefaultHandling>0</DefaultHandling>\n"
+                                "  </ApplicationServer>\n"
+                                "  </InitialFilterCriteria>\n"
+                                "</ServiceProfile></IMSSubscription>");
+
+  TransportFlow tpBono(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.99.88.11", 12345);
+  TransportFlow tpAS1(TransportFlow::Protocol::UDP, stack_data.scscf_port, "1.2.3.4", 56789);
+
+  // Send a terminating INVITE for a subscriber with a tel: URI
+  Message msg;
+  msg._via = "10.99.88.11:12345;transport=TCP";
+  msg._to = "6505551234@homedomain";
+  msg._route = "Route: <sip:homedomain>";
+  msg._todomain = "";
+  msg._requri = "tel:6505551235";
+
+  msg._method = "INVITE";
+  list<HeaderMatcher> hdrs;
+
+  inject_msg(msg.get_request(), &tpBono);
+  poll();
+  ASSERT_EQ(2, txdata_count());
+
+  // 100 Trying goes back to bono
+  pjsip_msg* out = current_txdata()->msg;
+  RespMatcher(100).matches(out);
+  tpBono.expect_target(current_txdata(), true);  // Requests always come back on same transport
+  msg.set_route(out);
+  free_txdata();
+  ASSERT_EQ(1, txdata_count());
+
+  // INVITE passed on to AS1
+  SCOPED_TRACE("INVITE (S)");
+  pjsip_tx_data* tdata = current_txdata();
+  out = tdata->msg;
+  ReqMatcher r1("INVITE");
+  ASSERT_NO_FATAL_FAILURE(r1.matches(out));
+
+  tpAS1.expect_target(tdata, false);
+  EXPECT_THAT(get_headers(out, "Route"),
+              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;service=scscf>"));
+  
+  string fresp1 = respond_to_txdata(tdata, 404);
+  inject_msg(fresp1, &tpAS1);
+  ASSERT_EQ(3, txdata_count());
+  free_txdata();
+  free_txdata();
+  ASSERT_EQ(1, txdata_count());
+  
+  // 100 Trying goes back to bono
+  out = current_txdata()->msg;
+  RespMatcher(404).matches(out);
+  free_txdata();
+  ASSERT_EQ(0, txdata_count());
+}
+
+
 
 TEST_F(SCSCFTest, TestNoMoreForwards)
 {
@@ -2611,7 +2686,7 @@ TEST_F(SCSCFTest, ISCRetargetWithoutCdiv)
 }
 
 
-TEST_F(SCSCFTest, URINotIncludedInUserData)
+TEST_F(SCSCFTest, DISABLED_URINotIncludedInUserData)
 {
   register_uri(_sdm, _hss_connection, "6505551000", "homedomain", "sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob");
   _hss_connection->set_impu_result("tel:8886505551234", "call", "UNREGISTERED",

--- a/src/ut/scscf_test.cpp
+++ b/src/ut/scscf_test.cpp
@@ -1397,6 +1397,24 @@ TEST_F(SCSCFTest, TestTerminatingTelURI)
   doSuccessfulFlow(msg, testing::MatchesRegex("sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob"), hdrs, false);
 }
 
+// Test that allowing fallback IFCs (for when we don't have a matching bit of
+// XML) doesn't break mainline flows when we do.
+TEST_F(SCSCFTest, TestSimpleMainlineFallbackIFCs)
+{
+  SCOPED_TRACE("");
+  _hss_connection->allow_fallback_ifcs();
+  register_uri(_sdm, _hss_connection, "6505551234", "homedomain", "sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob");
+  Message msg;
+  list<HeaderMatcher> hdrs;
+  doSuccessfulFlow(msg, testing::MatchesRegex(".*wuntootreefower.*"), hdrs);
+
+  // This is a terminating call so should not result in a session setup time
+  // getting tracked.
+  EXPECT_EQ(0, ((SNMP::FakeEventAccumulatorTable*)_scscf_sproutlet->_audio_session_setup_time_tbl)->_count);
+  EXPECT_EQ(0, ((SNMP::FakeEventAccumulatorTable*)_scscf_sproutlet->_video_session_setup_time_tbl)->_count);
+}
+
+
 
 TEST_F(SCSCFTest, TestTelURIWildcard)
 {

--- a/src/ut/scscf_test.cpp
+++ b/src/ut/scscf_test.cpp
@@ -1423,6 +1423,7 @@ TEST_F(SCSCFTest, TestTelURIWildcard)
                                 "  </ApplicationServer>\n"
                                 "  </InitialFilterCriteria>\n"
                                 "</ServiceProfile></IMSSubscription>");
+  _hss_connection->allow_fallback_ifcs();
 
   TransportFlow tpBono(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.99.88.11", 12345);
   TransportFlow tpAS1(TransportFlow::Protocol::UDP, stack_data.scscf_port, "1.2.3.4", 56789);

--- a/src/ut/scscf_test.cpp
+++ b/src/ut/scscf_test.cpp
@@ -262,7 +262,6 @@ public:
     _local_data_store = new LocalStore();
     _sdm = new SubscriberDataManager((Store*)_local_data_store, _chronos_connection, true);
     _analytics = new AnalyticsLogger(&PrintingTestLogger::DEFAULT);
-    _hss_connection = new FakeHSSConnection();
     _bgcf_service = new BgcfService(string(UT_DIR).append("/test_stateful_proxy_bgcf.json"));
     _xdm_connection = new FakeXDMConnection();
     _sess_term_comm_tracker = new NiceMock<MockAsCommunicationTracker>();
@@ -288,7 +287,6 @@ public:
     delete _chronos_connection; _chronos_connection = NULL;
     delete _local_data_store; _local_data_store = NULL;
     delete _analytics; _analytics = NULL;
-    delete _hss_connection; _hss_connection = NULL;
     delete _enum_service; _enum_service = NULL;
     delete _bgcf_service; _bgcf_service = NULL;
     delete _xdm_connection; _xdm_connection = NULL;
@@ -301,10 +299,8 @@ public:
   {
     _log_traffic = PrintingTestLogger::DEFAULT.isPrinting(); // true to see all traffic
     _local_data_store->flush_all();  // start from a clean slate on each test
-    if (_hss_connection)
-    {
-      _hss_connection->flush_all();
-    }
+    
+    _hss_connection = new FakeHSSConnection();
 
 
     // Create the S-CSCF Sproutlet.
@@ -403,6 +399,7 @@ public:
     URIClassifier::enforce_global = false;
     ((SNMP::FakeCounterTable*)_scscf_sproutlet->_routed_by_preloaded_route_tbl)->reset_count();
 
+    delete _hss_connection; _hss_connection = NULL;
     delete _proxy; _proxy = NULL;
     delete _mmtel_sproutlet; _mmtel_sproutlet = NULL;
     delete _mmtel; _mmtel = NULL;
@@ -2687,7 +2684,7 @@ TEST_F(SCSCFTest, ISCRetargetWithoutCdiv)
 }
 
 
-TEST_F(SCSCFTest, DISABLED_URINotIncludedInUserData)
+TEST_F(SCSCFTest, URINotIncludedInUserData)
 {
   register_uri(_sdm, _hss_connection, "6505551000", "homedomain", "sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob");
   _hss_connection->set_impu_result("tel:8886505551234", "call", "UNREGISTERED",


### PR DESCRIPTION
We don't support wildcard matching yet, but one thing that's quite common is to have wildcard PSIs, where we do a lookup for +1234 and get back a single IFC for +123!*!.

We don't need wildcard matching support to handle this - all we need to do is assume the IFC the HSS gave us is the one we're meant to have, even if the Identity field doesn't match.

This PR adds a command-line option to make that assumption (I haven't assumed it by default, because it could do the wrong thing in some situations, e.g. if we had multiple IFCs).

Not urgent.