### PR TITLE
[Reviewer: Graeme] Allow Mangelwurzel to handle REGISTER requests

### DIFF
--- a/docs/Mangelwurzel.md
+++ b/docs/Mangelwurzel.md
@@ -8,7 +8,7 @@ Mangelwurzel is installed on top of sprout-base. It can be installed through the
 
 ## Invocation and configuration
 
-Mangelwurzel is invoked and configured through iFCs. The URI must contain mangelwurzel (and must obviously be routable to the mangelwurzel node). Typically it would be either sip:mangelwurzel@homedomain or sip:mangelwurzel@\<mangelwurzel_addr\>. There are also a number of optional parameters encoded on the URI which define mangelwurzel's configuration. They are as follows:
+Mangelwurzel is invoked and configured through iFCs. The URI must contain mangelwurzel (and must obviously be routable to the mangelwurzel node). Typically it would be either sip:mangelwurzel.homedomain or sip:mangelwurzel@\<mangelwurzel_addr\>. There are also a number of optional parameters encoded on the URI which define mangelwurzel's configuration. They are as follows:
 
 * dialog – Present if the dialog identifiers (From tag, To tag and call ID) should be changed.
 * req-uri – Present if the Request URI (and Contact URI) of this request should be changed.

--- a/docs/Mangelwurzel.md
+++ b/docs/Mangelwurzel.md
@@ -8,7 +8,7 @@ Mangelwurzel is installed on top of sprout-base. It can be installed through the
 
 ## Invocation and configuration
 
-Mangelwurzel is invoked and configured through iFCs. The URI must contain mangelwurzel (and must obviously be routable to the mangelwurzel node). Typically it would be either sip:mangelwurzel.homedomain or sip:mangelwurzel@\<mangelwurzel_addr\>. There are also a number of optional parameters encoded on the URI which define mangelwurzel's configuration. They are as follows:
+Mangelwurzel is invoked and configured through iFCs. The URI must contain mangelwurzel (and must obviously be routable to the mangelwurzel node). Typically it would be either sip:mangelwurzel@homedomain or sip:mangelwurzel@\<mangelwurzel_addr\>. There are also a number of optional parameters encoded on the URI which define mangelwurzel's configuration. They are as follows:
 
 * dialog – Present if the dialog identifiers (From tag, To tag and call ID) should be changed.
 * req-uri – Present if the Request URI (and Contact URI) of this request should be changed.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1505,20 +1505,6 @@ int main(int argc, char* argv[])
     return 1;
   }
 
-  if ((opt.auth_enabled) && (opt.hss_server == ""))
-  {
-    CL_SPROUT_AUTH_NO_HOMESTEAD.log();
-    TRC_ERROR("Authentication enabled, but no Homestead server specified");
-    return 1;
-  }
-
-  if ((opt.xdm_server != "") && (opt.hss_server == ""))
-  {
-    CL_SPROUT_XDM_NO_HOMESTEAD.log();
-    TRC_ERROR("XDM server configured for services, but no Homestead server specified");
-    return 1;
-  }
-
   if ((opt.pcscf_enabled) && (opt.hss_server != ""))
   {
     TRC_WARNING("Homestead server configured on P-CSCF, ignoring");

--- a/src/mangelwurzel/mangelwurzel.cpp
+++ b/src/mangelwurzel/mangelwurzel.cpp
@@ -147,6 +147,16 @@ SproutletTsx* Mangelwurzel::get_tsx(SproutletTsxHelper* helper,
 /// - It can mangle the Record-Route headers URIs.
 void MangelwurzelTsx::on_rx_initial_request(pjsip_msg* req)
 {
+  // If Mangelwurzel receives an INVITE we would to respond with a 200OK
+  if (req->line.req.method.id == PJSIP_REGISTER_METHOD)
+  {
+    pjsip_status_code status_code = PJSIP_SC_OK;
+    pjsip_msg* rsp = create_response(req, status_code);
+    send_response(req);
+    free_msg(req);
+    return;
+  }
+
   pj_pool_t* pool = get_pool(req);
 
   // Get mangewurzel's route header and clone the URI. We use this in the SAS

--- a/src/mangelwurzel/mangelwurzel.cpp
+++ b/src/mangelwurzel/mangelwurzel.cpp
@@ -66,71 +66,71 @@ SproutletTsx* Mangelwurzel::get_tsx(SproutletTsxHelper* helper,
   // Find the mangewurzel Route header, parse the parameters and use them to
   // build a Config object. Then construct the MangelwurzelTsx.
   pjsip_route_hdr* route_hdr = (pjsip_route_hdr*)helper->route_hdr();
+  pjsip_sip_uri* mangelwurzel_uri;
 
   if (route_hdr != NULL)
   {
-    pjsip_sip_uri* route_hdr_uri = (pjsip_sip_uri*)route_hdr->name_addr.uri;
-
-    if (pjsip_param_find(&route_hdr_uri->other_param, &DIALOG_PARAM) != NULL)
-    {
-      config.dialog = true;
-    }
-    if (pjsip_param_find(&route_hdr_uri->other_param, &REQ_URI_PARAM) != NULL)
-    {
-      config.req_uri = true;
-    }
-    if (pjsip_param_find(&route_hdr_uri->other_param, &TO_PARAM) != NULL)
-    {
-      config.to = true;
-    }
-    if (pjsip_param_find(&route_hdr_uri->other_param, &ROUTES_PARAM) != NULL)
-    {
-      config.routes = true;
-    }
-    if (pjsip_param_find(&route_hdr_uri->other_param, &DOMAIN_PARAM) != NULL)
-    {
-      config.change_domain = true;
-    }
-    if (pjsip_param_find(&route_hdr_uri->other_param, &ORIG_PARAM) != NULL)
-    {
-      config.orig = true;
-    }
-    if (pjsip_param_find(&route_hdr_uri->other_param, &OOTB_PARAM) != NULL)
-    {
-      config.ootb = true;
-    }
-
-    // The mangalgorithm defaults to ROT_13, so only change it if REVERSE is
-    // specified, but raise a log if an invalid mangalgorithm is specified.
-    pjsip_param* mangalgorithm_param =
-      pjsip_param_find(&route_hdr_uri->other_param,
-                       &MANGALGORITHM_PARAM);
-    if (mangalgorithm_param != NULL)
-    {
-      std::string mangalgorithm =
-        PJUtils::pj_str_to_string(&mangalgorithm_param->value);
-
-      if (mangalgorithm == REVERSE_MANGALGORITHM)
-      {
-        config.mangalgorithm = MangelwurzelTsx::REVERSE;
-      }
-      else if (mangalgorithm != ROT_13_MANGALGORITHM)
-      {
-        TRC_ERROR("Invalid mangalgorithm specified: %s",
-                  mangalgorithm.c_str());
-        SAS::Event event(helper->trail(), SASEvent::INVALID_MANGALGORITHM, 0);
-        event.add_var_param(mangalgorithm);
-        SAS::report_event(event);
-      }
-    }
-
-    return new MangelwurzelTsx(helper, config);
+    mangelwurzel_uri = (pjsip_sip_uri*)route_hdr->name_addr.uri;
   }
   else
   {
-    TRC_DEBUG("Failed to find Route header - not invoking mangelwurzel");
-    return NULL;
+    mangelwurzel_uri = (pjsip_sip_uri*)req->line.req.uri;
   }
+
+  if (pjsip_param_find(&mangelwurzel_uri->other_param, &DIALOG_PARAM) != NULL)
+  {
+    config.dialog = true;
+  }
+  if (pjsip_param_find(&mangelwurzel_uri->other_param, &REQ_URI_PARAM) != NULL)
+  {
+    config.req_uri = true;
+  }
+  if (pjsip_param_find(&mangelwurzel_uri->other_param, &TO_PARAM) != NULL)
+  {
+    config.to = true;
+  }
+  if (pjsip_param_find(&mangelwurzel_uri->other_param, &ROUTES_PARAM) != NULL)
+  {
+    config.routes = true;
+  }
+  if (pjsip_param_find(&mangelwurzel_uri->other_param, &DOMAIN_PARAM) != NULL)
+  {
+    config.change_domain = true;
+  }
+  if (pjsip_param_find(&mangelwurzel_uri->other_param, &ORIG_PARAM) != NULL)
+  {
+    config.orig = true;
+  }
+  if (pjsip_param_find(&mangelwurzel_uri->other_param, &OOTB_PARAM) != NULL)
+  {
+    config.ootb = true;
+  }
+
+  // The mangalgorithm defaults to ROT_13, so only change it if REVERSE is
+  // specified, but raise a log if an invalid mangalgorithm is specified.
+  pjsip_param* mangalgorithm_param =
+    pjsip_param_find(&mangelwurzel_uri->other_param,
+                     &MANGALGORITHM_PARAM);
+  if (mangalgorithm_param != NULL)
+  {
+    std::string mangalgorithm =
+      PJUtils::pj_str_to_string(&mangalgorithm_param->value);
+
+    if (mangalgorithm == REVERSE_MANGALGORITHM)
+    {
+      config.mangalgorithm = MangelwurzelTsx::REVERSE;
+    }
+    else if (mangalgorithm != ROT_13_MANGALGORITHM)
+    {
+      TRC_ERROR("Invalid mangalgorithm specified: %s",
+                mangalgorithm.c_str());
+      SAS::Event event(helper->trail(), SASEvent::INVALID_MANGALGORITHM, 0);
+      event.add_var_param(mangalgorithm);
+      SAS::report_event(event);
+    }
+  }
+
+  return new MangelwurzelTsx(helper, config);
 }
 
 /// Mangelwurzel receives an initial request. It will Record-Route itself,

--- a/src/mangelwurzel/mangelwurzel.cpp
+++ b/src/mangelwurzel/mangelwurzel.cpp
@@ -147,19 +147,19 @@ SproutletTsx* Mangelwurzel::get_tsx(SproutletTsxHelper* helper,
 /// - It can mangle the Record-Route headers URIs.
 void MangelwurzelTsx::on_rx_initial_request(pjsip_msg* req)
 {
-  // If Mangelwurzel receives an INVITE we would to respond with a 200OK
+  // If Mangelwurzel receives a REGISTER, we need to respond with a 200 OK
+  // rather than mangling the request and forwarding it on.
   if (req->line.req.method.id == PJSIP_REGISTER_METHOD)
   {
-    pjsip_status_code status_code = PJSIP_SC_OK;
-    pjsip_msg* rsp = create_response(req, status_code);
+    pjsip_msg* rsp = create_response(req, PJSIP_SC_OK);
     send_response(rsp);
-    free_msg(rsp);
+    free_msg(req);
     return;
   }
 
   pj_pool_t* pool = get_pool(req);
 
-  // Get mangewurzel's route header and clone the URI. We use this in the SAS
+  // Get Mangelwurzel's route header and clone the URI. We use this in the SAS
   // event logging that we've received a request, and then we use it to
   // Record-Route ourselves.
   const pjsip_route_hdr* mangelwurzel_route_hdr = route_hdr();

--- a/src/mangelwurzel/mangelwurzel.cpp
+++ b/src/mangelwurzel/mangelwurzel.cpp
@@ -152,8 +152,8 @@ void MangelwurzelTsx::on_rx_initial_request(pjsip_msg* req)
   {
     pjsip_status_code status_code = PJSIP_SC_OK;
     pjsip_msg* rsp = create_response(req, status_code);
-    send_response(req);
-    free_msg(req);
+    send_response(rsp);
+    free_msg(rsp);
     return;
   }
 

--- a/src/mangelwurzel/ut/mangelwurzel_test.cpp
+++ b/src/mangelwurzel/ut/mangelwurzel_test.cpp
@@ -46,6 +46,7 @@ using namespace std;
 using testing::InSequence;
 using testing::Return;
 using testing::ReturnNull;
+using testing::_;
 
 /// Fixture for MangelwurzelTest.
 ///
@@ -78,6 +79,7 @@ public:
   {
   public:
     string _requri;
+    string _method;
     string _from;
     string _to;
     string _call_id;
@@ -86,6 +88,7 @@ public:
 
     Message() :
       _requri("sip:6505550001@homedomain"),
+      _method("INVITE"),
       _from("\"6505550000\" <sip:6505550000@homedomain>;tag=12345678"),
       _to("\"6505550001\" <sip:6505550001@homedomain>;tag=87654321"),
       _call_id("0123456789abcdef-10.83.18.38"),
@@ -99,7 +102,7 @@ public:
       char buf[16384];
 
       int n = snprintf(buf, sizeof(buf),
-                       "INVITE %1$s SIP/2.0\r\n"
+                       "%7$s %1$s SIP/2.0\r\n"
                        "Via: SIP/2.0/TCP 10.83.18.38:36530;rport;branch=z9hG4bKPjmo1aimuq33BAI4rjhgQgBr4sY5e9kSPI\r\n"
                        "%5$s"
                        "Max-Forwards: 68\r\n"
@@ -111,12 +114,13 @@ public:
                        "%6$s"
                        "Allow: INVITE, ACK, CANCEL, OPTIONS, BYE, REFER, NOTIFY, MESSAGE, SUBSCRIBE, INFO\r\n"
                        "User-Agent: Cleaarwater UT\r\n",
-                       _requri.c_str(),    // $1
-                       _to.c_str(),        // $2
-                       _from.c_str(),      // $3
-                       _call_id.c_str(),   // $4
-                       _routes.c_str(),    // $5
-                       _extra_hdrs.c_str() // $6
+                       _requri.c_str(),     // $1
+                       _to.c_str(),         // $2
+                       _from.c_str(),       // $3
+                       _call_id.c_str(),    // $4
+                       _routes.c_str(),     // $5
+                       _extra_hdrs.c_str(), // $6
+                       _method.c_str()      // $7
                       );
 
       EXPECT_LT(n, (int)sizeof(buf));
@@ -488,4 +492,38 @@ TEST_F(MangelwurzelTest, InDialogReq)
             get_headers(req, "Route"));
   EXPECT_EQ("", get_headers(req, "Via"));
   EXPECT_THAT(req, ReqUriEquals("sip:1000555056@homedomain"));
+}
+
+
+TEST_F(MangelwurzelTest, REGISTER)
+{
+  // Create a request with an S-CSCF Route header, a Contact header and a
+  // Record-Route header. The request is addressed to a tel URI.
+  Message msg;
+  msg._method = "REGISTER";
+  pjsip_msg* req = parse_msg(msg.get_request());
+
+  // Save off the original request. We expect mangelwurzel to request it later.
+  pjsip_msg* original_req = parse_msg(msg.get_request());
+  EXPECT_CALL(*_helper, original_request()).WillRepeatedly(Return(original_req));
+
+  // Set up the mangelwurzel transaction's config. This is different to the
+  // mainline case in order to test more code paths.
+  MangelwurzelTsx::Config config;
+  config.dialog = true;
+  config.req_uri = true;
+  config.to = true;
+  config.routes = true;
+  config.change_domain = false;
+  config.orig = false;
+  config.ootb = false;
+  config.mangalgorithm = MangelwurzelTsx::REVERSE;
+  MangelwurzelTsx mangelwurzel_tsx(_helper, config);
+
+  // Trigger in dialog request processing in mangelwurzel and catch the request
+  // again when mangelwurzel sends it on.
+  EXPECT_CALL(*_helper, create_response(_, PJSIP_SC_OK, ""));
+  EXPECT_CALL(*_helper, send_response(_));
+  EXPECT_CALL(*_helper, free_msg(req));
+  mangelwurzel_tsx.on_rx_initial_request(req);
 }

--- a/src/mangelwurzel/ut/mangelwurzel_test.cpp
+++ b/src/mangelwurzel/ut/mangelwurzel_test.cpp
@@ -328,22 +328,23 @@ TEST_F(MangelwurzelTest, CreateInvalidMangalgorithm)
 }
 
 /// Test creating a mangelwurzel transaction with no mangelwurzel Route header.
-/// We won't create a transaction.
+/// We should pick up information from the Request-URI.
 TEST_F(MangelwurzelTest, CreateNoRouteHdr)
 {
   Mangelwurzel mangelwurzel("mangelwurzel", 5058, "sip:mangelwurzel.homedomain:5058;transport=tcp");
   Message msg;
+  msg._requri = "sip:mangelwurzel.homedomain;mangalgorithm=reverse";
   pjsip_msg* req = parse_msg(msg.get_request());
 
-  // Check that we don't create a mangelwurzel transaction if we can't find the
-  // mangelwurzel Route header.
   EXPECT_CALL(*_helper, route_hdr()).WillOnce(ReturnNull());
 
   MangelwurzelTsx* mangelwurzel_tsx =
     (MangelwurzelTsx*)mangelwurzel.get_tsx(_helper,
                                            "mangelwurzel",
                                            req);
-  EXPECT_TRUE(mangelwurzel_tsx == NULL);
+  EXPECT_TRUE(mangelwurzel_tsx != NULL);
+  EXPECT_EQ(mangelwurzel_tsx->_config.mangalgorithm, MangelwurzelTsx::REVERSE);
+  delete mangelwurzel_tsx; mangelwurzel_tsx = NULL;
 }
 
 TEST_F(MangelwurzelTest, InitialReq)


### PR DESCRIPTION
This:

* gets Mangelwurzel to respond with 200 OK to REGISTER requests, allowing us to take standard IFCs and swap in Mangelwurzel's URI
* gets Mangelwurzel to recognise itself in the Request-URI as well as the top Route header, as that's how REGISTER requests to app servers are formed (this required changing a lot of indentation, sorry)
* removes two checks in main.cpp that don't make sense (one is that you must have a Homestead unless you set `authentication=N`, which doesn't make sense for app-server-only nodes, and the other is that you must have a Homestead URL if you have a Homer URL, which is fine for Mangelwurzel but doesn't make sense for MMTel AS)
    * there is a check that you must have a Homestead URL if you're an I-CSCF or S-CSCF, so I think these checks are redundant