### PR TITLE
[Reviewer: RKD] Recognize AKAv2 when choosing stats table for auth

### DIFF
--- a/src/authentication.cpp
+++ b/src/authentication.cpp
@@ -917,12 +917,12 @@ pj_bool_t authenticate_rx_request(pjsip_rx_data* rdata)
     }
     else
     {
-      if (!pj_strcmp2(&credentials->algorithm, "MD5"))
+      if (!pj_strcmp(&credentials->algorithm, &STR_MD5))
       {
         auth_stats_table = auth_stats_tables->sip_digest_auth_tbl;
       }
-      else if ((!pj_strcmp2(&credentials->algorithm, "AKAv1-MD5")) ||
-               (!pj_strcmp2(&credentials->algorithm, "AKAv2-MD5")))
+      else if ((!pj_strcmp(&credentials->algorithm, &STR_AKAV1_MD5)) ||
+               (!pj_strcmp(&credentials->algorithm, &STR_AKAV2_MD5)))
       {
         auth_stats_table = auth_stats_tables->ims_aka_auth_tbl;
       }

--- a/src/authentication.cpp
+++ b/src/authentication.cpp
@@ -921,7 +921,8 @@ pj_bool_t authenticate_rx_request(pjsip_rx_data* rdata)
       {
         auth_stats_table = auth_stats_tables->sip_digest_auth_tbl;
       }
-      else if (!pj_strcmp2(&credentials->algorithm, "AKAv1-MD5"))
+      else if ((!pj_strcmp2(&credentials->algorithm, "AKAv1-MD5")) ||
+               (!pj_strcmp2(&credentials->algorithm, "AKAv2-MD5")))
       {
         auth_stats_table = auth_stats_tables->ims_aka_auth_tbl;
       }


### PR DESCRIPTION
Rob,

As discussed, here's a fix to our AKAv2 support.

I haven't add any new UTs - I had a look, but the current tests fall through to looking at the challenge instead, so it still works. I don't think there's anything sensible to do here. I could send in an authentication request where we've replied invalidly to a challenge (i.e we were challenged with DIGEST, but respond with AKAv2), but that feels wrong. As such, I suspect this fix has no impact in a real deployment.