### PR TITLE
Reviewer MGM: Analytics logs minor fixes

### DIFF
--- a/sprout-base.root/usr/share/clearwater/infrastructure/scripts/create-analytics-syslog-config
+++ b/sprout-base.root/usr/share/clearwater/infrastructure/scripts/create-analytics-syslog-config
@@ -53,7 +53,10 @@ cat > $temp_file << EOF
 \$FileCreateMode 0666
 \$umask 0000
 
-# Define a template that strips the "<analytics>" tag off the front of it.
+# Define a template that strips the "<analytics>" tag off the front of it.  This
+# actually strips 14 characters off the message because we also strip off the
+# leading whitespace that rsyslog adds in order to conform with RFC3164 syslog
+# format, but that we don't want.
 \$template analytics-format,"%msg:14:$%\r\n"
 
 :msg, contains, "<analytics>" /var/log/sprout/analytics.log;analytics-format

--- a/src/analyticslogger.cpp
+++ b/src/analyticslogger.cpp
@@ -77,7 +77,7 @@ void AnalyticsLogger::log_with_tag_and_timestamp(char* log)
           dt.tm_sec,
           (int)(timespec.tv_nsec / 1000000));
 
-  syslog(LOG_INFO, "<analytics> %s %s", log, timestamp);
+  syslog(LOG_INFO, "<analytics> %s %s", timestamp, log);
 }
 
 void AnalyticsLogger::registration(const std::string& aor,
@@ -88,7 +88,7 @@ void AnalyticsLogger::registration(const std::string& aor,
   char buf[BUFFER_SIZE];
 
   snprintf(buf, sizeof(buf),
-           "Registration: USER_URI=%s BINDING_ID=%s CONTACT_URI=%s EXPIRES=%d\n",
+           "Registration: USER_URI=%s BINDING_ID=%s CONTACT_URI=%s EXPIRES=%d",
            aor.c_str(),
            binding_id.c_str(),
            contact.c_str(),
@@ -103,7 +103,7 @@ void AnalyticsLogger::subscription(const std::string& aor,
 {
   char buf[BUFFER_SIZE];
   snprintf(buf, sizeof(buf),
-           "<analytics> Subscription: USER_URI=%s SUBSCRIPTION_ID=%s CONTACT_URI=%s EXPIRES=%d\n",
+           "Subscription: USER_URI=%s SUBSCRIPTION_ID=%s CONTACT_URI=%s EXPIRES=%d",
            aor.c_str(),
            subscription_id.c_str(),
            contact.c_str(),
@@ -116,7 +116,7 @@ void AnalyticsLogger::auth_failure(const std::string& auth,
 {
   char buf[BUFFER_SIZE];
   snprintf(buf, sizeof(buf),
-           "<analytics> Auth-Failure: Private Identity=%s Public Identity=%s\n",
+           "Auth-Failure: Private Identity=%s Public Identity=%s",
            auth.c_str(),
            to.c_str());
   log_with_tag_and_timestamp(buf);
@@ -129,7 +129,7 @@ void AnalyticsLogger::call_connected(const std::string& from,
 {
   char buf[BUFFER_SIZE];
   snprintf(buf, sizeof(buf),
-           "<analytics> Call-Connected: FROM=%s TO=%s CALL_ID=%s\n",
+           "Call-Connected: FROM=%s TO=%s CALL_ID=%s",
            from.c_str(),
            to.c_str(),
            call_id.c_str());
@@ -144,7 +144,7 @@ void AnalyticsLogger::call_not_connected(const std::string& from,
 {
   char buf[BUFFER_SIZE];
   snprintf(buf, sizeof(buf),
-           "<analytics> Call-Not-Connected: FROM=%s TO=%s CALL_ID=%s REASON=%d\n",
+           "Call-Not-Connected: FROM=%s TO=%s CALL_ID=%s REASON=%d",
            from.c_str(),
            to.c_str(),
            call_id.c_str(),
@@ -158,7 +158,7 @@ void AnalyticsLogger::call_disconnected(const std::string& call_id,
 {
   char buf[BUFFER_SIZE];
   snprintf(buf, sizeof(buf),
-           "<analytics> Call-Disconnected: CALL_ID=%s REASON=%d\n",
+           "Call-Disconnected: CALL_ID=%s REASON=%d",
            call_id.c_str(),
            reason);
   log_with_tag_and_timestamp(buf);


### PR DESCRIPTION
I was printing the contents of the log and the timestamp the wrong way around. This also exposed the fact that my logs had an (unnecessary) new line in them, which was now being printed out (as #012).

I've also added a random comment.