### PR TITLE
Reviewer RKD: Use syslog for analytics logs

### DIFF
--- a/include/analyticslogger.h
+++ b/include/analyticslogger.h
@@ -48,6 +48,8 @@ public:
   AnalyticsLogger();
   ~AnalyticsLogger();
 
+  void log_with_tag_and_timestamp(char* log);
+
   void registration(const std::string& aor,
                     const std::string& binding_id,
                     const std::string& contact,

--- a/include/analyticslogger.h
+++ b/include/analyticslogger.h
@@ -42,12 +42,10 @@
 
 #include <sstream>
 
-#include "logger.h"
-
 class AnalyticsLogger
 {
 public:
-  AnalyticsLogger(Logger* logger);
+  AnalyticsLogger();
   ~AnalyticsLogger();
 
   void registration(const std::string& aor,
@@ -77,8 +75,6 @@ public:
 
 private:
   static const int BUFFER_SIZE = 1000;
-
-  Logger* _logger;
 };
 
 #endif

--- a/include/sprout_pd_definitions.h
+++ b/include/sprout_pd_definitions.h
@@ -46,9 +46,7 @@
 // The fields for each PDLog instance contains:
 //   Identity - Identifies the log id to be used in the syslog id field.
 //   Severity - One of Emergency, Alert, Critical, Error, Warning, Notice,
-//              and Info.  Directly corresponds to the syslog severity types.
-//              Only PDLOG_ERROR or PDLOG_NOTICE are used.
-//              See syslog_facade.h for definitions.
+//              and Info.  Only LOG_ERROR or LOG_NOTICE are used.
 //   Message  - Formatted description of the condition.
 //   Cause    - The cause of the condition.
 //   Effect   - The effect the condition.
@@ -57,7 +55,7 @@
 static const PDLog2<const char*, const char*> CL_SPROUT_INVALID_PORT_SPROUTLET
 (
   PDLogBase::CL_SPROUT_ID + 1,
-  PDLOG_ERR,
+  LOG_ERR,
   "The %s port specified in /etc/clearwater/ must be in a range from"
   "1 to 65535 but has a value of %s.",
   "The <sproutlet>=<port> port value is outside the permitted range.",
@@ -68,7 +66,7 @@ static const PDLog2<const char*, const char*> CL_SPROUT_INVALID_PORT_SPROUTLET
 static const PDLog CL_SPROUT_INVALID_SAS_OPTION
 (
   PDLogBase::CL_SPROUT_ID + 3,
-  PDLOG_INFO,
+  LOG_INFO,
   "The sas_server option in /etc/clearwater/config is invalid "
   "or not configured.",
   "The interface to the SAS is not specified.",
@@ -79,7 +77,7 @@ static const PDLog CL_SPROUT_INVALID_SAS_OPTION
 static const PDLog1<const char*> CL_SPROUT_CRASH
 (
   PDLogBase::CL_SPROUT_ID + 4,
-  PDLOG_ERR,
+  LOG_ERR,
   "Fatal - The application has exited or crashed with signal %s.",
   "The application has encountered a fatal software error or has "
   "been terminated.",
@@ -91,7 +89,7 @@ static const PDLog1<const char*> CL_SPROUT_CRASH
 static const PDLog CL_SPROUT_STARTED
 (
   PDLogBase::CL_SPROUT_ID + 5,
-  PDLOG_ERR,
+  LOG_ERR,
   "Application started.",
   "The application is starting.",
   "Normal.",
@@ -101,7 +99,7 @@ static const PDLog CL_SPROUT_STARTED
 static const PDLog CL_SPROUT_NO_SI_CSCF
 (
   PDLogBase::CL_SPROUT_ID + 6,
-  PDLOG_NOTICE,
+  LOG_NOTICE,
   "Neither P-CSCF, S-CSCF nor I-CSCF functionality is enabled on this node.",
   "Neither a P-CSCF, a S-CSCF nor an I-CSCF was configured in "
   "/etc/clearwater/config.",
@@ -115,7 +113,7 @@ static const PDLog CL_SPROUT_NO_SI_CSCF
 static const PDLog CL_SPROUT_SI_CSCF_NO_HOMESTEAD
 (
   PDLogBase::CL_SPROUT_ID + 7,
-  PDLOG_ERR,
+  LOG_ERR,
   "Fatal - S/I-CSCF enabled with no Homestead server specified in "
   "/etc/clearwater/config.",
   "The S-CSCF and/or the I-CSCF options (scscf=<port>, icscf=<port>) "
@@ -129,7 +127,7 @@ static const PDLog CL_SPROUT_SI_CSCF_NO_HOMESTEAD
 static const PDLog CL_SPROUT_AUTH_NO_HOMESTEAD
 (
   PDLogBase::CL_SPROUT_ID + 8,
-  PDLOG_ERR,
+  LOG_ERR,
   "Fatal - Authentication enabled, but no Homestead server specified in "
   "/etc/clearwater/config.",
   "The hs_hostname was not set in the /etc/clearwater/config file.",
@@ -141,7 +139,7 @@ static const PDLog CL_SPROUT_AUTH_NO_HOMESTEAD
 static const PDLog CL_SPROUT_XDM_NO_HOMESTEAD
 (
   PDLogBase::CL_SPROUT_ID + 9,
-  PDLOG_ERR,
+  LOG_ERR,
   "Fatal - Homer XDM service is configured but no Homestead server specified "
   "in /etc/clearwater/config.",
   "The hs_hostname was not set in the /etc/clearwater/config file.",
@@ -153,7 +151,7 @@ static const PDLog CL_SPROUT_XDM_NO_HOMESTEAD
 static const PDLog1<const char*> CL_SPROUT_SIP_INIT_INTERFACE_FAIL
 (
   PDLogBase::CL_SPROUT_ID + 12,
-  PDLOG_ERR,
+  LOG_ERR,
   "Fatal - Error initializing SIP interfaces with error %s.",
   "The SIP interfaces could not be started.",
   "The application will exit and restart until the problem is fixed.",
@@ -165,7 +163,7 @@ static const PDLog1<const char*> CL_SPROUT_SIP_INIT_INTERFACE_FAIL
 static const PDLog CL_SPROUT_NO_RALF_CONFIGURED
 (
   PDLogBase::CL_SPROUT_ID + 13,
-  PDLOG_ERR,
+  LOG_ERR,
   "The application did not start a connection to Ralf because "
   "Ralf is not enabled.",
   "Ralf was not configured in the /etc/clearwater/config file.",
@@ -176,7 +174,7 @@ static const PDLog CL_SPROUT_NO_RALF_CONFIGURED
 static const PDLog CL_SPROUT_MEMCACHE_CONN_FAIL
 (
   PDLogBase::CL_SPROUT_ID + 14,
-  PDLOG_ERR,
+  LOG_ERR,
   "Fatal - Failed to connect to the memcached data store.",
   "The connection to the local store could not be created.",
   "The application will exit and restart until the problem is fixed.",
@@ -188,7 +186,7 @@ static const PDLog CL_SPROUT_MEMCACHE_CONN_FAIL
 static const PDLog1<const char*> CL_SPROUT_INIT_SERVICE_ROUTE_FAIL
 (
   PDLogBase::CL_SPROUT_ID + 15,
-  PDLOG_ERR,
+  LOG_ERR,
   "Fatal - Failed to enable the S-CSCF registrar with error %s.",
   "The S-CSCF registar could not be initialized.",
   "The application will exit and restart until the problem is fixed.",
@@ -198,7 +196,7 @@ static const PDLog1<const char*> CL_SPROUT_INIT_SERVICE_ROUTE_FAIL
 static const PDLog1<const char*> CL_SPROUT_REG_SUBSCRIBER_HAND_FAIL
 (
   PDLogBase::CL_SPROUT_ID + 16,
-  PDLOG_ERR,
+  LOG_ERR,
   "Fatal - Failed to register the SUBSCRIBE handlers with the SIP stack %s.",
   "The application subscription module could not be loaded.",
   "The application will exit and restart until the problem is fixed.",
@@ -208,7 +206,7 @@ static const PDLog1<const char*> CL_SPROUT_REG_SUBSCRIBER_HAND_FAIL
 static const PDLog1<const char*> CL_SPROUT_SIP_STACK_INIT_FAIL
 (
   PDLogBase::CL_SPROUT_ID + 19,
-  PDLOG_ERR,
+  LOG_ERR,
   "Fatal - The SIP stack failed to initialize with error, %s.",
   "The SIP interfaces could not be started.",
   "The application will exit and restart until the problem is fixed.",
@@ -219,7 +217,7 @@ static const PDLog1<const char*> CL_SPROUT_SIP_STACK_INIT_FAIL
 static const PDLog2<const char*, int> CL_SPROUT_HTTP_INTERFACE_FAIL
 (
   PDLogBase::CL_SPROUT_ID + 20,
-  PDLOG_ERR,
+  LOG_ERR,
   "An HTTP interface failed to initialize or start in %s with error %d.",
   "An HTTP interface has failed initialization.",
   "The application will exit and restart until the problem is fixed.",
@@ -229,7 +227,7 @@ static const PDLog2<const char*, int> CL_SPROUT_HTTP_INTERFACE_FAIL
 static const PDLog CL_SPROUT_ENDED
 (
   PDLogBase::CL_SPROUT_ID + 21,
-  PDLOG_ERR,
+  LOG_ERR,
   "The application is ending -- Shutting down.",
   "The application has been terminated by monit or has exited.",
   "Application services are no longer available.",
@@ -242,7 +240,7 @@ static const PDLog CL_SPROUT_ENDED
 static const PDLog2<const char*, int> CL_SPROUT_HTTP_INTERFACE_STOP_FAIL
 (
   PDLogBase::CL_SPROUT_ID + 22,
-  PDLOG_ERR,
+  LOG_ERR,
   "The HTTP interfaces encountered an error when stopping the HTTP stack in "
   "%s with error %d.",
   "When the application was exiting it encountered an error when shutting "
@@ -254,7 +252,7 @@ static const PDLog2<const char*, int> CL_SPROUT_HTTP_INTERFACE_STOP_FAIL
 static const PDLog2<const char*, const char*> CL_SPROUT_SIP_SEND_REQUEST_ERR
 (
   PDLogBase::CL_SPROUT_ID + 23,
-  PDLOG_ERR,
+  LOG_ERR,
   "Failed to send SIP request to %s with error %s.",
   "An attempt to send a SIP request failed.",
   "This may cause a call to fail.",
@@ -264,7 +262,7 @@ static const PDLog2<const char*, const char*> CL_SPROUT_SIP_SEND_REQUEST_ERR
 static const PDLog CL_SPROUT_SIP_DEADLOCK
 (
   PDLogBase::CL_SPROUT_ID + 24,
-  PDLOG_ERR,
+  LOG_ERR,
   "Fatal - The application detected a fatal software deadlock "
   "affecting SIP communication.",
   "An internal application software error has been detected.",
@@ -275,7 +273,7 @@ static const PDLog CL_SPROUT_SIP_DEADLOCK
 static const PDLog2<int, const char*> CL_SPROUT_SIP_UDP_INTERFACE_START_FAIL
 (
   PDLogBase::CL_SPROUT_ID + 25,
-  PDLOG_ERR,
+  LOG_ERR,
   "Failed to start a SIP UDP interface for port %d with error %s.",
   "The application could not start a UDP interface.",
   "This may affect call processing.",
@@ -286,7 +284,7 @@ static const PDLog2<int, const char*> CL_SPROUT_SIP_UDP_INTERFACE_START_FAIL
 static const PDLog2<int, const char*> CL_SPROUT_SIP_TCP_START_FAIL
 (
   PDLogBase::CL_SPROUT_ID + 26,
-  PDLOG_ERR,
+  LOG_ERR,
   "Failed to start a SIP TCP transport for port %d with error %s.",
   "Failed to start a SIP TCP connection.",
   "This may affect call processing.",
@@ -297,7 +295,7 @@ static const PDLog2<int, const char*> CL_SPROUT_SIP_TCP_START_FAIL
 static const PDLog2<int, const char*> CL_SPROUT_SIP_TCP_SERVICE_START_FAIL
 (
   PDLogBase::CL_SPROUT_ID + 27,
-  PDLOG_ERR,
+  LOG_ERR,
   "Failed to start a SIP TCP service for port %d with error %s.",
   "The application could not start a TCP service.",
   "This may affect call processing.",
@@ -309,7 +307,7 @@ static const PDLog2<int, const char*> CL_SPROUT_SIP_TCP_SERVICE_START_FAIL
 static const PDLog1<int> CL_SPROUT_SPROUTLET_END
 (
   PDLogBase::CL_SPROUT_ID + 30,
-  PDLOG_ERR,
+  LOG_ERR,
   "All Sproutlets using port %d have ended.",
   "The Sproutlet services are no longer available.",
   "The application will exit and restart until the problem is fixed.",
@@ -320,7 +318,7 @@ static const PDLog1<int> CL_SPROUT_SPROUTLET_END
 static const PDLog1<int> CL_SPROUT_SPROUTLET_AVAIL
 (
   PDLogBase::CL_SPROUT_ID + 34,
-  PDLOG_NOTICE,
+  LOG_NOTICE,
   "The Sproutlet services on port %d are now available.",
   "The Sproutlet services are now available.",
   "Normal.",
@@ -330,7 +328,7 @@ static const PDLog1<int> CL_SPROUT_SPROUTLET_AVAIL
 static const PDLog1<int> CL_SPROUT_SPROUTLET_INIT_FAIL2
 (
   PDLogBase::CL_SPROUT_ID + 35,
-  PDLOG_ERR,
+  LOG_ERR,
   "The Sproutlet services on port %d failed to initialize.",
   "The Sproutlet services are no longer available.",
   "The application will exit and restart until the problem is fixed.",
@@ -340,7 +338,7 @@ static const PDLog1<int> CL_SPROUT_SPROUTLET_INIT_FAIL2
 static const PDLog CL_SPROUT_PLUGIN_FAILURE
 (
   PDLogBase::CL_SPROUT_ID + 38,
-  PDLOG_ERR,
+  LOG_ERR,
   "One or more plugins failed to load.",
   "The service is no longer available.",
   "The application will exit and restart until the problem is fixed.",
@@ -350,7 +348,7 @@ static const PDLog CL_SPROUT_PLUGIN_FAILURE
 static const PDLog1<const char*> CL_SPROUT_ENUM_FILE_MISSING
 (
   PDLogBase::CL_SPROUT_ID + 39,
-  PDLOG_ERR,
+  LOG_ERR,
   "The ENUM file is not present.",
   "Sprout is configured to use file-based ENUM, but the configuration file does not exist.",
   "Sprout will not be able to translate telephone numbers into routable URIs.",
@@ -360,7 +358,7 @@ static const PDLog1<const char*> CL_SPROUT_ENUM_FILE_MISSING
 static const PDLog1<const char*> CL_SPROUT_ENUM_FILE_EMPTY
 (
   PDLogBase::CL_SPROUT_ID + 40,
-  PDLOG_ERR,
+  LOG_ERR,
   "The ENUM file is empty.",
   "Sprout is configured to use file-based ENUM, but the configuration file is empty.",
   "Sprout will not be able to translate telephone numbers into routable URIs.",
@@ -370,7 +368,7 @@ static const PDLog1<const char*> CL_SPROUT_ENUM_FILE_EMPTY
 static const PDLog1<const char*> CL_SPROUT_ENUM_FILE_INVALID
 (
   PDLogBase::CL_SPROUT_ID + 41,
-  PDLOG_ERR,
+  LOG_ERR,
   "The ENUM file is invalid.",
   "Sprout is configured to use file-based ENUM, but the configuration file does not exist.",
   "Sprout will not be able to translate telephone numbers into routable URIs.",
@@ -380,7 +378,7 @@ static const PDLog1<const char*> CL_SPROUT_ENUM_FILE_INVALID
 static const PDLog CL_SPROUT_SCSCF_FILE_MISSING
 (
   PDLogBase::CL_SPROUT_ID + 42,
-  PDLOG_ERR,
+  LOG_ERR,
   "The file listing S-CSCFs is not present.",
   "Sprout is configured as an I-CSCF, but the /etc/clearwater/s-cscf.json file (defining which S-CSCFs to use) does not exist.",
   "The Sprout I-CSCF will use the default S-CSCF URI only.",
@@ -390,7 +388,7 @@ static const PDLog CL_SPROUT_SCSCF_FILE_MISSING
 static const PDLog CL_SPROUT_SCSCF_FILE_EMPTY
 (
   PDLogBase::CL_SPROUT_ID + 43,
-  PDLOG_ERR,
+  LOG_ERR,
   "The file listing S-CSCFs is empty.",
   "Sprout is configured as an I-CSCF, but the /etc/clearwater/s-cscf.json file (defining which S-CSCFs to use) is empty.",
   "The Sprout I-CSCF will use the default S-CSCF URI only.",
@@ -400,7 +398,7 @@ static const PDLog CL_SPROUT_SCSCF_FILE_EMPTY
 static const PDLog CL_SPROUT_SCSCF_FILE_INVALID
 (
   PDLogBase::CL_SPROUT_ID + 44,
-  PDLOG_ERR,
+  LOG_ERR,
   "The file listing S-CSCFs is invalid.",
   "Sprout is configured as an I-CSCF, but the /etc/clearwater/s-cscf.json file (defining which S-CSCFs to use) is invalid due to invalid JSON or missing elements.",
   "The Sprout I-CSCF will use the default S-CSCF URI only.",
@@ -410,7 +408,7 @@ static const PDLog CL_SPROUT_SCSCF_FILE_INVALID
 static const PDLog CL_SPROUT_BGCF_FILE_MISSING
 (
   PDLogBase::CL_SPROUT_ID + 45,
-  PDLOG_NOTICE,
+  LOG_NOTICE,
   "The file listing BGCF routes is not present.",
   "The /etc/clearwater/bgcf.json file, defining which BGCF routes to use, does not exist.",
   "Sprout will not be able to route any calls outside the local deployment.",
@@ -420,7 +418,7 @@ static const PDLog CL_SPROUT_BGCF_FILE_MISSING
 static const PDLog CL_SPROUT_BGCF_FILE_EMPTY
 (
   PDLogBase::CL_SPROUT_ID + 46,
-  PDLOG_ERR,
+  LOG_ERR,
   "The file listing BGCF routes is empty.",
   "The /etc/clearwater/bgcf.json file, defining which BGCF routes to use, is empty.",
   "Sprout will not be able to route any calls outside the local deployment.",
@@ -430,7 +428,7 @@ static const PDLog CL_SPROUT_BGCF_FILE_EMPTY
 static const PDLog CL_SPROUT_BGCF_FILE_INVALID
 (
   PDLogBase::CL_SPROUT_ID + 47,
-  PDLOG_ERR,
+  LOG_ERR,
   "The file listing BGCF routes is not present or empty.",
   "The /etc/clearwater/bgcf.json file, defining which BGCF routes to use, is not valid (due to invalid JSON or missing elements).",
   "Sprout will not be able to route some or all calls outside the local deployment.",
@@ -440,7 +438,7 @@ static const PDLog CL_SPROUT_BGCF_FILE_INVALID
 static const PDLog2<const char *, const char*> CL_SPROUT_SESS_TERM_AS_COMM_FAILURE
 (
   PDLogBase::CL_SPROUT_ID + 48,
-  PDLOG_ERR,
+  LOG_ERR,
   "Sprout is currently unable to successfully communicate with an Application Server that uses session terminated default handling. The server's URI is: %s. Failure reason: %s",
   "Communication is failing to an Application Server",
   "Probable major loss of service. The precise impact will vary depending on the role of this Application Server.",
@@ -450,7 +448,7 @@ static const PDLog2<const char *, const char*> CL_SPROUT_SESS_TERM_AS_COMM_FAILU
 static const PDLog1<const char *> CL_SPROUT_SESS_TERM_AS_COMM_SUCCESS
 (
   PDLogBase::CL_SPROUT_ID + 49,
-  PDLOG_NOTICE,
+  LOG_NOTICE,
   "Sprout is able to successfully communicate with an Application Server that uses session terminated default handling. ",
   "Communication has been restored to an Application Server",
   "Full service has been restored.",
@@ -460,7 +458,7 @@ static const PDLog1<const char *> CL_SPROUT_SESS_TERM_AS_COMM_SUCCESS
 static const PDLog2<const char *, const char*> CL_SPROUT_SESS_CONT_AS_COMM_FAILURE
 (
   PDLogBase::CL_SPROUT_ID + 50,
-  PDLOG_ERR,
+  LOG_ERR,
   "Sprout is currently unable to successfully communicate with an Application Server that uses session continued default handling. The server's URI is %s. Failure reason: %s",
   "Communication is failing to <URI>",
   "Probable minor degradation of service, or loss of a supplemental service. The precise impact will vary depending on the role of the Application Server in the deployment.",
@@ -470,7 +468,7 @@ static const PDLog2<const char *, const char*> CL_SPROUT_SESS_CONT_AS_COMM_FAILU
 static const PDLog1<const char *> CL_SPROUT_SESS_CONT_AS_COMM_SUCCESS
 (
   PDLogBase::CL_SPROUT_ID + 51,
-  PDLOG_NOTICE,
+  LOG_NOTICE,
   "Sprout is able to successfully communicate with an Application Server that uses session continued default handling.",
   "Communication has been restored to an Application Server",
   "Full service has been restored.",

--- a/scripts/sprout-log-cleanup
+++ b/scripts/sprout-log-cleanup
@@ -6,4 +6,4 @@ max_log_directory_size=$ONE_GIG
 
 python2.7 /usr/share/clearwater/bin/log_cleanup.py /var/log/sprout --prefix sprout_ --maxsize $max_log_directory_size --count $WEEK_COUNT
 python2.7 /usr/share/clearwater/bin/log_cleanup.py /var/log/sprout --prefix log_ --maxsize $max_log_directory_size --count $WEEK_COUNT
-python2.7 /usr/share/clearwater/bin/log_cleanup.py /var/log/sprout --prefix access_ --maxsize $max_log_directory_size --count $WEEK_COUNT
+python2.7 /usr/share/clearwater/bin/log_cleanup.py /var/log/sprout --prefix analytics --maxsize $max_log_directory_size

--- a/sprout-base.root/etc/logrotate.d/sproutanalytics
+++ b/sprout-base.root/etc/logrotate.d/sproutanalytics
@@ -1,11 +1,16 @@
 /var/log/sprout/analytics.log {
   su sprout sprout
   daily
+  # Keep 36500 log files (i.e. 100 years worth). The log cleanup scripts will
+  # clean up this directory if the files become too big.
   rotate 36500
+  # Add a date and timestamp to the rotated log file.
   dateext
   dateformat .%Y-%m-%d-%s
   extension .log
   missingok
+  # After rotating, rsyslog still has the rotated file open; reload it so that
+  # it starts writing to the new file.
   postrotate
     reload rsyslog >/dev/null 2>&1 || true
   endscript

--- a/sprout-base.root/etc/logrotate.d/sproutanalytics
+++ b/sprout-base.root/etc/logrotate.d/sproutanalytics
@@ -1,0 +1,12 @@
+/var/log/sprout/analytics.log {
+  su sprout sprout
+  daily
+  rotate 36500
+  dateext
+  dateformat .%Y-%m-%d-%s
+  extension .log
+  missingok
+  postrotate
+    reload rsyslog >/dev/null 2>&1 || true
+  endscript
+}

--- a/sprout-base.root/usr/share/clearwater/infrastructure/scripts/create-analytics-syslog-config
+++ b/sprout-base.root/usr/share/clearwater/infrastructure/scripts/create-analytics-syslog-config
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# @file create-analytic-syslog-config
+#
+# Project Clearwater - IMS in the Cloud
+# Copyright (C) 2016 Metaswitch Networks Ltd
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version, along with the "Special Exception" for use of
+# the program along with SSL, set forth below. This program is distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details. You should have received a copy of the GNU General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# The author can be reached by email at clearwater@metaswitch.com or by
+# post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+#
+# Special Exception
+# Metaswitch Networks Ltd  grants you permission to copy, modify,
+# propagate, and distribute a work formed by combining OpenSSL with The
+# Software, or a work derivative of such a combination, even if such
+# copying, modification, propagation, or distribution would otherwise
+# violate the terms of the GPL. You must comply with the GPL in all
+# respects for all of the code used other than OpenSSL.
+# "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+# Project and licensed under the OpenSSL Licenses, or a work based on such
+# software and licensed under the OpenSSL Licenses.
+# "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+# under which the OpenSSL Project distributes the OpenSSL toolkit software,
+# as those licenses appear in the file LICENSE-OPENSSL.
+
+# This file creates a syslog config file for Sprout's analytics logs.
+
+syslog_conf_file=/etc/rsyslog.d/30-sproutanalytics.conf
+temp_file=$(mktemp sproutanalytics.syslog.XXXXXXXX)
+
+. /etc/clearwater/config
+if [ -n "$remote_audit_logging_server" ]; then
+  remote_syslog_audit_server_str=":msg, startswith, \"<analytics> Registration:\" @@${remote_audit_logging_server}"
+fi
+
+cat > $temp_file << EOF
+\$FileCreateMode 0666
+\$umask 0000
+
+# Define a template that includes the time that Sprout reported the log in UTC
+# with milliseconds, and strip the "<analytics>" tag off the front of it.
+\$template analytics-format,"%timereported:::date-utc;date-rfc3339% %msg:11:$%\r\n"
+
+:msg, startswith, "<analytics>" /var/log/sprout/analytics.log;analytics-format
+:msg, startswith, "<analytics>" stop
+
+$remote_syslog_audit_server_str
+
+\$FileCreateMode 0644
+EOF
+
+if ! diff $temp_file $syslog_conf_file > /dev/null 2>&1
+then
+  # Update the config file.
+  mv $temp_file $syslog_conf_file
+
+  # Restart rsyslog to pick up the new config file.
+  service rsyslog restart
+else
+  rm $temp_file
+fi

--- a/sprout-base.root/usr/share/clearwater/infrastructure/scripts/create-analytics-syslog-config
+++ b/sprout-base.root/usr/share/clearwater/infrastructure/scripts/create-analytics-syslog-config
@@ -40,22 +40,25 @@ syslog_conf_file=/etc/rsyslog.d/30-sproutanalytics.conf
 temp_file=$(mktemp sproutanalytics.syslog.XXXXXXXX)
 
 . /etc/clearwater/config
+
 if [ -n "$remote_audit_logging_server" ]; then
-  remote_syslog_audit_server_str=":msg, startswith, \"<analytics> Registration:\" @@${remote_audit_logging_server}"
+  # If a remote syslog server is configured for auditing registrations, we need
+  # an rsyslog config line for directing the correct syslogs to this server. We
+  # use a regex to forward messages that start with the correct tag and are
+  # registrations.
+  remote_syslog_audit_server_str=":msg, regex, \"<analytics>.*Registration:.*\" @@${remote_audit_logging_server}"
 fi
 
 cat > $temp_file << EOF
 \$FileCreateMode 0666
 \$umask 0000
 
-# Define a template that includes the time that Sprout reported the log in UTC
-# with milliseconds, and strip the "<analytics>" tag off the front of it.
-\$template analytics-format,"%timereported:::date-utc;date-rfc3339% %msg:11:$%\r\n"
+# Define a template that strips the "<analytics>" tag off the front of it.
+\$template analytics-format,"%msg:14:$%\r\n"
 
-:msg, startswith, "<analytics>" /var/log/sprout/analytics.log;analytics-format
-:msg, startswith, "<analytics>" stop
-
+:msg, contains, "<analytics>" /var/log/sprout/analytics.log;analytics-format
 $remote_syslog_audit_server_str
+:msg, contains, "<analytics>" stop
 
 \$FileCreateMode 0644
 EOF

--- a/src/Makefile
+++ b/src/Makefile
@@ -95,7 +95,6 @@ sprout_SOURCES := ${SPROUT_COMMON_SOURCES} \
                   snmp_success_fail_count_table.cpp \
                   snmp_success_fail_count_by_request_type_table.cpp \
                   snmp_event_accumulator_table.cpp \
-                  pdlog.cpp \
                   main.cpp
 
 sprout_test_SOURCES := ${SPROUT_COMMON_SOURCES} \

--- a/src/analyticslogger.cpp
+++ b/src/analyticslogger.cpp
@@ -37,6 +37,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
+#include <syslog.h>
 
 // Common STL includes.
 #include <cassert>
@@ -51,7 +52,7 @@
 #include "analyticslogger.h"
 
 
-AnalyticsLogger::AnalyticsLogger(Logger* logger): _logger(logger)
+AnalyticsLogger::AnalyticsLogger()
 {
 }
 
@@ -68,12 +69,12 @@ void AnalyticsLogger::registration(const std::string& aor,
 {
   char buf[BUFFER_SIZE];
   snprintf(buf, sizeof(buf),
-           "Registration: USER_URI=%s BINDING_ID=%s CONTACT_URI=%s EXPIRES=%d\n",
+           "<analytics> Registration: USER_URI=%s BINDING_ID=%s CONTACT_URI=%s EXPIRES=%d\n",
            aor.c_str(),
            binding_id.c_str(),
            contact.c_str(),
            expires);
-  _logger->write(buf);
+  syslog(LOG_INFO, "%s", buf);
 }
 
 void AnalyticsLogger::subscription(const std::string& aor,
@@ -83,12 +84,12 @@ void AnalyticsLogger::subscription(const std::string& aor,
 {
   char buf[BUFFER_SIZE];
   snprintf(buf, sizeof(buf),
-           "Subscription: USER_URI=%s SUBSCRIPTION_ID=%s CONTACT_URI=%s EXPIRES=%d\n",
+           "<analytics> Subscription: USER_URI=%s SUBSCRIPTION_ID=%s CONTACT_URI=%s EXPIRES=%d\n",
            aor.c_str(),
            subscription_id.c_str(),
            contact.c_str(),
            expires);
-  _logger->write(buf);
+  syslog(LOG_INFO, "%s", buf);
 }
 
 void AnalyticsLogger::auth_failure(const std::string& auth,
@@ -96,10 +97,10 @@ void AnalyticsLogger::auth_failure(const std::string& auth,
 {
   char buf[BUFFER_SIZE];
   snprintf(buf, sizeof(buf),
-           "Auth-Failure: Private Identity=%s Public Identity=%s\n",
+           "<analytics> Auth-Failure: Private Identity=%s Public Identity=%s\n",
            auth.c_str(),
            to.c_str());
-  _logger->write(buf);
+  syslog(LOG_INFO, "%s", buf);
 }
 
 
@@ -109,11 +110,11 @@ void AnalyticsLogger::call_connected(const std::string& from,
 {
   char buf[BUFFER_SIZE];
   snprintf(buf, sizeof(buf),
-           "Call-Connected: FROM=%s TO=%s CALL_ID=%s\n",
+           "<analytics> Call-Connected: FROM=%s TO=%s CALL_ID=%s\n",
            from.c_str(),
            to.c_str(),
            call_id.c_str());
-  _logger->write(buf);
+  syslog(LOG_INFO, "%s", buf);
 }
 
 
@@ -124,12 +125,12 @@ void AnalyticsLogger::call_not_connected(const std::string& from,
 {
   char buf[BUFFER_SIZE];
   snprintf(buf, sizeof(buf),
-           "Call-Not-Connected: FROM=%s TO=%s CALL_ID=%s REASON=%d\n",
+           "<analytics> Call-Not-Connected: FROM=%s TO=%s CALL_ID=%s REASON=%d\n",
            from.c_str(),
            to.c_str(),
            call_id.c_str(),
            reason);
-  _logger->write(buf);
+  syslog(LOG_INFO, "%s", buf);
 }
 
 
@@ -138,9 +139,9 @@ void AnalyticsLogger::call_disconnected(const std::string& call_id,
 {
   char buf[BUFFER_SIZE];
   snprintf(buf, sizeof(buf),
-           "Call-Disconnected: CALL_ID=%s REASON=%d\n",
+           "<analytics> Call-Disconnected: CALL_ID=%s REASON=%d\n",
            call_id.c_str(),
            reason);
-  _logger->write(buf);
+  syslog(LOG_INFO, "%s", buf);
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1286,7 +1286,6 @@ int main(int argc, char* argv[])
   pj_status_t status;
   struct options opt;
 
-  Logger* analytics_logger_logger = NULL;
   AnalyticsLogger* analytics_logger = NULL;
   SIPResolver* sip_resolver = NULL;
   Store* remote_data_store = NULL;
@@ -1441,9 +1440,7 @@ int main(int argc, char* argv[])
 
   if (opt.analytics_enabled)
   {
-    analytics_logger_logger = new Logger(opt.analytics_directory, std::string("log"));
-    analytics_logger_logger->set_flags(Logger::ADD_TIMESTAMPS|Logger::FLUSH_ON_WRITE);
-    analytics_logger = new AnalyticsLogger(analytics_logger_logger);
+    analytics_logger = new AnalyticsLogger();
   }
 
   std::vector<std::string> sproutlet_uris;
@@ -2323,7 +2320,6 @@ int main(int argc, char* argv[])
   delete dns_resolver;
 
   delete analytics_logger;
-  delete analytics_logger_logger;
 
   // Delete Sprout's alarm objects
   delete chronos_comm_monitor;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1378,11 +1378,6 @@ int main(int argc, char* argv[])
   opt.disable_tcp_switch = false;
   opt.allow_fallback_ifcs = false;
 
-  // Initialise ENT logging before making "Started" log
-  PDLogStatic::init(argv[0]);
-
-  CL_SPROUT_STARTED.log();
-
   status = init_logging_options(argc, argv, &opt);
 
   if (status != PJ_SUCCESS)
@@ -1402,6 +1397,10 @@ int main(int argc, char* argv[])
                           opt.log_directory,
                           opt.log_level,
                           opt.log_to_file);
+
+  // We should now have a connection to syslog so we can write the started ENT
+  // log.
+  CL_SPROUT_STARTED.log();
 
   if ((opt.log_to_file) && (opt.log_directory != ""))
   {

--- a/src/ut/authentication_test.cpp
+++ b/src/ut/authentication_test.cpp
@@ -84,7 +84,7 @@ public:
     _impi_store = new ImpiStore(_local_data_store, ImpiStore::Mode::READ_AV_IMPI_WRITE_AV_IMPI);
     _hss_connection = new FakeHSSConnection();
     _chronos_connection = new FakeChronosConnection();
-    _analytics = new AnalyticsLogger(&PrintingTestLogger::DEFAULT);
+    _analytics = new AnalyticsLogger();
     _acr_factory = new ACRFactory();
   }
 

--- a/src/ut/bono_test.cpp
+++ b/src/ut/bono_test.cpp
@@ -263,7 +263,7 @@ public:
     _chronos_connection = new FakeChronosConnection();
     _local_data_store = new LocalStore();
     _sdm = new SubscriberDataManager((Store*)_local_data_store, _chronos_connection, true);
-    _analytics = new AnalyticsLogger(&PrintingTestLogger::DEFAULT);
+    _analytics = new AnalyticsLogger();
     _hss_connection = new FakeHSSConnection();
     if (ifcs)
     {

--- a/src/ut/registrar_test.cpp
+++ b/src/ut/registrar_test.cpp
@@ -177,7 +177,7 @@ public:
     _sdm = new SubscriberDataManager((Store*)_local_data_store, _chronos_connection, true);
     _remote_sdm = new SubscriberDataManager((Store*)_remote_data_store, _chronos_connection, false);
     _remote_sdms = {_remote_sdm};
-    _analytics = new AnalyticsLogger(&PrintingTestLogger::DEFAULT);
+    _analytics = new AnalyticsLogger();
     _hss_connection = new FakeHSSConnection();
     _acr_factory = new ACRFactory();
     pj_status_t ret = init_registrar(_sdm,
@@ -529,7 +529,7 @@ public:
     _remote_sdm_no_bindings = new SDMNoBindings((Store*)_remote_data_store_no_bindings, _chronos_connection, false);
     _remote_sdm = new SubscriberDataManager((Store*)_remote_data_store, _chronos_connection, false);
     _remote_sdms = {_remote_sdm_no_bindings, _remote_sdm};
-    _analytics = new AnalyticsLogger(&PrintingTestLogger::DEFAULT);
+    _analytics = new AnalyticsLogger();
     _hss_connection = new FakeHSSConnection();
     _acr_factory = new ACRFactory();
     pj_status_t ret = init_registrar(_sdm,
@@ -2597,7 +2597,7 @@ public:
     _chronos_connection = new FakeChronosConnection();
     _local_data_store = new MockStore();
     _sdm = new SubscriberDataManager((Store*)_local_data_store, _chronos_connection, true);
-    _analytics = new AnalyticsLogger(&PrintingTestLogger::DEFAULT);
+    _analytics = new AnalyticsLogger();
     _hss_connection = new FakeHSSConnection();
     _acr_factory = new ACRFactory();
     pj_status_t ret = init_registrar(_sdm,

--- a/src/ut/scscf_test.cpp
+++ b/src/ut/scscf_test.cpp
@@ -261,7 +261,7 @@ public:
     _chronos_connection = new FakeChronosConnection();
     _local_data_store = new LocalStore();
     _sdm = new SubscriberDataManager((Store*)_local_data_store, _chronos_connection, true);
-    _analytics = new AnalyticsLogger(&PrintingTestLogger::DEFAULT);
+    _analytics = new AnalyticsLogger();
     _bgcf_service = new BgcfService(string(UT_DIR).append("/test_stateful_proxy_bgcf.json"));
     _xdm_connection = new FakeXDMConnection();
     _sess_term_comm_tracker = new NiceMock<MockAsCommunicationTracker>();

--- a/src/ut/subscription_test.cpp
+++ b/src/ut/subscription_test.cpp
@@ -70,7 +70,7 @@ public:
     _sdm = new SubscriberDataManager((Store*)_local_data_store, _chronos_connection, true);
     _remote_sdm = new SubscriberDataManager((Store*)_remote_data_store, _chronos_connection, false);
     std::vector<SubscriberDataManager*> remote_sdms = {_remote_sdm};
-    _analytics = new AnalyticsLogger(&PrintingTestLogger::DEFAULT);
+    _analytics = new AnalyticsLogger();
     _hss_connection = new FakeHSSConnection();
     _acr_factory = new ACRFactory();
     pj_status_t ret = init_subscription(_sdm, remote_sdms, _hss_connection, _acr_factory, _analytics, 300);
@@ -817,7 +817,7 @@ public:
     _chronos_connection = new FakeChronosConnection();
     _local_data_store = new MockStore();
     _sdm = new SubscriberDataManager((Store*)_local_data_store, _chronos_connection, true);
-    _analytics = new AnalyticsLogger(&PrintingTestLogger::DEFAULT);
+    _analytics = new AnalyticsLogger();
     _hss_connection = new FakeHSSConnection();
     _acr_factory = new ACRFactory();
     pj_status_t ret = init_subscription(_sdm, {}, _hss_connection, _acr_factory, _analytics, 300);


### PR DESCRIPTION
Use syslog to log analytics logs.

This also contains the Sprout changes that match https://github.com/Metaswitch/cpp-common/pull/574.