### PR TITLE
[Reviewer Alex] BGCF Routing by phone number

### DIFF
--- a/src/bgcfsproutlet.cpp
+++ b/src/bgcfsproutlet.cpp
@@ -160,10 +160,22 @@ void BGCFSproutletTsx::on_rx_initial_request(pjsip_msg* req)
   else if ((uri_class == LOCAL_PHONE_NUMBER) ||
            (uri_class == GLOBAL_PHONE_NUMBER))
   {
-    // Find the downstream routes based on the domain - this only matches
-    // any wild card routing set up
-    routing_value = "";
-    bgcf_routes = _bgcf->get_route_from_domain(routing_value, trail());
+    // Try to route based on the phone number first
+    pj_str_t pj_user = PJUtils::user_from_uri(req_uri);
+    routing_value = PJUtils::pj_str_to_string(&pj_user);
+    bgcf_routes = _bgcf->get_route_from_number(routing_value, trail());
+
+    // If there are no matching routes, just route based on the domain - this
+    // only matches any wild card routing set up
+    if (bgcf_routes.empty())
+    {
+      routing_value = "";
+      bgcf_routes = _bgcf->get_route_from_domain(routing_value, trail());
+    }
+    else
+    {
+      routing_with_number = true;
+    }
   }
   else
   {

--- a/src/ut/bgcf_test.cpp
+++ b/src/ut/bgcf_test.cpp
@@ -345,7 +345,7 @@ void BGCFTest::doFailureFlow(BGCFMessage& msg, int st_code)
   inject_msg(msg.get_request());
   ASSERT_EQ(2, txdata_count());
 
-  // We get the 100 Trying from the SproutletProxy, so check this first  
+  // We get the 100 Trying from the SproutletProxy, so check this first
   pjsip_msg* out = current_txdata()->msg;
   RespMatcher(100).matches(out);
   free_txdata();
@@ -356,8 +356,49 @@ void BGCFTest::doFailureFlow(BGCFMessage& msg, int st_code)
   free_txdata();
 }
 
-// Test that a simple Tel URI is picked up by the wild card domain
-TEST_F(BGCFTest, TestSimpleTelURI)
+// Test that a simple Tel URI is picked up by the number route
+TEST_F(BGCFTest, TestSimpleTelURIMatched)
+{
+  add_host_mapping("ut.cw-ngv.com", "10.9.8.7");
+  SCOPED_TRACE("");
+  BGCFMessage msg;
+  msg._toscheme = "tel";
+  msg._to = "+16505551234";
+  msg._todomain = "";
+  list<HeaderMatcher> hdrs;
+  hdrs.push_back(HeaderMatcher("Route", ".*10.0.0.1:5060.*"));
+  doSuccessfulFlow(msg, testing::MatchesRegex(".*16505551234$"), hdrs);
+}
+
+// Tests that a sip: URI with user=phone and no routing number parameter matches
+// on the number route
+TEST_F(BGCFTest, TestSipPhoneNumberUriMatched)
+{
+  add_host_mapping("ut.cw-ngv.com", "10.9.8.7");
+  SCOPED_TRACE("");
+  BGCFMessage msg;
+  msg._requri = "sip:+16505551234@notamatchingdomain;user=phone";
+  list<HeaderMatcher> hdrs;
+  hdrs.push_back(HeaderMatcher("Route", ".*10.0.0.1:5060.*"));
+  doSuccessfulFlow(msg, testing::MatchesRegex("sip:[+]16505551234@notamatchingdomain;user=phone"), hdrs);
+}
+
+// Tests that a SIP URI representing a phone number that doesn't match a number
+// route is picked up by the wildcard domain
+TEST_F(BGCFTest, TestSipPhoneNumberUriNotMatched)
+{
+  add_host_mapping("ut.cw-ngv.com", "10.9.8.7");
+  SCOPED_TRACE("");
+  BGCFMessage msg;
+  msg._requri = "sip:16505551234@notamatchingdomain;user=phone";
+  list<HeaderMatcher> hdrs;
+  hdrs.push_back(HeaderMatcher("Route", ".*10.0.0.2:5060.*"));
+  doSuccessfulFlow(msg, testing::MatchesRegex("sip:16505551234@notamatchingdomain;user=phone"), hdrs);
+}
+
+// Test that a simple Tel URI that doesn't match a route is picked up by the
+// wildcard domain
+TEST_F(BGCFTest, TestSimpleTelURIUnmatched)
 {
   add_host_mapping("ut.cw-ngv.com", "10.9.8.7");
   SCOPED_TRACE("");


### PR DESCRIPTION
Route phone number URIs with no routing number parameter on the phone number.
Previously, they were always routed to the wildcard domain route. Now, try to route on the phone number. If no matching routes found, fall back to the wildcard domain as before.

**Testing done:**
 - unit tests