### PR TITLE
[Reviewer: Ellie] Add load monitor to the http stacks.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2010,7 +2010,8 @@ int main(int argc, char* argv[])
   // with it.
   HttpStack* http_stack_sig = new HttpStack(opt.http_threads,
                                             exception_handler,
-                                            access_logger);
+                                            access_logger,
+                                            load_monitor);
   try
   {
     http_stack_sig->initialize();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2026,7 +2026,8 @@ int main(int argc, char* argv[])
 
   HttpStack* http_stack_mgmt = new HttpStack(NUM_HTTP_MGMT_THREADS,
                                              exception_handler,
-                                             access_logger);
+                                             access_logger,
+                                             load_monitor);
   try
   {
     http_stack_mgmt->initialize();


### PR DESCRIPTION
In testing https://github.com/Metaswitch/clearwater-infrastructure/pull/393, and investigating why sprout wouldn't build with the hacked in change for forcing 503 returns, i found that there was no load monitor on the signaling http stack. 
This meant that even when overloaded, sprout would not return a 503 to the poll-http script.

To test that this works, i altered https://github.com/Metaswitch/cpp-common/blob/54371f20e89c60a04218bdeebe90d687f26345fc/src/httpstack.cpp#L313 to test `!(_load_monitor->admit_request(trail)`, forcing overload while testing the load monitor.

This has not been tested on a system under significant load
