### PR TITLE
[Reviewer: Matt] Add management cached data APIs

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -51,7 +51,7 @@ Description: Debugging symbols for sprout, the SIP Router
 
 Package: sprout-base
 Architecture: any
-Depends: clearwater-infrastructure, clearwater-tcp-scalability, clearwater-log-cleanup, sprout-libs, libboost-regex1.54.0, libboost-system1.54.0, libboost-thread1.54.0, libzmq3, libevent-pthreads-2.0-5, clearwater-socket-factory, libboost-filesystem1.54.0, libsnmp30 (>= 5.7.2~dfsg-clearwater4), clearwater-monit
+Depends: clearwater-infrastructure, clearwater-tcp-scalability, clearwater-log-cleanup, sprout-libs, libboost-regex1.54.0, libboost-system1.54.0, libboost-thread1.54.0, libzmq3, libevent-pthreads-2.0-5, clearwater-socket-factory, libboost-filesystem1.54.0, libsnmp30 (>= 5.7.2~dfsg-clearwater4), clearwater-monit, clearwater-nginx
 Suggests: sprout-dbg, clearwater-logging
 Replaces: sprout
 Description: sprout-base, the SIP Router basic executable

--- a/debian/sprout-base.postinst
+++ b/debian/sprout-base.postinst
@@ -95,20 +95,23 @@ case "$1" in
         /usr/share/clearwater/infrastructure/scripts/sprout.monit
 
         # Stop the cluster/config managers, so that it is restarted by Monit
-        # and picks up the new plugins. We check whether the process is 
+        # and picks up the new plugins. We check whether the process is
         # installed to avoid warning logs when etcd isn't being used
         if [ -x "/etc/init.d/clearwater-cluster-manager" ]; then
           service clearwater-cluster-manager stop || /bin/true
-        fi  
+        fi
         if [ -x "/etc/init.d/clearwater-config-manager" ]; then
           service clearwater-config-manager stop || /bin/true
-        fi 
+        fi
 
         # Restart sprout.  Always do this by terminating sprout so monit will
         # restart it more-or-less immediately.  (monit restart seems to have
         # significant lag.)
         # Don't fail if it's already stopped.
         service sprout stop || /bin/true
+
+        # Restart clearwater infrastructure to generate sprout's nginx config.
+        service clearwater-infrastructure restart || /bin/true
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/include/handlers.h
+++ b/include/handlers.h
@@ -218,4 +218,31 @@ protected:
   std::string serialize_data(SubscriberDataManager::AoR* aor);
 };
 
+class DeleteImpuTask : public HttpStackUtils::Task
+{
+public:
+  struct Config
+  {
+    Config(SubscriberDataManager* sdm,
+           std::vector<SubscriberDataManager*> remote_sdms,
+           HSSConnection* hss) :
+      _sdm(sdm), _remote_sdms(remote_sdms), _hss(hss)
+    {}
+
+    SubscriberDataManager* _sdm;
+    std::vector<SubscriberDataManager*> _remote_sdms;
+    HSSConnection* _hss;
+  };
+
+  DeleteImpuTask(HttpStack::Request& req, const Config* cfg, SAS::TrailId trail) :
+    HttpStackUtils::Task(req, trail), _cfg(cfg)
+  {};
+  virtual ~DeleteImpuTask() {}
+
+  void run();
+
+private:
+  const Config* _cfg;
+};
+
 #endif

--- a/include/handlers.h
+++ b/include/handlers.h
@@ -176,4 +176,46 @@ protected:
 
 };
 
+class GetCachedDataTask : public HttpStackUtils::Task
+{
+public:
+  struct Config
+  {
+    Config(SubscriberDataManager* sdm,
+           std::vector<SubscriberDataManager*> remote_sdms) :
+      _sdm(sdm),
+      _remote_sdms(remote_sdms)
+    {}
+
+    SubscriberDataManager* _sdm;
+    std::vector<SubscriberDataManager*> _remote_sdms;
+  };
+
+  GetCachedDataTask(HttpStack::Request& req, const Config* cfg, SAS::TrailId trail) :
+    HttpStackUtils::Task(req, trail), _cfg(cfg)
+  {};
+
+  void run();
+
+protected:
+  virtual std::string serialize_data(SubscriberDataManager::AoR* aor) = 0;
+  const Config* _cfg;
+};
+
+class GetBindingsTask : public GetCachedDataTask
+{
+public:
+  using GetCachedDataTask::GetCachedDataTask;
+protected:
+  std::string serialize_data(SubscriberDataManager::AoR* aor);
+};
+
+class GetSubscriptionsTask : public GetCachedDataTask
+{
+public:
+  using GetCachedDataTask::GetCachedDataTask;
+protected:
+  std::string serialize_data(SubscriberDataManager::AoR* aor);
+};
+
 #endif

--- a/include/handlers.h
+++ b/include/handlers.h
@@ -176,6 +176,13 @@ protected:
 
 };
 
+
+/// Abstract class that contains most of the logic for retrieving stored
+/// bindings and subscriptions.
+///
+/// This class handles checking the request, extracting the requested IMPU and
+/// retrieving data from the store. It calls into the subclass to build a
+/// response, which it then sends.
 class GetCachedDataTask : public HttpStackUtils::Task
 {
 public:
@@ -202,6 +209,7 @@ protected:
   const Config* _cfg;
 };
 
+/// Concrete subclass for retrieving bindings.
 class GetBindingsTask : public GetCachedDataTask
 {
 public:
@@ -210,6 +218,7 @@ protected:
   std::string serialize_data(SubscriberDataManager::AoR* aor);
 };
 
+/// Concrete subclass for retrieving subscriptions.
 class GetSubscriptionsTask : public GetCachedDataTask
 {
 public:
@@ -218,6 +227,13 @@ protected:
   std::string serialize_data(SubscriberDataManager::AoR* aor);
 };
 
+/// Task for performing an administrative deregistration at the S-CSCF. This
+///
+/// -  Deletes subscriber data from the store (including all bindings and
+///    subscriptions).
+/// -  Sends a deregistration request to homestead.
+/// -  Sends NOTIFYs for any subscriptions to the reg state package for the AoR.
+/// -  Sends 3rd party deregister requests to Application Servers if required.
 class DeleteImpuTask : public HttpStackUtils::Task
 {
 public:

--- a/include/hssconnection.h
+++ b/include/hssconnection.h
@@ -120,12 +120,12 @@ public:
                                              const std::string& private_user_identity,
                                              const std::string& type,
                                              SAS::TrailId trail);
-  HTTPCode update_registration_state(const std::string& public_user_identity,
-                                     const std::string& private_user_identity,
-                                     const std::string& type,
-                                     std::map<std::string, Ifcs >& service_profiles,
-                                     std::vector<std::string>& associated_uris,
-                                     SAS::TrailId trail);
+  virtual HTTPCode update_registration_state(const std::string& public_user_identity,
+                                             const std::string& private_user_identity,
+                                             const std::string& type,
+                                             std::map<std::string, Ifcs >& service_profiles,
+                                             std::vector<std::string>& associated_uris,
+                                             SAS::TrailId trail);
 
   HTTPCode get_registration_data(const std::string& public_user_identity,
                                  std::string& regstate,

--- a/include/registration_utils.h
+++ b/include/registration_utils.h
@@ -55,13 +55,14 @@ namespace RegistrationUtils {
 void init(SNMP::RegistrationStatsTables* third_party_reg_stats_tables_arg,
           bool force_third_party_register_body_arg);
 
-void remove_bindings(SubscriberDataManager* sdm,
+bool remove_bindings(SubscriberDataManager* sdm,
                      std::vector<SubscriberDataManager*> remote_sdms,
                      HSSConnection* hss,
                      const std::string& aor,
                      const std::string& binding_id,
                      const std::string& dereg_type,
-                     SAS::TrailId trail);
+                     SAS::TrailId trail,
+                     HTTPCode* hss_status_code = nullptr);
 
 void register_with_application_servers(Ifcs& ifcs,
                                        SubscriberDataManager* sdm,

--- a/include/subscriber_data_manager.h
+++ b/include/subscriber_data_manager.h
@@ -54,6 +54,7 @@ extern "C" {
 #include "sas.h"
 
 #include "rapidjson/writer.h"
+#include "rapidjson/document.h"
 
 class SubscriberDataManager
 {
@@ -122,6 +123,14 @@ public:
       ///
       /// @param writer - a rapidjson writer to write to.
       void to_json(rapidjson::Writer<rapidjson::StringBuffer>& writer) const;
+
+      // Deserialize a binding from a JSON object.
+      //
+      // @param b_obj - The binding as a JSON object.
+      //
+      // @return      - Nothing. If this function fails (because the JSON is not
+      //                semantically valid) this method throws JsonFormError.
+      void from_json(const rapidjson::Value& b_obj);
     };
 
     /// @class SubscriberDataManager::AoR::Subscription
@@ -164,6 +173,14 @@ public:
       ///
       /// @param writer - a rapidjson writer to write to.
       void to_json(rapidjson::Writer<rapidjson::StringBuffer>& writer) const;
+
+      // Deserialize a subscription from a JSON object.
+      //
+      // @param s_obj - The subscription as a JSON object.
+      //
+      // @return      - Nothing. If this function fails (because the JSON is not
+      //                semantically valid) this method throws JsonFormError.
+      void from_json(const rapidjson::Value& s_obj);
    };
 
     /// Default Constructor.

--- a/include/subscriber_data_manager.h
+++ b/include/subscriber_data_manager.h
@@ -53,6 +53,7 @@ extern "C" {
 #include "chronosconnection.h"
 #include "sas.h"
 
+#include "rapidjson/writer.h"
 
 class SubscriberDataManager
 {
@@ -116,6 +117,11 @@ public:
       pjsip_sip_uri* pub_gruu(pj_pool_t* pool) const;
       std::string pub_gruu_str(pj_pool_t* pool) const;
       std::string pub_gruu_quoted_string(pj_pool_t* pool) const;
+
+      /// Serialize the binding as a JSON object.
+      ///
+      /// @param writer - a rapidjson writer to write to.
+      void to_json(rapidjson::Writer<rapidjson::StringBuffer>& writer) const;
     };
 
     /// @class SubscriberDataManager::AoR::Subscription
@@ -153,6 +159,11 @@ public:
 
       /// The timer ID provided by Chronos.
       std::string _timer_id;
+
+      /// Serialize the subscription as a JSON object.
+      ///
+      /// @param writer - a rapidjson writer to write to.
+      void to_json(rapidjson::Writer<rapidjson::StringBuffer>& writer) const;
    };
 
     /// Default Constructor.

--- a/sprout-base.root/usr/share/clearwater/infrastructure/scripts/create-sprout-nginx-config
+++ b/sprout-base.root/usr/share/clearwater/infrastructure/scripts/create-sprout-nginx-config
@@ -38,11 +38,17 @@
 
 . /etc/clearwater/config
 
-if [ -n "$sprout_hostname" ]
+split_domain_and_port()
+{
+  echo $1 | perl -ne '$_ =~ /(.+):([0-9]+)$/ && print "$1 $2\n"'
+}
+
+if [ -n "$sprout_mgmt_hostname" ]
 then
   site_file=/etc/nginx/sites-available/sprout
   enabled_file=/etc/nginx/sites-enabled/sprout
   temp_file=$(mktemp sprout.nginx.XXXXXXXX)
+  server_name_and_port=( $( split_domain_and_port $sprout_mgmt_hostname ) )
 
   cat > $temp_file << EOF
 upstream http_sprout {
@@ -54,7 +60,7 @@ upstream http_sprout {
 
 server {
         listen       [::]:9886 ipv6only=off;
-        server_name  $sprout_hostname;
+        server_name  ${server_name_and_port[0]};
 
         location / {
                 proxy_pass http://http_sprout;

--- a/sprout-base.root/usr/share/clearwater/infrastructure/scripts/create-sprout-nginx-config
+++ b/sprout-base.root/usr/share/clearwater/infrastructure/scripts/create-sprout-nginx-config
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+# @file create-sprout-nginx-config
+#
+# Project Clearwater - IMS in the Cloud
+# Copyright (C) 2016 Metaswitch Networks Ltd
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version, along with the "Special Exception" for use of
+# the program along with SSL, set forth below. This program is distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details. You should have received a copy of the GNU General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# The author can be reached by email at clearwater@metaswitch.com or by
+# post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+#
+# Special Exception
+# Metaswitch Networks Ltd  grants you permission to copy, modify,
+# propagate, and distribute a work formed by combining OpenSSL with The
+# Software, or a work derivative of such a combination, even if such
+# copying, modification, propagation, or distribution would otherwise
+# violate the terms of the GPL. You must comply with the GPL in all
+# respects for all of the code used other than OpenSSL.
+# "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+# Project and licensed under the OpenSSL Licenses, or a work based on such
+# software and licensed under the OpenSSL Licenses.
+# "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+# under which the OpenSSL Project distributes the OpenSSL toolkit software,
+# as those licenses appear in the file LICENSE-OPENSSL.
+
+# This file creates an nginx config file for sprout.
+
+. /etc/clearwater/config
+
+if [ -n "$sprout_hostname" ]
+then
+  site_file=/etc/nginx/sites-available/sprout
+  enabled_file=/etc/nginx/sites-enabled/sprout
+  temp_file=$(mktemp sprout.nginx.XXXXXXXX)
+
+  cat > $temp_file << EOF
+upstream http_sprout {
+        server unix:/tmp/sprout-http-mgmt-socket;
+
+        # The minimum number of idle connections to keep alive to the upstream.
+        keepalive 16;
+}
+
+server {
+        listen       [::]:9886 ipv6only=off;
+        server_name  $sprout_hostname;
+
+        location / {
+                proxy_pass http://http_sprout;
+                proxy_http_version 1.1;
+
+                # The client may have instructed the server to close the
+                # connection - do not forward this upstream.
+                proxy_set_header Connection "";
+        }
+}
+EOF
+
+  if ! diff $temp_file $enabled_file > /dev/null 2>&1
+  then
+    # Update the site file
+    mv $temp_file $site_file
+
+    # Enable the sprout nginx site
+    if ( nginx_ensite sprout > /dev/null )
+    then
+      service nginx stop
+    fi
+  else
+    rm $temp_file
+  fi
+fi

--- a/sprout-base.root/usr/share/clearwater/infrastructure/scripts/create-sprout-nginx-config
+++ b/sprout-base.root/usr/share/clearwater/infrastructure/scripts/create-sprout-nginx-config
@@ -55,7 +55,7 @@ upstream http_sprout {
         server unix:/tmp/sprout-http-mgmt-socket;
 
         # The minimum number of idle connections to keep alive to the upstream.
-        keepalive 16;
+        keepalive 2;
 }
 
 server {

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -833,3 +833,77 @@ std::string GetSubscriptionsTask::serialize_data(SubscriberDataManager::AoR* aor
 
   return sb.GetString();
 }
+
+void DeleteImpuTask::run()
+{
+  TRC_DEBUG("Request to delete an IMPU");
+
+  // This interface only supports DELETEs
+  if (_req.method() != htp_method_DELETE)
+  {
+    send_http_reply(HTTP_BADMETHOD);
+    delete this;
+    return;
+  }
+
+  // Extract the IMPU that has been requested. The URL is of the form
+  //
+  //   /impu/<public ID>
+  const std::string prefix = "/impu/";
+  std::string impu = _req.full_path().substr(prefix.length());
+  TRC_DEBUG("Extracted impu %s", impu.c_str());
+
+  HTTPCode hss_sc;
+  int sc;
+
+  // Expire all the bindings. This will handle deregistering with the HSS and
+  // sending NOTIFYs and 3rd party REGISTERs.
+  bool all_bindings_expired =
+    RegistrationUtils::remove_bindings(_cfg->_sdm,
+                                       _cfg->_remote_sdms,
+                                       _cfg->_hss,
+                                       impu,
+                                       "*",
+                                       HSSConnection::DEREG_ADMIN,
+                                       trail(),
+                                       &hss_sc);
+
+  // Work out what status code to return.
+  if (all_bindings_expired)
+  {
+    // All bindings expired successfully, so the status code is determined by
+    // the response from homestead.
+    if ((hss_sc <= 200) && (hss_sc < 300))
+    {
+      // 2xx -> 200.
+      sc = HTTP_OK;
+    }
+    else if (hss_sc == HTTP_NOT_FOUND)
+    {
+      // 404 -> 404.
+      sc = HTTP_NOT_FOUND;
+    }
+    else if ((hss_sc <= 400) && (hss_sc < 500))
+    {
+      // Any other 4xx -> 400
+      sc = HTTP_BAD_REQUEST;
+    }
+    else
+    {
+      // Everything else is mapped to 502 Bad Gateway. This covers 5xx responses
+      // (which indicate homestead went wrong) or 3xx responses (which homestead
+      // should not return).
+      sc = HTTP_BAD_GATEWAY;
+    }
+
+    TRC_DEBUG("All bindings expired. Homestead returned %d (-> %d)", hss_sc, sc);
+  }
+  else
+  {
+    TRC_DEBUG("Failed to expire bindings");
+    sc = HTTP_SERVER_ERROR;
+  }
+
+  delete this;
+  return;
+}

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -762,8 +762,8 @@ void GetCachedDataTask::run()
     return;
   }
 
-  // If there are no bindings we don't have any data for the requested
-  // subscriber so return a 404.
+  // If there are no bindings we can't have any data data for the requested
+  // subscriber (including subscriptions) so return a 404.
   if (aor_pair->get_current()->bindings().empty())
   {
     send_http_reply(HTTP_NOT_FOUND);
@@ -874,7 +874,7 @@ void DeleteImpuTask::run()
   {
     // All bindings expired successfully, so the status code is determined by
     // the response from homestead.
-    if ((hss_sc <= 200) && (hss_sc < 300))
+    if ((hss_sc >= 200) && (hss_sc < 300))
     {
       // 2xx -> 200.
       sc = HTTP_OK;
@@ -884,7 +884,7 @@ void DeleteImpuTask::run()
       // 404 -> 404.
       sc = HTTP_NOT_FOUND;
     }
-    else if ((hss_sc <= 400) && (hss_sc < 500))
+    else if ((hss_sc >= 400) && (hss_sc < 500))
     {
       // Any other 4xx -> 400
       sc = HTTP_BAD_REQUEST;

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -767,6 +767,7 @@ void GetCachedDataTask::run()
   if (aor_pair->get_current()->bindings().empty())
   {
     send_http_reply(HTTP_NOT_FOUND);
+    delete aor_pair; aor_pair = NULL;
     delete this;
     return;
   }

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -903,6 +903,7 @@ void DeleteImpuTask::run()
     TRC_DEBUG("Failed to expire bindings");
     sc = HTTP_SERVER_ERROR;
   }
+  send_http_reply(sc);
 
   delete this;
   return;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2162,6 +2162,7 @@ int main(int argc, char* argv[])
                                                    sip_resolver,
                                                    impi_store);
   GetCachedDataTask::Config get_cached_data_config(local_sdm, {remote_sdm});
+  DeleteImpuTask::Config delete_impu_config(local_sdm, {remote_sdm}, hss_connection);
 
   // The AoRTimeoutTask and AuthTimeoutTask both handle
   // chronos requests, so use the ChronosHandler.
@@ -2171,6 +2172,7 @@ int main(int argc, char* argv[])
   HttpStackUtils::PingHandler ping_handler;
   HttpStackUtils::SpawningHandler<GetBindingsTask, GetCachedDataTask::Config> get_bindings_handler(&get_cached_data_config);
   HttpStackUtils::SpawningHandler<GetSubscriptionsTask, GetCachedDataTask::Config> get_subscriptions_handler(&get_cached_data_config);
+  HttpStackUtils::SpawningHandler<DeleteImpuTask, DeleteImpuTask::Config> delete_impu_handler(&delete_impu_config);
 
   if (opt.enabled_scscf)
   {
@@ -2201,6 +2203,8 @@ int main(int argc, char* argv[])
                                         &get_bindings_handler);
       http_stack_mgmt->register_handler("^/impu/[^/]+/subscriptions$",
                                         &get_subscriptions_handler);
+      http_stack_mgmt->register_handler("^/impu/[^/]+$",
+                                        &delete_impu_handler);
       http_stack_mgmt->start(&reg_httpthread_with_pjsip);
     }
     catch (HttpStack::Exception& e)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -247,7 +247,9 @@ const static int QUIESCE_SIGNAL = SIGQUIT;
 const static int UNQUIESCE_SIGNAL = SIGUSR1;
 // Minimum value allowed by rfc4028, section 4
 const static int MIN_SESSION_EXPIRES = 90;
+
 static const std::string SPROUT_HTTP_MGMT_SOCKET_PATH = "/tmp/sprout-http-mgmt-socket";
+static const int NUM_HTTP_MGMT_THREADS = 5;
 
 static void usage(void)
 {
@@ -2010,7 +2012,7 @@ int main(int argc, char* argv[])
     return 1;
   }
 
-  HttpStack* http_stack_mgmt = new HttpStack(opt.http_threads,
+  HttpStack* http_stack_mgmt = new HttpStack(NUM_HTTP_MGMT_THREADS,
                                              exception_handler,
                                              access_logger);
   try

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2161,6 +2161,7 @@ int main(int argc, char* argv[])
                                                    hss_connection,
                                                    sip_resolver,
                                                    impi_store);
+  GetCachedDataTask::Config get_cached_data_config(local_sdm, {remote_sdm});
 
   // The AoRTimeoutTask and AuthTimeoutTask both handle
   // chronos requests, so use the ChronosHandler.
@@ -2168,6 +2169,8 @@ int main(int argc, char* argv[])
   ChronosHandler<AuthTimeoutTask, AuthTimeoutTask::Config> auth_timeout_handler(&auth_timeout_config);
   HttpStackUtils::SpawningHandler<DeregistrationTask, DeregistrationTask::Config> deregistration_handler(&deregistration_config);
   HttpStackUtils::PingHandler ping_handler;
+  HttpStackUtils::SpawningHandler<GetBindingsTask, GetCachedDataTask::Config> get_bindings_handler(&get_cached_data_config);
+  HttpStackUtils::SpawningHandler<GetSubscriptionsTask, GetCachedDataTask::Config> get_subscriptions_handler(&get_cached_data_config);
 
   if (opt.enabled_scscf)
   {
@@ -2194,6 +2197,10 @@ int main(int argc, char* argv[])
     {
       http_stack_mgmt->register_handler("^/ping$",
                                         &ping_handler);
+      http_stack_mgmt->register_handler("^/impu/[^/]+/bindings$",
+                                        &get_bindings_handler);
+      http_stack_mgmt->register_handler("^/impu/[^/]+/subscriptions$",
+                                        &get_subscriptions_handler);
       http_stack_mgmt->start(&reg_httpthread_with_pjsip);
     }
     catch (HttpStack::Exception& e)

--- a/src/ut/handlers_test.cpp
+++ b/src/ut/handlers_test.cpp
@@ -1604,3 +1604,14 @@ TEST_F(DeleteImpuTaskTest, WritingToRemoteStores)
 
   task->run();
 }
+
+TEST_F(DeleteImpuTaskTest, BadMethod)
+{
+  std::string impu = "sip:6505550231@homedomain";
+  std::string impu_escaped =  "sip%3A6505550231%40homedomain";
+
+  build_task(impu_escaped, htp_method_PUT);
+  EXPECT_CALL(*stack, send_reply(_, 405, _));
+
+  task->run();
+}

--- a/src/ut/handlers_test.cpp
+++ b/src/ut/handlers_test.cpp
@@ -1457,6 +1457,11 @@ class DeleteImpuTaskTest : public TestWithMockSdms
   }
 };
 
+MATCHER(EmptyAoR, "")
+{
+  return !arg->current_contains_bindings();
+}
+
 TEST_F(DeleteImpuTaskTest, Mainline)
 {
   std::string impu = "sip:6505550231@homedomain";
@@ -1469,7 +1474,7 @@ TEST_F(DeleteImpuTaskTest, Mainline)
     InSequence s;
       // Neither store has any bindings so the backup store is checked.
       EXPECT_CALL(*store, get_aor_data(impu, _)).WillOnce(Return(aor));
-      EXPECT_CALL(*store, set_aor_data(impu, _, _, _, _, _))
+      EXPECT_CALL(*store, set_aor_data(impu, EmptyAoR(), _, _, _, _))
         .WillOnce(DoAll(SetArgReferee<3>(true), // All bindings are expired.
                         Return(Store::OK)));
       EXPECT_CALL(*mock_hss, update_registration_state(impu, _, "dereg-admin", _, _, _))
@@ -1583,14 +1588,14 @@ TEST_F(DeleteImpuTaskTest, WritingToRemoteStores)
     InSequence s;
       // Neither store has any bindings so the backup store is checked.
       EXPECT_CALL(*store, get_aor_data(impu, _)).WillOnce(Return(aor));
-      EXPECT_CALL(*store, set_aor_data(impu, _, _, _, _, _))
+      EXPECT_CALL(*store, set_aor_data(impu, EmptyAoR(), _, _, _, _))
         .WillOnce(DoAll(SetArgReferee<3>(true), // All bindings expired
                         Return(Store::OK)));
       EXPECT_CALL(*mock_hss, update_registration_state(impu, _,_, _, _, _))
         .WillOnce(Return(200));
 
       EXPECT_CALL(*remote_store1, get_aor_data(impu, _)).WillOnce(Return(remote_aor));
-      EXPECT_CALL(*remote_store1, set_aor_data(impu, _, _, _, _, _))
+      EXPECT_CALL(*remote_store1, set_aor_data(impu, EmptyAoR(), _, _, _, _))
         .WillOnce(DoAll(SetArgReferee<3>(true), // All bindings expired
                         Return(Store::OK)));
 

--- a/src/ut/mock_hss_connection.h
+++ b/src/ut/mock_hss_connection.h
@@ -58,11 +58,18 @@ public:
                                       "sip:scscf.sprout.homedomain:5058;transport=TCP") {};
   virtual ~MockHSSConnection() {};
 
-  MOCK_METHOD4(update_registration_state, HTTPCode(
-                                  const std::string& public_user_identity,
-                                  const std::string& private_user_identity,
-                                  const std::string& type,
-                                  SAS::TrailId trail));
+  MOCK_METHOD4(update_registration_state,
+               HTTPCode(const std::string& public_user_identity,
+                        const std::string& private_user_identity,
+                        const std::string& type,
+                        SAS::TrailId trail));
+  MOCK_METHOD6(update_registration_state,
+               HTTPCode(const std::string& public_user_identity,
+                        const std::string& private_user_identity,
+                        const std::string& type,
+                        std::map<std::string, Ifcs >& service_profiles,
+                        std::vector<std::string>& associated_uris,
+                        SAS::TrailId trail));
 };
 
 #endif


### PR DESCRIPTION
Hi Matt, please can you review this change to add an HTTP management API to sprout to allow users to query a subscriber's bindings and subscriptions, and to administratively deregister them.

I've tested this in UT, and also live:

* Try to get the bindings/subscriptions for a subscriber who isn't registered.
* Get the bindings/subscriptions for a subscriber who *is* registered.
* Administratively deregister a subscriber, and check that a dereg request is sent to homestead. 

Graeme is doing a fuller live test. 