### PR TITLE
[Reviewer: Seb] Check the sprout_hostname correctly

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1140,10 +1140,17 @@ static pj_status_t init_options(int argc, char* argv[], struct options* options)
     case OPT_SPROUT_HOSTNAME:
       options->sprout_hostname = std::string(pj_optarg);
 
-      if (Utils::parse_ip_address(options->sprout_hostname) !=
-          Utils::IPAddressType::INVALID)
+      if (Utils::parse_ip_address(options->sprout_hostname) ==
+          Utils::IPAddressType::INVALID_WITH_PORT)
       {
-        TRC_ERROR("The sprout hostname (%s) can't be an IP address",
+        TRC_ERROR("The sprout hostname (%s) must not include a port",
+                  options->sprout_hostname.c_str());
+        return -1;
+      }
+      else if (Utils::parse_ip_address(options->sprout_hostname) !=
+               Utils::IPAddressType::INVALID)
+      {
+        TRC_ERROR("The sprout hostname (%s) must not be an IP address",
                   options->sprout_hostname.c_str());
         return -1;
       }


### PR DESCRIPTION
Validate the sprout_hostname config option correctly (must not have a port, must not be an IP address)

Fixes issue #1631 