### PR TITLE
Vary priority of bindings, for code coverage

### DIFF
--- a/src/ut/contact_filtering_test.cpp
+++ b/src/ut/contact_filtering_test.cpp
@@ -971,6 +971,11 @@ TEST_F(ContactFilteringFullStackTest, LotsOfBindings)
     {
       binding->_params["+sip.other2"] = "#5";
     }
+    if (ii % 7 == 0)
+    {
+      binding->_priority += ii;
+    }
+
     binding->_expires = ii * 100;
   }
 


### PR DESCRIPTION
Merging #1597 damaged code coverage (which is very interesting... I guess the old bogus code was being optimised away and then nothing could tell that we weren't hitting it).

This tweak varies the priority in some unit tests so that we do now hit all code branches.  

NB Per the existing testcases, we don't actually check that the comparison gives the right answer!  I propose that fixing that is out of scope for this pull request.

Alex - sending to you since you merged #1597 for me.