### PR TITLE
[REVIEWER: Ellie] Add a stat to track forked INVITEs due to multiple bindings.

### DIFF
--- a/include/scscfsproutlet.h
+++ b/include/scscfsproutlet.h
@@ -228,9 +228,9 @@ private:
   SNMP::CounterTable* _routed_by_preloaded_route_tbl = NULL;
   SNMP::CounterTable* _invites_cancelled_before_1xx_tbl = NULL;
   SNMP::CounterTable* _invites_cancelled_after_1xx_tbl = NULL;
-  SNMP::CounterTable* _forked_request_tbl = NULL;
   SNMP::EventAccumulatorTable* _video_session_setup_time_tbl = NULL;
   SNMP::EventAccumulatorTable* _audio_session_setup_time_tbl = NULL;
+  SNMP::CounterTable* _forked_invite_tbl = NULL;
 
   AsCommunicationTracker* _sess_term_as_tracker;
   AsCommunicationTracker* _sess_cont_as_tracker;

--- a/include/scscfsproutlet.h
+++ b/include/scscfsproutlet.h
@@ -228,6 +228,7 @@ private:
   SNMP::CounterTable* _routed_by_preloaded_route_tbl = NULL;
   SNMP::CounterTable* _invites_cancelled_before_1xx_tbl = NULL;
   SNMP::CounterTable* _invites_cancelled_after_1xx_tbl = NULL;
+  SNMP::CounterTable* _forked_request_tbl = NULL;
   SNMP::EventAccumulatorTable* _video_session_setup_time_tbl = NULL;
   SNMP::EventAccumulatorTable* _audio_session_setup_time_tbl = NULL;
 

--- a/src/scscfsproutlet.cpp
+++ b/src/scscfsproutlet.cpp
@@ -99,11 +99,12 @@ SCSCFSproutlet::SCSCFSproutlet(const std::string& scscf_name,
                                                                  "1.2.826.0.1.1578918.9.3.32");
   _invites_cancelled_after_1xx_tbl = SNMP::CounterTable::create("invites_cancelled_after_1xx",
                                                                 "1.2.826.0.1.1578918.9.3.33");
+  _forked_request_tbl = SNMP::CounterTable::create("scscf_forked_requests",
+                                                   "1.2.826.0.1.1578918.9.3.36");
   _audio_session_setup_time_tbl = SNMP::EventAccumulatorTable::create("scscf_audio_session_setup_time",
                                                                       "1.2.826.0.1.1578918.9.3.34");
   _video_session_setup_time_tbl = SNMP::EventAccumulatorTable::create("scscf_video_session_setup_time",
                                                                       "1.2.826.0.1.1578918.9.3.35");
-
 }
 
 
@@ -114,6 +115,7 @@ SCSCFSproutlet::~SCSCFSproutlet()
   delete _routed_by_preloaded_route_tbl;
   delete _invites_cancelled_before_1xx_tbl;
   delete _invites_cancelled_after_1xx_tbl;
+  delete _forked_request_tbl;
   delete _audio_session_setup_time_tbl;
   delete _video_session_setup_time_tbl;
 }
@@ -1662,6 +1664,11 @@ void SCSCFSproutletTsx::route_to_ue_bindings(pjsip_msg* req)
       // in case we get a 430 Flow Failed response.
       int fork_id = send_request(to_send);
       _target_bindings.insert(std::make_pair(fork_id, targets[ii].binding_id));
+
+      if (ii != 0)
+      {
+        _scscf->_forked_request_tbl->increment();
+      }
     }
   }
 }

--- a/src/scscfsproutlet.cpp
+++ b/src/scscfsproutlet.cpp
@@ -103,8 +103,8 @@ SCSCFSproutlet::SCSCFSproutlet(const std::string& scscf_name,
                                                                       "1.2.826.0.1.1578918.9.3.34");
   _video_session_setup_time_tbl = SNMP::EventAccumulatorTable::create("scscf_video_session_setup_time",
                                                                       "1.2.826.0.1.1578918.9.3.35");
-  _forked_request_tbl = SNMP::CounterTable::create("scscf_forked_requests",
-                                                   "1.2.826.0.1.1578918.9.3.36");
+  _forked_invite_tbl = SNMP::CounterTable::create("scscf_forked_invites",
+                                                  "1.2.826.0.1.1578918.9.3.36");
 }
 
 
@@ -115,7 +115,7 @@ SCSCFSproutlet::~SCSCFSproutlet()
   delete _routed_by_preloaded_route_tbl;
   delete _invites_cancelled_before_1xx_tbl;
   delete _invites_cancelled_after_1xx_tbl;
-  delete _forked_request_tbl;
+  delete _forked_invite_tbl;
   delete _audio_session_setup_time_tbl;
   delete _video_session_setup_time_tbl;
 }
@@ -1665,9 +1665,9 @@ void SCSCFSproutletTsx::route_to_ue_bindings(pjsip_msg* req)
       int fork_id = send_request(to_send);
       _target_bindings.insert(std::make_pair(fork_id, targets[ii].binding_id));
 
-      if (ii != 0)
+      if ((_req_type == PJSIP_INVITE_METHOD) && (ii != 0))
       {
-        _scscf->_forked_request_tbl->increment();
+        _scscf->_forked_invite_tbl->increment();
       }
     }
   }

--- a/src/scscfsproutlet.cpp
+++ b/src/scscfsproutlet.cpp
@@ -99,12 +99,12 @@ SCSCFSproutlet::SCSCFSproutlet(const std::string& scscf_name,
                                                                  "1.2.826.0.1.1578918.9.3.32");
   _invites_cancelled_after_1xx_tbl = SNMP::CounterTable::create("invites_cancelled_after_1xx",
                                                                 "1.2.826.0.1.1578918.9.3.33");
-  _forked_request_tbl = SNMP::CounterTable::create("scscf_forked_requests",
-                                                   "1.2.826.0.1.1578918.9.3.36");
   _audio_session_setup_time_tbl = SNMP::EventAccumulatorTable::create("scscf_audio_session_setup_time",
                                                                       "1.2.826.0.1.1578918.9.3.34");
   _video_session_setup_time_tbl = SNMP::EventAccumulatorTable::create("scscf_video_session_setup_time",
                                                                       "1.2.826.0.1.1578918.9.3.35");
+  _forked_request_tbl = SNMP::CounterTable::create("scscf_forked_requests",
+                                                   "1.2.826.0.1.1578918.9.3.36");
 }
 
 

--- a/src/scscfsproutlet.cpp
+++ b/src/scscfsproutlet.cpp
@@ -104,7 +104,7 @@ SCSCFSproutlet::SCSCFSproutlet(const std::string& scscf_name,
   _video_session_setup_time_tbl = SNMP::EventAccumulatorTable::create("scscf_video_session_setup_time",
                                                                       "1.2.826.0.1.1578918.9.3.35");
   _forked_invite_tbl = SNMP::CounterTable::create("scscf_forked_invites",
-                                                  "1.2.826.0.1.1578918.9.3.36");
+                                                  "1.2.826.0.1.1578918.9.3.38");
 }
 
 
@@ -1667,6 +1667,8 @@ void SCSCFSproutletTsx::route_to_ue_bindings(pjsip_msg* req)
 
       if ((_req_type == PJSIP_INVITE_METHOD) && (ii != 0))
       {
+        // Increment stat tracking the number of additional INVITEs generated
+        // due to there being multiple registered targets.
         _scscf->_forked_invite_tbl->increment();
       }
     }

--- a/src/ut/scscf_test.cpp
+++ b/src/ut/scscf_test.cpp
@@ -299,7 +299,7 @@ public:
   {
     _log_traffic = PrintingTestLogger::DEFAULT.isPrinting(); // true to see all traffic
     _local_data_store->flush_all();  // start from a clean slate on each test
-    
+
     _hss_connection = new FakeHSSConnection();
 
 
@@ -1267,6 +1267,9 @@ TEST_F(SCSCFTest, TestSimpleMainline)
   // getting tracked.
   EXPECT_EQ(0, ((SNMP::FakeEventAccumulatorTable*)_scscf_sproutlet->_audio_session_setup_time_tbl)->_count);
   EXPECT_EQ(0, ((SNMP::FakeEventAccumulatorTable*)_scscf_sproutlet->_video_session_setup_time_tbl)->_count);
+
+  // It also shouldn't result in any forked INVITEs
+  EXPECT_EQ(0, ((SNMP::FakeCounterTable*)_scscf_sproutlet->_forked_request_tbl)->_count);
 }
 
 // Send a request where the URI is for the same port as a Sproutlet,
@@ -1476,14 +1479,14 @@ TEST_F(SCSCFTest, TestTelURIWildcard)
   tpAS1.expect_target(tdata, false);
   EXPECT_THAT(get_headers(out, "Route"),
               testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;service=scscf>"));
-  
+
   string fresp1 = respond_to_txdata(tdata, 404);
   inject_msg(fresp1, &tpAS1);
   ASSERT_EQ(3, txdata_count());
   free_txdata();
   free_txdata();
   ASSERT_EQ(1, txdata_count());
-  
+
   // 100 Trying goes back to bono
   out = current_txdata()->msg;
   RespMatcher(404).matches(out);
@@ -2083,6 +2086,9 @@ TEST_F(SCSCFTest, TestForkedFlow)
 
   // All done!
   expect_all_tsx_done();
+
+  // Ensure we count the forked INVITEs
+  EXPECT_EQ(2, ((SNMP::FakeCounterTable*)_scscf_sproutlet->_forked_request_tbl)->_count);
 }
 
 TEST_F(SCSCFTest, TestForkedFlow2)
@@ -2145,6 +2151,9 @@ TEST_F(SCSCFTest, TestForkedFlow2)
 
   // All done!
   expect_all_tsx_done();
+
+  // Ensure we count the forked INVITEs
+  EXPECT_EQ(2, ((SNMP::FakeCounterTable*)_scscf_sproutlet->_forked_request_tbl)->_count);
 }
 
 TEST_F(SCSCFTest, TestForkedFlow3)
@@ -2195,6 +2204,9 @@ TEST_F(SCSCFTest, TestForkedFlow3)
 
   // All done!
   expect_all_tsx_done();
+
+  // Ensure we count the forked INVITEs
+  EXPECT_EQ(2, ((SNMP::FakeCounterTable*)_scscf_sproutlet->_forked_request_tbl)->_count);
 }
 
 TEST_F(SCSCFTest, TestForkedFlow4)
@@ -2263,6 +2275,9 @@ TEST_F(SCSCFTest, TestForkedFlow4)
 
   // All done!
   expect_all_tsx_done();
+
+  // Ensure we count the forked INVITEs
+  EXPECT_EQ(2, ((SNMP::FakeCounterTable*)_scscf_sproutlet->_forked_request_tbl)->_count);
 }
 
 // Test SIP Message flows

--- a/src/ut/scscf_test.cpp
+++ b/src/ut/scscf_test.cpp
@@ -1269,7 +1269,7 @@ TEST_F(SCSCFTest, TestSimpleMainline)
   EXPECT_EQ(0, ((SNMP::FakeEventAccumulatorTable*)_scscf_sproutlet->_video_session_setup_time_tbl)->_count);
 
   // It also shouldn't result in any forked INVITEs
-  EXPECT_EQ(0, ((SNMP::FakeCounterTable*)_scscf_sproutlet->_forked_request_tbl)->_count);
+  EXPECT_EQ(0, ((SNMP::FakeCounterTable*)_scscf_sproutlet->_forked_invite_tbl)->_count);
 }
 
 // Send a request where the URI is for the same port as a Sproutlet,
@@ -2088,7 +2088,7 @@ TEST_F(SCSCFTest, TestForkedFlow)
   expect_all_tsx_done();
 
   // Ensure we count the forked INVITEs
-  EXPECT_EQ(2, ((SNMP::FakeCounterTable*)_scscf_sproutlet->_forked_request_tbl)->_count);
+  EXPECT_EQ(2, ((SNMP::FakeCounterTable*)_scscf_sproutlet->_forked_invite_tbl)->_count);
 }
 
 TEST_F(SCSCFTest, TestForkedFlow2)
@@ -2153,7 +2153,7 @@ TEST_F(SCSCFTest, TestForkedFlow2)
   expect_all_tsx_done();
 
   // Ensure we count the forked INVITEs
-  EXPECT_EQ(2, ((SNMP::FakeCounterTable*)_scscf_sproutlet->_forked_request_tbl)->_count);
+  EXPECT_EQ(2, ((SNMP::FakeCounterTable*)_scscf_sproutlet->_forked_invite_tbl)->_count);
 }
 
 TEST_F(SCSCFTest, TestForkedFlow3)
@@ -2206,7 +2206,7 @@ TEST_F(SCSCFTest, TestForkedFlow3)
   expect_all_tsx_done();
 
   // Ensure we count the forked INVITEs
-  EXPECT_EQ(2, ((SNMP::FakeCounterTable*)_scscf_sproutlet->_forked_request_tbl)->_count);
+  EXPECT_EQ(2, ((SNMP::FakeCounterTable*)_scscf_sproutlet->_forked_invite_tbl)->_count);
 }
 
 TEST_F(SCSCFTest, TestForkedFlow4)
@@ -2277,7 +2277,7 @@ TEST_F(SCSCFTest, TestForkedFlow4)
   expect_all_tsx_done();
 
   // Ensure we count the forked INVITEs
-  EXPECT_EQ(2, ((SNMP::FakeCounterTable*)_scscf_sproutlet->_forked_request_tbl)->_count);
+  EXPECT_EQ(2, ((SNMP::FakeCounterTable*)_scscf_sproutlet->_forked_invite_tbl)->_count);
 }
 
 // Test SIP Message flows


### PR DESCRIPTION
This is supposed to track the number of additional INVITEs sent because a target has multiple bindings, e.g. if a user has 3 registered devices then the stat is incremented twice per call, and it is not incremented if a user has only 1 registered device.