### PR TITLE
[Reviewer: AJH] Only check for NP data in URI classification when this is more important than domain-based classification

### DIFF
--- a/include/uri_classifier.h
+++ b/include/uri_classifier.h
@@ -55,7 +55,7 @@ enum URIClass
 
 namespace URIClassifier
 {
-  URIClass classify_uri(const pjsip_uri* uri, bool prefer_sip = true);
+  URIClass classify_uri(const pjsip_uri* uri, bool prefer_sip = true, bool check_np = false);
 
   bool is_user_numeric(pj_str_t user);
 

--- a/src/icscfsproutlet.cpp
+++ b/src/icscfsproutlet.cpp
@@ -614,7 +614,7 @@ void ICSCFSproutletTsx::on_rx_initial_request(pjsip_msg* req)
           pjsip_uri* original_req_uri = req->line.req.uri;
           _icscf->translate_request_uri(req, get_pool(req), trail());
           uri = req->line.req.uri;
-          URIClass uri_class = URIClassifier::classify_uri(uri, false);
+          URIClass uri_class = URIClassifier::classify_uri(uri, false, true);
 
           std::string rn;
 

--- a/src/pjutils.cpp
+++ b/src/pjutils.cpp
@@ -2110,26 +2110,15 @@ pjsip_uri* PJUtils::translate_sip_uri_to_tel_uri(const pjsip_sip_uri* sip_uri,
     tel_uri->ext_param.ptr = ext->value.ptr;
   }
 
-  // Copy across any routing number and NPDI parameters to the new URI
-  pjsip_param* rn = pjsip_param_find(&sip_uri->userinfo_param, &STR_RN);
-  bool npdi = (pjsip_param_find(&sip_uri->userinfo_param, &STR_NPDI) != NULL);
-
-  if (rn != NULL)
+  // Copy across any SIP user parameters to the new Tel URI
+  for (pjsip_param* p = sip_uri->userinfo_param.next;
+       (p != NULL) && (p != &sip_uri->userinfo_param);
+       p = p->next)
   {
-    // Add the `rn` parameter.
-    pjsip_param* tel_rn_param = PJ_POOL_ALLOC_T(pool, pjsip_param);
-    pj_strdup(pool, &tel_rn_param->name, &STR_RN);
-    pj_strdup(pool, &tel_rn_param->value, &rn->value);
-    pj_list_insert_after(&tel_uri->other_param, tel_rn_param);
-  }
-
-  if (npdi)
-  {
-    // Add the 'npdi' parameter
-    pjsip_param* tel_npdi_param = PJ_POOL_ALLOC_T(pool, pjsip_param);
-    pj_strdup(pool, &tel_npdi_param->name, &STR_NPDI);
-    tel_npdi_param->value.slen = 0;
-    pj_list_insert_after(&tel_uri->other_param, tel_npdi_param);
+    pjsip_param* tel_param = PJ_POOL_ALLOC_T(pool, pjsip_param);
+    pj_strdup(pool, &tel_param->name, &p->name);
+    pj_strdup(pool, &tel_param->value, &p->value);
+    pj_list_insert_after(&tel_uri->other_param, tel_param);
   }
 
   return (pjsip_uri*)tel_uri;

--- a/src/scscfsproutlet.cpp
+++ b/src/scscfsproutlet.cpp
@@ -1221,7 +1221,7 @@ void SCSCFSproutletTsx::apply_originating_services(pjsip_msg* req)
       // database.
       _scscf->translate_request_uri(req, get_pool(req), trail());
 
-      URIClass uri_class = URIClassifier::classify_uri(req->line.req.uri);
+      URIClass uri_class = URIClassifier::classify_uri(req->line.req.uri, true, true);
       std::string new_uri_str = PJUtils::uri_to_string(PJSIP_URI_IN_REQ_URI, req->line.req.uri);
       TRC_INFO("New URI string is %s", new_uri_str.c_str());
 

--- a/src/uri_classifier.cpp
+++ b/src/uri_classifier.cpp
@@ -54,7 +54,7 @@ bool URIClassifier::is_user_numeric(pj_str_t user)
         (uri[i] == ')') ||
         (uri[i] == '[') ||
         (uri[i] == ']') ||
-        ((uri[i] >= '0') && 
+        ((uri[i] >= '0') &&
          (uri[i] <= '9')))
     {
       continue;
@@ -104,8 +104,10 @@ static bool is_local_name(pj_str_t host)
 // - uri - the URI to classify
 // - prefer_sip - for ambiguous URIs like sip:+1234@example.com (which could be a global phone
 // number or just a SIP URI), prefer to interpret it as SIP
+// - check_np - check for the presence of Number Portability parameters and
+// classify accordingly
 //
-URIClass URIClassifier::classify_uri(const pjsip_uri* uri, bool prefer_sip)
+URIClass URIClassifier::classify_uri(const pjsip_uri* uri, bool prefer_sip, bool check_np)
 {
   URIClass ret = URIClass::UNKNOWN;
 
@@ -113,17 +115,20 @@ URIClass URIClassifier::classify_uri(const pjsip_uri* uri, bool prefer_sip)
   bool has_rn = false;
   bool has_npdi = false;
 
-  if (PJSIP_URI_SCHEME_IS_TEL(uri))
+  if (check_np)
   {
-    // If the URI is a tel URI, pull out the information from the other_params
-    has_rn = (pjsip_param_find(&((pjsip_tel_uri*)uri)->other_param, &STR_RN) != NULL);
-    has_npdi = (pjsip_param_find(&((pjsip_tel_uri*)uri)->other_param, &STR_NPDI) != NULL);
-  }
-  else if (PJSIP_URI_SCHEME_IS_SIP(uri))
-  {
-    // If the URI is a tel URI, pull out the information from the userinfo_params
-    has_rn = (pjsip_param_find(&((pjsip_sip_uri*)uri)->userinfo_param, &STR_RN) != NULL);
-    has_npdi = (pjsip_param_find(&((pjsip_sip_uri*)uri)->userinfo_param, &STR_NPDI) != NULL);
+    if (PJSIP_URI_SCHEME_IS_TEL(uri))
+    {
+      // If the URI is a tel URI, pull out the information from the other_params
+      has_rn = (pjsip_param_find(&((pjsip_tel_uri*)uri)->other_param, &STR_RN) != NULL);
+      has_npdi = (pjsip_param_find(&((pjsip_tel_uri*)uri)->other_param, &STR_NPDI) != NULL);
+    }
+    else if (PJSIP_URI_SCHEME_IS_SIP(uri))
+    {
+      // If the URI is a tel URI, pull out the information from the userinfo_params
+      has_rn = (pjsip_param_find(&((pjsip_sip_uri*)uri)->userinfo_param, &STR_RN) != NULL);
+      has_npdi = (pjsip_param_find(&((pjsip_sip_uri*)uri)->userinfo_param, &STR_NPDI) != NULL);
+    }
   }
 
   if (has_rn)

--- a/src/ut/icscfsproutlet_test.cpp
+++ b/src/ut/icscfsproutlet_test.cpp
@@ -3088,9 +3088,12 @@ TEST_F(ICSCFSproutletTest, RouteTermInviteNumericSIPURI)
 
   // Inject an INVITE request to a sip URI representing a telephone number with a
   // P-Served-User header.
+  //
+  // Add NP data to the SIP URI - it should be ignored for the purposes of SIP -> Tel URI
+  // conversion
   Message msg1;
   msg1._method = "INVITE";
-  msg1._requri = "sip:+16505551234@homedomain";
+  msg1._requri = "sip:+16505551234;rn=567@homedomain";
   msg1._to = "+16505551234";
   msg1._via = tp->to_string(false);
   msg1._extra = "Contact: sip:6505551000@" +

--- a/src/ut/icscfsproutlet_test.cpp
+++ b/src/ut/icscfsproutlet_test.cpp
@@ -3093,7 +3093,7 @@ TEST_F(ICSCFSproutletTest, RouteTermInviteNumericSIPURI)
   // conversion
   Message msg1;
   msg1._method = "INVITE";
-  msg1._requri = "sip:+16505551234;rn=567@homedomain";
+  msg1._requri = "sip:+16505551234;npdi;rn=567@homedomain";
   msg1._to = "+16505551234";
   msg1._via = tp->to_string(false);
   msg1._extra = "Contact: sip:6505551000@" +
@@ -3118,6 +3118,9 @@ TEST_F(ICSCFSproutletTest, RouteTermInviteNumericSIPURI)
   expect_target("TCP", "10.10.10.1", 5058, tdata);
   ReqMatcher r1("INVITE");
   r1.matches(tdata->msg);
+
+  // Verify that the user parameters were carried through the SIP to Tel URI conversion successfully
+  ASSERT_EQ("tel:+16505551234;npdi;rn=567", str_uri(tdata->msg->line.req.uri));
 
   // Check that a Route header has been added routing the INVITE to the
   // selected S-CSCF.  This must include the orig parameter.


### PR DESCRIPTION
This addresses a couple of problems in our handling of terminating requests that contain NP data.  

-  If a terminating request arrives at the I-CSCF with a global telephone SIP URI that contains NP data, we don't convert it to a Tel URI (and don't perform an ENUM lookup) because we are looking for a GLOBAL_PHONE_NUMBER and we get (FINAL_)NP_DATA from classify_uri

-  If a terminating request arrives at the S-CSCF with a global telephone SIP URI that contains NP data, classify_uri gives us (FINAL_)NP_DATA and we reject the request because we don't see NODE_LOCAL_SIP_URI or HOME_DOMAIN_SIP_URI.

Note that there is an alternative fix here, which is to recognize that NP data is effectively orthogonal to other types of classification and to return it as a three valued output param (NONE/NP_DATA/FINAL_NP_DATA) from classify_uri, taking the *NP_DATA values out of the returned enum.  Would that make more sense going forward?