### PR TITLE
[Reviewer: Ellie] Handle digests and keys with null bytes in them

### DIFF
--- a/src/authentication.cpp
+++ b/src/authentication.cpp
@@ -315,7 +315,7 @@ pj_status_t user_lookup(pj_pool_t *pool,
       }
 
       cred_info->data_type = PJSIP_CRED_DATA_PLAIN_PASSWD;
-      pj_strdup2(pool, &cred_info->data, xres.c_str());
+      pj_strdup4(pool, &cred_info->data, xres.data(), xres.length());
       TRC_DEBUG("Found AKA XRES = %.*s", cred_info->data.slen, cred_info->data.ptr);
 
       // Use default realm as it isn't specified in the AV.
@@ -493,14 +493,15 @@ void create_challenge(pjsip_digest_credential* credentials,
         // - base64-encode that
         std::string joined = unhex(xres + integritykey + cryptkey);
         std::string formality = "http-digest-akav2-password";
+        unsigned int digest_len;
         unsigned char* digest = HMAC(EVP_md5(),
                                      (unsigned char*)joined.data(),
                                      joined.size(),
                                      (unsigned char*)(formality.data()),
                                      formality.size(),
                                      NULL,
-                                     NULL);
-        std::string password = base64_encode(std::string(reinterpret_cast<char*>(digest)));
+                                     &digest_len);
+        std::string password = base64_encode(std::string((char*) digest, digest_len));
 
         // We hex-decode this when getting it out of memcached later (for
         // consistency with AKAv1) so hex-encode it now.

--- a/src/ut/authentication_test.cpp
+++ b/src/ut/authentication_test.cpp
@@ -206,6 +206,8 @@ class AuthenticationTest : public BaseAuthenticationTest
     ASSERT_EQ(PJ_SUCCESS, ret);
   }
 
+  void TestAKAAuthSuccess(char* key);
+
   static void TearDownTestCase()
   {
     destroy_authentication();
@@ -1311,20 +1313,10 @@ TEST_F(AuthenticationTest, DigestChallengeExpired)
   _hss_connection->delete_result("/impi/6505550001%40homedomain/av?impu=sip%3A6505550001%40homedomain");
 }
 
-TEST_F(AuthenticationTest, AKAAuthSuccess)
+void AuthenticationTest::TestAKAAuthSuccess(char* key)
 {
   // Test a successful AKA authentication flow.
   pjsip_tx_data* tdata;
-
-  // Set up the HSS response for the AV query using a default private user identity.
-  // The keys in this test case are not consistent, but that won't matter for
-  // the purposes of the test as Clearwater never itself runs the MILENAGE
-  // algorithms to generate or extract keys.
-  _hss_connection->set_result("/impi/6505550001%40homedomain/av/aka?impu=sip%3A6505550001%40homedomain",
-                              "{\"aka\":{\"challenge\":\"87654321876543218765432187654321\","
-                              "\"response\":\"12345678123456781234567812345678\","
-                              "\"cryptkey\":\"0123456789abcdef\","
-                              "\"integritykey\":\"fedcba9876543210\"}}");
 
   // Send in a REGISTER request with an authentication header with
   // integrity-protected=no.  This triggers aka authentication.
@@ -1352,7 +1344,7 @@ TEST_F(AuthenticationTest, AKAAuthSuccess)
   // response.
   AuthenticationMessage msg2("REGISTER");
   msg2._algorithm = "AKAv1-MD5";
-  msg2._key = "12345678123456781234567812345678";
+  msg2._key = key;
   msg2._nonce = auth_params["nonce"];
   msg2._opaque = auth_params["opaque"];
   msg2._nc = "00000001";
@@ -1369,6 +1361,35 @@ TEST_F(AuthenticationTest, AKAAuthSuccess)
   _hss_connection->delete_result("/impi/6505550001%40homedomain/av/aka?impu=sip%3A6505550001%40homedomain");
 }
 
+TEST_F(AuthenticationTest, AKAAuthSuccess)
+{
+  // Set up the HSS response for the AV query using a default private user identity.
+  // The keys in this test case are not consistent, but that won't matter for
+  // the purposes of the test as Clearwater never itself runs the MILENAGE
+  // algorithms to generate or extract keys.
+  _hss_connection->set_result("/impi/6505550001%40homedomain/av/aka?impu=sip%3A6505550001%40homedomain",
+                              "{\"aka\":{\"challenge\":\"87654321876543218765432187654321\","
+                              "\"response\":\"12345678123456781234567812345678\","
+                              "\"cryptkey\":\"0123456789abcdef\","
+                              "\"integritykey\":\"fedcba9876543210\"}}");
+
+  AuthenticationTest::TestAKAAuthSuccess("12345678123456781234567812345678");
+}
+
+TEST_F(AuthenticationTest, AKAAuthSuccessWithNullBytes)
+{
+  // Set up the HSS response for the AV query using a default private user identity.
+  // The keys in this test case are not consistent, but that won't matter for
+  // the purposes of the test as Clearwater never itself runs the MILENAGE
+  // algorithms to generate or extract keys.
+  _hss_connection->set_result("/impi/6505550001%40homedomain/av/aka?impu=sip%3A6505550001%40homedomain",
+                              "{\"aka\":{\"challenge\":\"87654321876543218765432187654321\","
+                              "\"response\":\"12345678000000000000000012345678\","
+                              "\"cryptkey\":\"0123456789abcdef\","
+                              "\"integritykey\":\"fedcba9876543210\"}}");
+
+  AuthenticationTest::TestAKAAuthSuccess("12345678000000000000000012345678");
+}
 
 TEST_F(AuthenticationTest, AKAv2AuthSuccess)
 {

--- a/src/ut/authentication_test.cpp
+++ b/src/ut/authentication_test.cpp
@@ -1361,6 +1361,7 @@ void AuthenticationTest::TestAKAAuthSuccess(char* key)
   _hss_connection->delete_result("/impi/6505550001%40homedomain/av/aka?impu=sip%3A6505550001%40homedomain");
 }
 
+// Test that a normal AKA authenticated registration succeeds.
 TEST_F(AuthenticationTest, AKAAuthSuccess)
 {
   // Set up the HSS response for the AV query using a default private user identity.
@@ -1376,6 +1377,9 @@ TEST_F(AuthenticationTest, AKAAuthSuccess)
   AuthenticationTest::TestAKAAuthSuccess("12345678123456781234567812345678");
 }
 
+// Test that a normal AKA authenticated registration succeeds, when the response
+// contains null bytes. This was previously seen to cause incorrect behaviour
+// when the null bytes were hex decoded and placed in a string.
 TEST_F(AuthenticationTest, AKAAuthSuccessWithNullBytes)
 {
   // Set up the HSS response for the AV query using a default private user identity.


### PR DESCRIPTION
This fixes #1599.

We fix this by using the known string length, rather than just up until the first null byte when we have decoded the hex from Homestead. I've added a UT for handling null bytes in a response, which fails before this fix, and succeeds afterwards.

This also fixes the other issue Rob spotted, where if the digest includes a null byte, we'll fail to handle the request correctly. It also fixes an issue where the buffer given to us by OpenSSL isn't totally guaranteed to be null terminated (but probably is).

This needs https://github.com/Metaswitch/pjsip-upstream/pull/52 for the pj_strdup4 function.