### PR TITLE
[Reviewer: Ellie] Add chronos-sprout-callback-uri option

### DIFF
--- a/include/cfgoptions.h
+++ b/include/cfgoptions.h
@@ -151,7 +151,7 @@ struct options
   bool                                 sas_signaling_if;
   bool                                 disable_tcp_switch;
   std::string                          chronos_hostname;
-  std::string                          chronos_sprout_callback_uri;
+  std::string                          sprout_chronos_callback_uri;
   bool                                 allow_fallback_ifcs;
 };
 

--- a/include/cfgoptions.h
+++ b/include/cfgoptions.h
@@ -151,6 +151,7 @@ struct options
   bool                                 sas_signaling_if;
   bool                                 disable_tcp_switch;
   std::string                          chronos_hostname;
+  std::string                          chronos_sprout_callback_uri;
   bool                                 allow_fallback_ifcs;
 };
 

--- a/sprout-base.root/etc/init.d/sprout
+++ b/sprout-base.root/etc/init.d/sprout
@@ -177,7 +177,7 @@ get_daemon_args()
         [ -z "$local_site_name" ] || local_site_name_arg="--local-site-name=$local_site_name"
         [ -z "$sprout_impi_store" ] || impi_store_arg="--impi-store=$sprout_impi_store"
         [ -z "$chronos_hostname" ] || chronos_hostname_arg="--chronos-hostname=$chronos_hostname"
-        [ -z "$chronos_sprout_callback_uri" ] || chronos_sprout_callback_uri_arg="--chronos-sprout-callback-uri=$chronos_sprout_callback_uri"
+        [ -z "$sprout_chronos_callback_uri" ] || sprout_chronos_callback_uri_arg="--sprout-chronos-callback-uri=$sprout_chronos_callback_uri"
         [ -z "$allow_fallback_ifcs" ] || allow_fallback_ifcs_arg="--allow-fallback-ifcs"
 
         DAEMON_ARGS="
@@ -191,7 +191,7 @@ get_daemon_args()
                      --sprout-hostname=$sprout_hostname
                      --scscf-node-uri=$scscf_node_uri
                      $chronos_hostname_arg
-                     $chronos_sprout_callback_uri_arg
+                     $sprout_chronos_callback_uri_arg
                      $xdms_hostname_arg
                      $ralf_arg
                      $enum_server_arg

--- a/sprout-base.root/etc/init.d/sprout
+++ b/sprout-base.root/etc/init.d/sprout
@@ -177,6 +177,7 @@ get_daemon_args()
         [ -z "$local_site_name" ] || local_site_name_arg="--local-site-name=$local_site_name"
         [ -z "$sprout_impi_store" ] || impi_store_arg="--impi-store=$sprout_impi_store"
         [ -z "$chronos_hostname" ] || chronos_hostname_arg="--chronos-hostname=$chronos_hostname"
+        [ -z "$chronos_sprout_callback_uri" ] || chronos_sprout_callback_uri_arg="--chronos-sprout-callback-uri=$chronos_sprout_callback_uri"
         [ -z "$allow_fallback_ifcs" ] || allow_fallback_ifcs_arg="--allow-fallback-ifcs"
 
         DAEMON_ARGS="
@@ -190,6 +191,7 @@ get_daemon_args()
                      --sprout-hostname=$sprout_hostname
                      --scscf-node-uri=$scscf_node_uri
                      $chronos_hostname_arg
+                     $chronos_sprout_callback_uri_arg
                      $xdms_hostname_arg
                      $ralf_arg
                      $enum_server_arg

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -157,7 +157,7 @@ enum OptionTypes
   OPT_DISABLE_TCP_SWITCH,
   OPT_DEFAULT_TEL_URI_TRANSLATION,
   OPT_CHRONOS_HOSTNAME,
-  OPT_CHRONOS_SPROUT_CALLBACK_URI,
+  OPT_SPROUT_CHRONOS_CALLBACK_URI,
   OPT_ALLOW_FALLBACK_IFCS,
 };
 
@@ -243,7 +243,7 @@ const static struct pj_getopt_option long_opt[] =
   { "sas-use-signaling-interface",  no_argument,       0, OPT_SAS_USE_SIGNALING_IF},
   { "disable-tcp-switch",           no_argument,       0, OPT_DISABLE_TCP_SWITCH},
   { "chronos-hostname",             required_argument, 0, OPT_CHRONOS_HOSTNAME},
-  { "chronos-sprout-callback-uri",  required_argument, 0, OPT_CHRONOS_SPROUT_CALLBACK_URI},
+  { "sprout-chronos-callback-uri",  required_argument, 0, OPT_SPROUT_CHRONOS_CALLBACK_URI},
   { "allow-fallback-ifcs",          no_argument,       0, OPT_ALLOW_FALLBACK_IFCS},
   { NULL,                           0,                 0, 0}
 };
@@ -448,6 +448,10 @@ static void usage(void)
        "     --chronos-hostname <hostname>\n"
        "                            Specify the hostname of a remote Chronos cluster. If unset the default\n"
        "                            is to use localhost, using localhost as the callback URL.\n"
+       "     --sprout-chronos-callback-uri <hostname>\n"
+       "                            Specify the sprout hostname used for Chronos callbacks. If unset \n"
+       "                            the default is to use the sprout-hostname.\n"
+       "                            Ignored if chronos-hostname is not set.\n"
        "     --allow-fallback-ifcs  If no Identity elements match for Initial Filter Criteria, use the\n"
        "                            first IFC returned as a fallback.\n"
        " -N, --plugin-option <plugin>,<name>,<value>\n"
@@ -1173,8 +1177,8 @@ static pj_status_t init_options(int argc, char* argv[], struct options* options)
     case OPT_CHRONOS_HOSTNAME:
       options->chronos_hostname = std::string(pj_optarg);
 
-    case OPT_CHRONOS_SPROUT_CALLBACK_URI:
-      options->chronos_sprout_callback_uri = std::string(pj_optarg);
+    case OPT_SPROUT_CHRONOS_CALLBACK_URI:
+      options->sprout_chronos_callback_uri = std::string(pj_optarg);
 
     case OPT_LISTEN_PORT:
       options->listen_port = atoi(pj_optarg);
@@ -1996,7 +2000,7 @@ int main(int argc, char* argv[])
   }
   else
   {
-    std::string chronos_callback_uri = opt.chronos_sprout_callback_uri;
+    std::string chronos_callback_uri = opt.sprout_chronos_callback_uri;
 
     if (chronos_callback_uri == "")
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -157,6 +157,7 @@ enum OptionTypes
   OPT_DISABLE_TCP_SWITCH,
   OPT_DEFAULT_TEL_URI_TRANSLATION,
   OPT_CHRONOS_HOSTNAME,
+  OPT_CHRONOS_SPROUT_CALLBACK_URI,
   OPT_ALLOW_FALLBACK_IFCS,
 };
 
@@ -242,6 +243,7 @@ const static struct pj_getopt_option long_opt[] =
   { "sas-use-signaling-interface",  no_argument,       0, OPT_SAS_USE_SIGNALING_IF},
   { "disable-tcp-switch",           no_argument,       0, OPT_DISABLE_TCP_SWITCH},
   { "chronos-hostname",             required_argument, 0, OPT_CHRONOS_HOSTNAME},
+  { "chronos-sprout-callback-uri",  required_argument, 0, OPT_CHRONOS_SPROUT_CALLBACK_URI},
   { "allow-fallback-ifcs",          no_argument,       0, OPT_ALLOW_FALLBACK_IFCS},
   { NULL,                           0,                 0, 0}
 };
@@ -1171,6 +1173,9 @@ static pj_status_t init_options(int argc, char* argv[], struct options* options)
     case OPT_CHRONOS_HOSTNAME:
       options->chronos_hostname = std::string(pj_optarg);
 
+    case OPT_CHRONOS_SPROUT_CALLBACK_URI:
+      options->chronos_sprout_callback_uri = std::string(pj_optarg);
+
     case OPT_LISTEN_PORT:
       options->listen_port = atoi(pj_optarg);
       break;
@@ -1991,8 +1996,15 @@ int main(int argc, char* argv[])
   }
   else
   {
+    std::string chronos_callback_uri = opt.chronos_sprout_callback_uri;
+
+    if (chronos_callback_uri == "")
+    {
+      chronos_callback_uri = opt.sprout_hostname;
+    }
+
     chronos_service = opt.chronos_hostname + ":7253";
-    chronos_callback_host = opt.sprout_hostname + ":" + port_str;
+    chronos_callback_host = chronos_callback_uri + ":" + port_str;
   }
 
   TRC_STATUS("Creating connection to Chronos %s using %s as the callback URI",


### PR DESCRIPTION
rather than just using the configured sprout hostname for chronos callbacks.
This allows us to configure chronos to always call back to sprouts in the local
site

Testing done:
 - live tested