### PR TITLE
reuse incoming transport

### DIFF
--- a/include/basicproxy.h
+++ b/include/basicproxy.h
@@ -228,6 +228,9 @@ protected:
     /// to additional targets if required.
     pjsip_tx_data* _req;
 
+    /// Pointer to the transport associated with the original request.
+    pjsip_transport* _original_transport;
+
     /// Pointer to the underlying PJSIP UAS transaction.
     pjsip_transaction* _tsx;
 

--- a/include/sproutlet.h
+++ b/include/sproutlet.h
@@ -93,6 +93,13 @@ public:
   ///
   virtual pjsip_msg* original_request() = 0;
 
+  /// Sets the transport on the given message to be the same as on the
+  /// original incoming request.
+  ///
+  /// @param  req          - The request message on which to set the
+  //                         transport.
+  virtual void copy_original_transport(pjsip_msg* req) = 0;
+
   /// Returns the top Route header from the original incoming request.  This
   /// can be inpsected by the Sproutlet, but should not be modified.  Note that
   /// this Route header is removed from the request passed to the Sproutlet on
@@ -352,6 +359,13 @@ protected:
   ///
   pjsip_msg* original_request()
     {return _helper->original_request();}
+
+  /// Sets the transport on this request to be the same as on the original.
+  ///
+  /// @param  req          - The request message on which to set the
+  ///                        transport.
+  void copy_original_transport(pjsip_msg* req)
+    {_helper->copy_original_transport(req);}
 
   /// Returns a URI that could be used to route back to the current Sproutlet.
   /// This URI may contain pre-loaded parameters that should not be modified

--- a/include/sproutletproxy.h
+++ b/include/sproutletproxy.h
@@ -271,6 +271,7 @@ public:
                    Sproutlet* sproutlet,
                    const std::string& sproutlet_alias,
                    pjsip_tx_data* req,
+                   pjsip_transport* original_transport,
                    SAS::TrailId trail_id);
 
   /// Virtual destructor.
@@ -283,6 +284,7 @@ public:
   /// the following.
   void add_to_dialog(const std::string& dialog_id="");
   pjsip_msg* original_request();
+  void copy_original_transport(pjsip_msg*);
   const char* msg_info(pjsip_msg*);
   const pjsip_route_hdr* route_hdr() const;
   const std::string& dialog_id() const;
@@ -343,6 +345,9 @@ private:
   /// is passed to the Sproutlet.
   pjsip_tx_data* _req;
   SNMP::SIPRequestTypes _req_type;
+
+  // Immutable reference to the transport used by the original request.
+  pjsip_transport* _original_transport;
 
   typedef std::unordered_map<const pjsip_msg*, pjsip_tx_data*> Packets;
   Packets _packets;

--- a/src/sproutletproxy.cpp
+++ b/src/sproutletproxy.cpp
@@ -1228,16 +1228,20 @@ void SproutletWrapper::copy_original_transport(pjsip_msg* req)
   // Get the original transport.
   if (_original_transport == NULL)
   {
+    // LCOV_EXCL_START - defensive code not hit in UT
     TRC_WARNING("Sproutlet tried to copy transport from unknown original");
     return;
+    // LCOV_EXCL_STOP
   }
 
   // Get this request's tdata from the map of clones.
   Packets::iterator it = _packets.find(req);
   if (it == _packets.end())
   {
+    // LCOV_EXCL_START - defensive code not hit in UT
     TRC_WARNING("Sproutlet tried to copy transport on an unknown request");
     return;
+    // LCOV_EXCL_STOP
   }
   pjsip_tx_data* tdata = it->second;
 

--- a/src/sproutletproxy.cpp
+++ b/src/sproutletproxy.cpp
@@ -573,6 +573,7 @@ pj_status_t SproutletProxy::UASTsx::init(pjsip_rx_data* rdata)
                                    sproutlet,
                                    alias,
                                    _req,
+                                   _original_transport,
                                    trail());
     }
   }
@@ -827,6 +828,7 @@ void SproutletProxy::UASTsx::schedule_requests()
                                                             sproutlet,
                                                             alias,
                                                             req.req,
+                                                            _original_transport,
                                                             trail());
 
         // Set up the mappings.
@@ -1080,6 +1082,7 @@ SproutletWrapper::SproutletWrapper(SproutletProxy* proxy,
                                    Sproutlet* sproutlet,
                                    const std::string& sproutlet_alias,
                                    pjsip_tx_data* req,
+                                   pjsip_transport* original_transport,
                                    SAS::TrailId trail_id) :
   _proxy(proxy),
   _proxy_tsx(proxy_tsx),
@@ -1089,6 +1092,7 @@ SproutletWrapper::SproutletWrapper(SproutletProxy* proxy,
   _id(""),
   _req(req),
   _req_type(),
+  _original_transport(original_transport),
   _packets(),
   _send_requests(),
   _send_responses(),
@@ -1101,6 +1105,11 @@ SproutletWrapper::SproutletWrapper(SproutletProxy* proxy,
   _pending_timers(),
   _trail_id(trail_id)
 {
+  if (_original_transport != NULL)
+  {
+    pjsip_transport_add_ref(_original_transport);
+  }
+
   _req_type = SNMP::string_to_request_type(_req->msg->line.req.method.name.ptr,
                                            _req->msg->line.req.method.name.slen);
   if (sproutlet != NULL)
@@ -1166,6 +1175,11 @@ SproutletWrapper::~SproutletWrapper()
       pjsip_tx_data_dec_ref(it->second);
     }
   }
+
+  if (_original_transport != NULL)
+  {
+    pjsip_transport_dec_ref(_original_transport);
+  }
 }
 
 const std::string& SproutletWrapper::service_name() const
@@ -1206,6 +1220,33 @@ pjsip_msg* SproutletWrapper::original_request()
   register_tdata(clone);
 
   return clone->msg;
+}
+
+// Sets the transport on this request to be the same as on the original.
+void SproutletWrapper::copy_original_transport(pjsip_msg* req)
+{
+  // Get the original transport.
+  if (_original_transport == NULL)
+  {
+    TRC_WARNING("Sproutlet tried to copy transport from unknown original");
+    return;
+  }
+
+  // Get this request's tdata from the map of clones.
+  Packets::iterator it = _packets.find(req);
+  if (it == _packets.end())
+  {
+    TRC_WARNING("Sproutlet tried to copy transport on an unknown request");
+    return;
+  }
+  pjsip_tx_data* tdata = it->second;
+
+  // Set the transport.
+  pjsip_tpselector tpsel;
+  pj_bzero(&tpsel, sizeof(tpsel));
+  tpsel.type = PJSIP_TPSELECTOR_TRANSPORT;
+  tpsel.u.transport = _original_transport;
+  pjsip_tx_data_set_transport(tdata, &tpsel);
 }
 
 /// Returns a brief message summary.

--- a/src/ut/mocktsxhelper.h
+++ b/src/ut/mocktsxhelper.h
@@ -57,6 +57,7 @@ public:
   SAS::TrailId _trail;
 
   MOCK_METHOD0(original_request, pjsip_msg*());
+  MOCK_METHOD1(copy_original_transport, void(pjsip_msg*));
   MOCK_CONST_METHOD0(route_hdr, const pjsip_route_hdr*());
   MOCK_CONST_METHOD1(get_reflexive_uri, pjsip_sip_uri*(pj_pool_t*));
   MOCK_CONST_METHOD1(is_uri_reflexive, bool(const pjsip_uri*));

--- a/src/ut/sproutletproxy_test.cpp
+++ b/src/ut/sproutletproxy_test.cpp
@@ -595,6 +595,21 @@ public:
   }
 };
 
+class FakeSproutletReusesTransport : public SproutletTsx
+{
+public:
+  FakeSproutletReusesTransport(SproutletTsxHelper* helper) :
+    SproutletTsx(helper)
+  {
+  }
+
+  void on_rx_initial_request(pjsip_msg* req)
+  {
+    copy_original_transport(req);
+    send_request(req);
+  }
+};
+
 class SproutletProxyTest : public SipTest
 {
 public:
@@ -627,6 +642,7 @@ public:
     _sproutlets.push_back(new FakeSproutlet<FakeSproutletTsxDelayAfterRsp<1> >("delayafterrsp", 0, "sip:delayafterrsp.homedomain;transport=tcp", ""));
     _sproutlets.push_back(new FakeSproutlet<FakeSproutletTsxDelayAfterFwd<1> >("delayafterfwd", 0, "sip:delayafterfwd.homedomain;transport=tcp", ""));
     _sproutlets.push_back(new FakeSproutlet<FakeSproutletTsxDummySCSCF>("scscf", 44444, "sip:scscf.homedomain:44444;transport=tcp", "scscf"));
+    _sproutlets.push_back(new FakeSproutlet<FakeSproutletReusesTransport>("transport", 0, "sip:transport.homedomain;transport=tcp", ""));
 
     // Create a host alias.
     std::unordered_set<std::string> host_aliases;
@@ -2327,3 +2343,69 @@ TEST_F(SproutletProxyTest, ServiceExtraction)
   ASSERT_EQ(0, names.size());
 }
 
+TEST_F(SproutletProxyTest, SproutletCopiesOriginalTransport)
+{
+  // Tests standard routing of a request through a Sproutlet that simply
+  // forwards requests and responses and doesn't Record-Route itself - and
+  // that reuses the original transport for onwards messages.
+  pjsip_tx_data* tdata;
+
+  // Create a TCP connection to the listening port.
+  TransportFlow* tp = new TransportFlow(TransportFlow::Protocol::TCP,
+                                        stack_data.scscf_port,
+                                        "10.10.28.1",   // node1.awaydomain
+                                        49152);
+
+  // Inject a request with two Route headers - the first referencing the
+  // transport-copying Sproutlet and the second going back to the sender.
+  Message msg1;
+  msg1._method = "INVITE";
+  msg1._requri = "sip:bob@awaydomain";
+  msg1._from = "sip:alice@homedomain";
+  msg1._to = "sip:bob@awaydomain";
+  msg1._via = tp->to_string(false);
+  msg1._route = "Route: <sip:transport.proxy1.homedomain;transport=TCP;lr>\r\nRoute: <sip:node1.awaydomain;transport=TCP;lr>";
+  inject_msg(msg1.get_request(), tp);
+
+  // Expecting 100 Trying and forwarded INVITE
+  ASSERT_EQ(2, txdata_count());
+
+  // Check the 100 Trying.
+  tdata = current_txdata();
+  RespMatcher(100).matches(tdata->msg);
+  tp->expect_target(tdata);
+  EXPECT_EQ("To: <sip:bob@awaydomain>", get_headers(tdata->msg, "To")); // No tag
+  free_txdata();
+
+  // Request is forwarded to the node in the second Route header, reusing the
+  // incoming transport
+  ASSERT_EQ(1, txdata_count());
+  tdata = current_txdata();
+  expect_target("TCP", "10.10.28.1", 49152, tdata);
+  ReqMatcher("INVITE").matches(tdata->msg);
+
+  // Check the RequestURI has not been altered.
+  EXPECT_EQ("sip:bob@awaydomain", str_uri(tdata->msg->line.req.uri));
+
+  // Check the first Route header has been removed.
+  EXPECT_EQ("Route: <sip:node1.awaydomain;transport=TCP;lr>",
+            get_headers(tdata->msg, "Route"));
+
+  // Check no Record-Route headers have been added.
+  EXPECT_EQ("", get_headers(tdata->msg, "Record-Route"));
+
+  // Send a 200 OK response.
+  inject_msg(respond_to_current_txdata(200));
+
+  // Check the response is forwarded back to the source.
+  ASSERT_EQ(1, txdata_count());
+  tdata = current_txdata();
+  tp->expect_target(tdata);
+  RespMatcher(200).matches(tdata->msg);
+  free_txdata();
+
+  // All done!
+  ASSERT_EQ(0, txdata_count());
+
+  delete tp;
+}

--- a/src/ut/sproutletproxy_test.cpp
+++ b/src/ut/sproutletproxy_test.cpp
@@ -2392,7 +2392,7 @@ TEST_F(SproutletProxyTest, SproutletCopiesOriginalTransport)
     // incoming transport
     ASSERT_EQ(1, txdata_count());
     tdata = current_txdata();
-    tp->expect_target(tdata);
+    tp->expect_target(tdata, true);
     ReqMatcher("INVITE").matches(tdata->msg);
 
     // Send a 200 OK response.


### PR DESCRIPTION
NOT FOR MERGING!

The ugliest part of our transport hacks: re-use incoming transport for outgoing messages.

John dabbled with making this configurable per application server but didn't get this into any sort of useful state, and I'm not convinced that it's the right scope to configure this anyway.  So I've removed that code from this diff.

I think I'd prefer to control this by a global config option whose meaning is basically "we're acting as an app server for a non-IMS call agent" (maybe we can come up with something that doesn't sound _quite_ so specific).  But definitely up for discussion.