### PR TITLE
Sproutlet refactor integration

### DIFF
--- a/include/authenticationsproutlet.h
+++ b/include/authenticationsproutlet.h
@@ -60,6 +60,7 @@ extern "C" {
 #include "analyticslogger.h"
 #include "snmp_success_fail_count_table.h"
 #include "cfgoptions.h"
+#include "forwardingsproutlet.h"
 
 typedef std::function<int(pjsip_contact_hdr*, pjsip_expires_hdr*)> get_expiry_for_binding_fn;
 
@@ -141,15 +142,15 @@ private:
 };
 
 
-class AuthenticationSproutletTsx : public SproutletTsx
+class AuthenticationSproutletTsx : public ForwardingSproutletTsx
 {
 public:
   AuthenticationSproutletTsx(SproutletTsxHelper* helper,
+                             const std::string& next_hop_service,
                              AuthenticationSproutlet* sproutlet);
   ~AuthenticationSproutletTsx();
 
   virtual void on_rx_initial_request(pjsip_msg* req) override;
-  virtual void on_rx_in_dialog_request(pjsip_msg* req) override;
 
 protected:
   friend class AuthenticationSproutlet;
@@ -163,8 +164,6 @@ protected:
   int calculate_challenge_expiration_time(pjsip_msg* req);
   bool verify_auth_vector(rapidjson::Document* av,
                           const std::string& impi);
-  void forward_request(pjsip_msg* req);
-
   static pj_status_t user_lookup(pj_pool_t *pool,
                                  const pjsip_auth_lookup_cred_param *param,
                                  pjsip_cred_info *cred_info,

--- a/include/authenticationsproutlet.h
+++ b/include/authenticationsproutlet.h
@@ -61,8 +61,7 @@ extern "C" {
 #include "snmp_success_fail_count_table.h"
 #include "cfgoptions.h"
 
-typedef int(*get_expiry_for_binding_fn)(pjsip_contact_hdr* contact,
-                                        pjsip_expires_hdr* expires);
+typedef std::function<int(pjsip_contact_hdr*, pjsip_expires_hdr*)> get_expiry_for_binding_fn;
 
 class AuthenticationSproutletTsx;
 
@@ -72,6 +71,8 @@ public:
   AuthenticationSproutlet(const std::string& name,
                           int port,
                           const std::string& uri,
+                          const std::string& next_hop_service,
+                          const std::list<std::string>& aliases,
                           const std::string& realm_name,
                           ImpiStore* _impi_store,
                           HSSConnection* hss_connection,
@@ -89,6 +90,8 @@ public:
   SproutletTsx* get_tsx(SproutletTsxHelper* helper,
                         const std::string& alias,
                         pjsip_msg* req) override;
+
+  const std::list<std::string> aliases() const override;
 
 private:
   friend class AuthenticationSproutletTsx;
@@ -128,6 +131,13 @@ private:
 
   // Controls when to challenge non-REGISTER messages.
   NonRegisterAuthentication _non_register_auth_mode;
+
+  // The next service to route requests onto if the sproutlet does not handle them
+  // itself.
+  std::string _next_hop_service;
+
+  // Aliases that this sproutlet registers for.
+  const std::list<std::string> _aliases;
 };
 
 

--- a/include/authenticationsproutlet.h
+++ b/include/authenticationsproutlet.h
@@ -149,6 +149,7 @@ public:
   ~AuthenticationSproutletTsx();
 
   virtual void on_rx_initial_request(pjsip_msg* req) override;
+  virtual void on_rx_in_dialog_request(pjsip_msg* req) override;
 
 protected:
   friend class AuthenticationSproutlet;

--- a/include/cfgoptions.h
+++ b/include/cfgoptions.h
@@ -177,5 +177,6 @@ extern ExceptionHandler* exception_handler;
 extern AlarmManager* alarm_manager;
 extern AnalyticsLogger* analytics_logger;
 extern ChronosConnection* chronos_connection;
+extern ImpiStore* impi_store;
 
 #endif

--- a/include/forwardingsproutlet.h
+++ b/include/forwardingsproutlet.h
@@ -40,25 +40,9 @@
 #include "sproutlet.h"
 
 ///
-/// A Sproutlet that by default forwards requests to an upstream sproutlet
+/// A Sproutlet TSX that by default forwards requests to an upstream sproutlet
 /// identified by a service name.
 ///
-
-class ForwardingSproutlet : public Sproutlet
-{
-public:
-  ForwardingSproutlet(const std::string& service_name,
-                      int port,
-                      const std::string& uri,
-                      const std::string& upstream_service_name,
-                      const std::string& service_host="",
-                      SNMP::SuccessFailCountByRequestTypeTable* incoming_sip_transactions_tbl = NULL,
-                      SNMP::SuccessFailCountByRequestTypeTable* outgoing_sip_transactions_tbl = NULL);
-  virtual ~ForwardingSproutlet() {}
-
-private:
-  std::string _upstream_service_name;
-};
 
 class ForwardingSproutletTsx : public SproutletTsx
 {
@@ -70,7 +54,7 @@ public:
   void on_rx_initial_request(pjsip_msg* req) { forward_request(req); }
   void on_rx_in_dialog_request(pjsip_msg* req) { forward_request(req); }
 
-private:
+protected:
   void forward_request(pjsip_msg* req);
 
   std::string _upstream_service_name;

--- a/include/forwardingsproutlet.h
+++ b/include/forwardingsproutlet.h
@@ -1,0 +1,80 @@
+/**
+ * @file forwaringsproutlet.h
+ *
+ * Project Clearwater - IMS in the Cloud
+ * Copyright (C) 2016  Metaswitch Networks Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version, along with the "Special Exception" for use of
+ * the program along with SSL, set forth below. This program is distributed
+ * in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * The author can be reached by email at clearwater@metaswitch.com or by
+ * post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+ *
+ * Special Exception
+ * Metaswitch Networks Ltd  grants you permission to copy, modify,
+ * propagate, and distribute a work formed by combining OpenSSL with The
+ * Software, or a work derivative of such a combination, even if such
+ * copying, modification, propagation, or distribution would otherwise
+ * violate the terms of the GPL. You must comply with the GPL in all
+ * respects for all of the code used other than OpenSSL.
+ * "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+ * Project and licensed under the OpenSSL Licenses, or a work based on such
+ * software and licensed under the OpenSSL Licenses.
+ * "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+ * under which the OpenSSL Project distributes the OpenSSL toolkit software,
+ * as those licenses appear in the file LICENSE-OPENSSL.
+ */
+
+#ifndef FORWARINGSPROUTLET_H__
+#define FORWARINGSPROUTLET_H__
+
+#include "sproutlet.h"
+
+///
+/// A Sproutlet that by default forwards requests to an upstream sproutlet
+/// identified by a service name.
+///
+
+class ForwardingSproutlet : public Sproutlet
+{
+public:
+  ForwardingSproutlet(const std::string& service_name,
+                      int port,
+                      const std::string& uri,
+                      const std::string& upstream_service_name,
+                      const std::string& service_host="",
+                      SNMP::SuccessFailCountByRequestTypeTable* incoming_sip_transactions_tbl = NULL,
+                      SNMP::SuccessFailCountByRequestTypeTable* outgoing_sip_transactions_tbl = NULL);
+  virtual ~ForwardingSproutlet() {}
+
+private:
+  std::string _upstream_service_name;
+};
+
+class ForwardingSproutletTsx : public SproutletTsx
+{
+public:
+  ForwardingSproutletTsx(SproutletTsxHelper* helper,
+                         const std::string& upstream_service_name);
+  virtual ~ForwardingSproutletTsx() {}
+
+  void on_rx_initial_request(pjsip_msg* req) { forward_request(req); }
+  void on_rx_in_dialog_request(pjsip_msg* req) { forward_request(req); }
+
+private:
+  void forward_request(pjsip_msg* req);
+
+  std::string _upstream_service_name;
+};
+
+#endif
+

--- a/include/registrarsproutlet.h
+++ b/include/registrarsproutlet.h
@@ -127,6 +127,7 @@ public:
   ~RegistrarSproutletTsx();
 
   virtual void on_rx_initial_request(pjsip_msg* req);
+  virtual void on_rx_in_dialog_request(pjsip_msg* req);
 
 protected:
   void process_register_request(pjsip_msg* req);

--- a/include/registrarsproutlet.h
+++ b/include/registrarsproutlet.h
@@ -58,6 +58,7 @@
 #include "snmp_success_fail_count_table.h"
 #include "session_expires_helper.h"
 #include "as_communication_tracker.h"
+#include "forwardingsproutlet.h"
 
 class RegistrarSproutletTsx;
 
@@ -119,15 +120,15 @@ private:
 };
 
 
-class RegistrarSproutletTsx : public SproutletTsx
+class RegistrarSproutletTsx : public ForwardingSproutletTsx
 {
 public:
   RegistrarSproutletTsx(SproutletTsxHelper* helper,
+                        const std::string& next_hop_service,
                         RegistrarSproutlet* sproutlet);
   ~RegistrarSproutletTsx();
 
   virtual void on_rx_initial_request(pjsip_msg* req);
-  virtual void on_rx_in_dialog_request(pjsip_msg* req);
 
 protected:
   void process_register_request(pjsip_msg* req);
@@ -148,7 +149,6 @@ protected:
   bool get_private_id(pjsip_msg* req, std::string& id);
   std::string get_binding_id(pjsip_contact_hdr *contact);
   void log_bindings(const std::string& aor_name, SubscriberDataManager::AoR* aor_data);
-  void route_to_subscription(pjsip_msg* req);
 
   RegistrarSproutlet* _sproutlet;
 };

--- a/include/registrarsproutlet.h
+++ b/include/registrarsproutlet.h
@@ -67,6 +67,7 @@ public:
   RegistrarSproutlet(const std::string& name,
                      int port,
                      const std::string& uri,
+                     const std::string& next_hop_service,
                      SubscriberDataManager* reg_sdm,
                      std::vector<SubscriberDataManager*> reg_remote_sdms,
                      HSSConnection* hss_connection,
@@ -83,6 +84,9 @@ public:
   SproutletTsx* get_tsx(SproutletTsxHelper* helper,
                         const std::string& alias,
                         pjsip_msg* req) override;
+
+  int expiry_for_binding(pjsip_contact_hdr* contact,
+                         pjsip_expires_hdr* expires);
 
 private:
   friend class RegistrarSproutletTsx;
@@ -108,6 +112,10 @@ private:
   // registration attempts.
   SNMP::RegistrationStatsTables* _reg_stats_tbls;
   SNMP::RegistrationStatsTables* _third_party_reg_stats_tbls;
+
+  // The next service to route requests onto if the sproutlet does not handle
+  // them itself.
+  std::string _next_hop_service;
 };
 
 
@@ -119,9 +127,6 @@ public:
   ~RegistrarSproutletTsx();
 
   virtual void on_rx_initial_request(pjsip_msg* req);
-  static int expiry_for_binding(pjsip_contact_hdr* contact,
-                                pjsip_expires_hdr* expires,
-                                int max_expires);
 
 protected:
   void process_register_request(pjsip_msg* req);

--- a/include/sproutlet.h
+++ b/include/sproutlet.h
@@ -265,6 +265,18 @@ public:
   ///
   virtual SAS::TrailId trail() const = 0;
 
+  /// Get a URI that routes to the given named service.
+  ///
+  /// @returns            - The new URI.
+  ///
+  /// @param service      - Name of the service to route to.
+  /// @param pool         - Pool to allocate the URI in.
+  /// @param existing_uri - An existing URI to use as a base for the new one.
+  ///                       Parameters from this URI will be preserved if
+  ///                       possible.
+  virtual pjsip_sip_uri* get_uri_for_service(const std::string& service,
+                                             pj_pool_t* pool,
+                                             pjsip_sip_uri* existing_uri) const = 0;
 };
 
 
@@ -555,6 +567,22 @@ protected:
   ///
   SAS::TrailId trail() const
     {return _helper->trail();}
+
+  /// Get a URI that routes to the given named service.
+  ///
+  /// @returns            - The new URI.
+  ///
+  /// @param service      - Name of the service to route to.
+  /// @param pool         - Pool to allocate the URI in.
+  /// @param existing_uri - An existing URI to use as a base for the new one.
+  ///                       Parameters from this URI will be preserved if
+  ///                       possible.
+  pjsip_sip_uri* get_uri_for_service(const std::string& service,
+                                     pj_pool_t* pool,
+                                     pjsip_sip_uri* existing_uri) const
+  {
+    return _helper->get_uri_for_service(service, pool, existing_uri);
+  }
 
 private:
   /// Transaction helper to use for underlying service-related processing.

--- a/include/sproutletproxy.h
+++ b/include/sproutletproxy.h
@@ -107,6 +107,9 @@ protected:
   /// Create a URI that routes to a given Sproutlet.
   pjsip_sip_uri* create_sproutlet_uri(pj_pool_t* pool,
                                       Sproutlet* sproutlet) const;
+  pjsip_sip_uri* create_sproutlet_uri(pj_pool_t* pool,
+                                      const std::string& name,
+                                      pjsip_sip_uri* existing_uri) const;
 
   Sproutlet* service_from_host(pjsip_sip_uri* uri);
   Sproutlet* service_from_user(pjsip_sip_uri* uri);
@@ -300,6 +303,9 @@ public:
   SAS::TrailId trail() const;
   bool is_uri_reflexive(const pjsip_uri*) const;
   pjsip_sip_uri* get_reflexive_uri(pj_pool_t*) const;
+  pjsip_sip_uri* get_uri_for_service(const std::string& service,
+                                     pj_pool_t* pool,
+                                     pjsip_sip_uri* existing_uri) const;
 
 private:
   void rx_request(pjsip_tx_data* req);

--- a/include/sproutletproxy.h
+++ b/include/sproutletproxy.h
@@ -107,9 +107,18 @@ protected:
   /// Create a URI that routes to a given Sproutlet.
   pjsip_sip_uri* create_sproutlet_uri(pj_pool_t* pool,
                                       Sproutlet* sproutlet) const;
-  pjsip_sip_uri* create_sproutlet_uri(pj_pool_t* pool,
-                                      const std::string& name,
-                                      pjsip_sip_uri* existing_uri) const;
+
+  /// Create a URI that routes to the named sproutlet internally within the
+  /// sproutlet proxy.
+  ///
+  /// @param pool         - Pool to allocate the URI from.
+  /// @param name         - The name of the service to invoke.
+  /// @param existing_uri - An existing URI to base the new URI on. Any user
+  ///                       part and URI parameters are copied over to the new
+  ///                       URI.
+  pjsip_sip_uri* create_internal_sproutlet_uri(pj_pool_t* pool,
+                                               const std::string& name,
+                                               pjsip_sip_uri* existing_uri) const;
 
   Sproutlet* service_from_host(pjsip_sip_uri* uri);
   Sproutlet* service_from_user(pjsip_sip_uri* uri);

--- a/include/subscriptionsproutlet.h
+++ b/include/subscriptionsproutlet.h
@@ -65,6 +65,7 @@ public:
   SubscriptionSproutlet(const std::string& name,
                         int port,
                         const std::string& uri,
+                        const std::string& next_hop_service,
                         SubscriberDataManager* sdm,
                         std::vector<SubscriberDataManager*> remote_sdms,
                         HSSConnection* hss_connection,
@@ -72,6 +73,8 @@ public:
                         AnalyticsLogger* analytics_logger,
                         int cfg_max_expires);
   ~SubscriptionSproutlet();
+
+  bool init();
 
   SproutletTsx* get_tsx(SproutletTsxHelper* helper,
                         const std::string& alias,
@@ -96,6 +99,10 @@ private:
 
   /// Default value for a subscription expiry. RFC3860 has this as 3761 seconds.
   static const int DEFAULT_SUBSCRIPTION_EXPIRES = 3761;
+
+  // The next service to route requests onto if the sproutlet does not handle
+  // them itself.
+  std::string _next_hop_service;
 };
 
 

--- a/include/subscriptionsproutlet.h
+++ b/include/subscriptionsproutlet.h
@@ -56,6 +56,7 @@
 #include "snmp_counter_table.h"
 #include "session_expires_helper.h"
 #include "as_communication_tracker.h"
+#include "forwardingsproutlet.h"
 
 class SubscriptionSproutletTsx;
 
@@ -106,10 +107,11 @@ private:
 };
 
 
-class SubscriptionSproutletTsx : public SproutletTsx
+class SubscriptionSproutletTsx : public ForwardingSproutletTsx
 {
 public:
   SubscriptionSproutletTsx(SproutletTsxHelper* helper,
+                           const std::string& next_hop_service,
                            SubscriptionSproutlet* sproutlet);
   ~SubscriptionSproutletTsx();
 
@@ -120,7 +122,6 @@ protected:
   void on_rx_request(pjsip_msg* req);
   bool handle_request(pjsip_msg* req);
   void process_subscription_request(pjsip_msg* req);
-  void route_to_scscf_proxy(pjsip_msg* req);
 
   SubscriberDataManager::AoRPair* write_subscriptions_to_store(
                      SubscriberDataManager* primary_sdm,        ///<store to write to

--- a/src/Makefile
+++ b/src/Makefile
@@ -230,7 +230,7 @@ SPROUT_COMMON_LDFLAGS := -rdynamic \
 # (which sprout-base doesn't), and the plugins are dynamically linked at run
 # time, so GCC won't link in the symbols they need unless we explicitly tell
 # it to.
-sprout_LDFLAGS := ${SPROUT_COMMON_LDFLAGS} \-Wl,--whole-archive -lpjmedia-x86_64-unknown-linux-gnu -Wl,--no-whole-archive `PKG_CONFIG_PATH=../usr/lib/pkgconfig pkg-config --libs libpjproject`
+sprout_LDFLAGS := ${SPROUT_COMMON_LDFLAGS} \-Wl,--whole-archive -lpjsip-x86_64-unknown-linux-gnu -lpjmedia-x86_64-unknown-linux-gnu -Wl,--no-whole-archive `PKG_CONFIG_PATH=../usr/lib/pkgconfig pkg-config --libs libpjproject`
 sprout_test_LDFLAGS := ${SPROUT_COMMON_LDFLAGS} \
                        -lthrift \
                        -lcassandra \

--- a/src/Makefile
+++ b/src/Makefile
@@ -179,6 +179,7 @@ sprout_test_SOURCES := ${SPROUT_COMMON_SOURCES} \
                        bgcf_test.cpp \
                        as_communication_tracker_test.cpp \
                        authenticationsproutlet.cpp \
+                       forwardingsproutlet.cpp \
                        pthread_cond_var_helper.cpp
 
 COVERAGE_ROOT := ..

--- a/src/Makefile
+++ b/src/Makefile
@@ -270,7 +270,7 @@ sprout_mmtel_as.so_SOURCES := mmtel.cpp sproutletappserver.cpp mmtelasplugin.cpp
 sprout_mmtel_as.so_CPPFLAGS := ${PLUGIN_COMMON_CPPFLAGS} -Wno-write-strings
 sprout_mmtel_as.so_LDFLAGS := ${PLUGIN_COMMON_LDFLAGS}
 
-sprout_scscf.so_SOURCES := authenticationsproutlet.cpp registrarsproutlet.cpp subscriptionsproutlet.cpp scscfsproutlet.cpp scscfplugin.cpp
+sprout_scscf.so_SOURCES := authenticationsproutlet.cpp registrarsproutlet.cpp subscriptionsproutlet.cpp scscfsproutlet.cpp scscfplugin.cpp forwardingsproutlet.cpp
 sprout_scscf.so_CPPFLAGS := ${PLUGIN_COMMON_CPPFLAGS}
 sprout_scscf.so_LDFLAGS := ${PLUGIN_COMMON_LDFLAGS}
 

--- a/src/authenticationsproutlet.cpp
+++ b/src/authenticationsproutlet.cpp
@@ -1199,10 +1199,12 @@ void AuthenticationSproutletTsx::on_rx_initial_request(pjsip_msg* req)
 
 void AuthenticationSproutletTsx::forward_request(pjsip_msg* req)
 {
+  const pjsip_route_hdr* route = route_hdr();
+  pjsip_sip_uri* base_uri = (pjsip_sip_uri*)(route ? route->name_addr.uri : nullptr);
   pjsip_sip_uri* uri =
     (pjsip_sip_uri*)get_uri_for_service(_sproutlet->_next_hop_service,
                                         get_pool(req),
-                                        (pjsip_sip_uri*)route_hdr()->name_addr.uri);
+                                        base_uri);
   PJUtils::add_top_route_header(req, uri, get_pool(req));
   send_request(req);
 }

--- a/src/authenticationsproutlet.cpp
+++ b/src/authenticationsproutlet.cpp
@@ -1197,6 +1197,11 @@ void AuthenticationSproutletTsx::on_rx_initial_request(pjsip_msg* req)
   delete impi_obj;
 }
 
+void AuthenticationSproutletTsx::on_rx_in_dialog_request(pjsip_msg* req)
+{
+  return forward_request(req);
+}
+
 void AuthenticationSproutletTsx::forward_request(pjsip_msg* req)
 {
   const pjsip_route_hdr* route = route_hdr();

--- a/src/authenticationsproutlet.cpp
+++ b/src/authenticationsproutlet.cpp
@@ -122,7 +122,7 @@ SproutletTsx* AuthenticationSproutlet::get_tsx(SproutletTsxHelper* helper,
                                                const std::string& alias,
                                                pjsip_msg* req)
 {
-  return new AuthenticationSproutletTsx(helper, this);
+  return new AuthenticationSproutletTsx(helper, _next_hop_service, this);
 }
 
 
@@ -136,8 +136,9 @@ const std::list<std::string> AuthenticationSproutlet::aliases() const
 //
 
 AuthenticationSproutletTsx::AuthenticationSproutletTsx(SproutletTsxHelper* helper,
+                                                       const std::string& next_hop_service,
                                                        AuthenticationSproutlet* auth_sproutlet) :
-  SproutletTsx(helper),
+  ForwardingSproutletTsx(helper, next_hop_service),
   _sproutlet(auth_sproutlet)
 {
 }
@@ -1195,21 +1196,4 @@ void AuthenticationSproutletTsx::on_rx_initial_request(pjsip_msg* req)
 
   delete acr;
   delete impi_obj;
-}
-
-void AuthenticationSproutletTsx::on_rx_in_dialog_request(pjsip_msg* req)
-{
-  return forward_request(req);
-}
-
-void AuthenticationSproutletTsx::forward_request(pjsip_msg* req)
-{
-  const pjsip_route_hdr* route = route_hdr();
-  pjsip_sip_uri* base_uri = (pjsip_sip_uri*)(route ? route->name_addr.uri : nullptr);
-  pjsip_sip_uri* uri =
-    (pjsip_sip_uri*)get_uri_for_service(_sproutlet->_next_hop_service,
-                                        get_pool(req),
-                                        base_uri);
-  PJUtils::add_top_route_header(req, uri, get_pool(req));
-  send_request(req);
 }

--- a/src/authenticationsproutlet.cpp
+++ b/src/authenticationsproutlet.cpp
@@ -115,6 +115,14 @@ bool AuthenticationSproutlet::init()
 
   params.options = PJSIP_AUTH_SRV_IS_PROXY;
   status = pjsip_auth_srv_init2(stack_data.pool, &_auth_srv_proxy, &params);
+
+  if (status != PJ_SUCCESS)
+  {
+    // LCOV_EXCL_START - Don't test initialization failures in UT
+    TRC_ERROR("Authentication sproutlet failed to initialize (%d)", status);
+    // LCOV_EXCL_STOP
+  }
+
   return (status == PJ_SUCCESS);
 }
 

--- a/src/forwardingsproutlet.cpp
+++ b/src/forwardingsproutlet.cpp
@@ -37,23 +37,6 @@
 #include "forwardingsproutlet.h"
 #include "pjutils.h"
 
-ForwardingSproutlet::
-ForwardingSproutlet(const std::string& service_name,
-                    int port,
-                    const std::string& uri,
-                    const std::string& upstream_service_name,
-                    const std::string& service_host,
-                    SNMP::SuccessFailCountByRequestTypeTable* incoming_sip_transactions_tbl,
-                    SNMP::SuccessFailCountByRequestTypeTable* outgoing_sip_transactions_tbl) :
-  Sproutlet(service_name,
-            port,
-            uri,
-            service_host,
-            incoming_sip_transactions_tbl,
-            outgoing_sip_transactions_tbl),
-  _upstream_service_name(upstream_service_name)
-{}
-
 ForwardingSproutletTsx::ForwardingSproutletTsx(SproutletTsxHelper* helper,
                                                const std::string& upstream_service_name) :
   SproutletTsx(helper), _upstream_service_name(upstream_service_name)

--- a/src/forwardingsproutlet.cpp
+++ b/src/forwardingsproutlet.cpp
@@ -1,0 +1,72 @@
+/**
+ * @file forwardingsproutlet.h
+ *
+ * Project Clearwater - IMS in the Cloud
+ * Copyright (C) 2016  Metaswitch Networks Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version, along with the "Special Exception" for use of
+ * the program along with SSL, set forth below. This program is distributed
+ * in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * The author can be reached by email at clearwater@metaswitch.com or by
+ * post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+ *
+ * Special Exception
+ * Metaswitch Networks Ltd  grants you permission to copy, modify,
+ * propagate, and distribute a work formed by combining OpenSSL with The
+ * Software, or a work derivative of such a combination, even if such
+ * copying, modification, propagation, or distribution would otherwise
+ * violate the terms of the GPL. You must comply with the GPL in all
+ * respects for all of the code used other than OpenSSL.
+ * "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+ * Project and licensed under the OpenSSL Licenses, or a work based on such
+ * software and licensed under the OpenSSL Licenses.
+ * "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+ * under which the OpenSSL Project distributes the OpenSSL toolkit software,
+ * as those licenses appear in the file LICENSE-OPENSSL.
+ */
+
+#include "forwardingsproutlet.h"
+#include "pjutils.h"
+
+ForwardingSproutlet::
+ForwardingSproutlet(const std::string& service_name,
+                    int port,
+                    const std::string& uri,
+                    const std::string& upstream_service_name,
+                    const std::string& service_host,
+                    SNMP::SuccessFailCountByRequestTypeTable* incoming_sip_transactions_tbl,
+                    SNMP::SuccessFailCountByRequestTypeTable* outgoing_sip_transactions_tbl) :
+  Sproutlet(service_name,
+            port,
+            uri,
+            service_host,
+            incoming_sip_transactions_tbl,
+            outgoing_sip_transactions_tbl),
+  _upstream_service_name(upstream_service_name)
+{}
+
+ForwardingSproutletTsx::ForwardingSproutletTsx(SproutletTsxHelper* helper,
+                                               const std::string& upstream_service_name) :
+  SproutletTsx(helper), _upstream_service_name(upstream_service_name)
+{}
+
+void ForwardingSproutletTsx::forward_request(pjsip_msg* req)
+{
+  const pjsip_route_hdr* route = route_hdr();
+  pjsip_sip_uri* base_uri = (pjsip_sip_uri*)(route ? route->name_addr.uri : nullptr);
+  pjsip_sip_uri* uri =
+    (pjsip_sip_uri*)get_uri_for_service(_upstream_service_name,
+                                        get_pool(req),
+                                        base_uri);
+  PJUtils::add_top_route_header(req, uri, get_pool(req));
+  send_request(req);
+}

--- a/src/forwardingsproutlet.cpp
+++ b/src/forwardingsproutlet.cpp
@@ -39,7 +39,8 @@
 
 ForwardingSproutletTsx::ForwardingSproutletTsx(SproutletTsxHelper* helper,
                                                const std::string& upstream_service_name) :
-  SproutletTsx(helper), _upstream_service_name(upstream_service_name)
+  SproutletTsx(helper),
+  _upstream_service_name(upstream_service_name)
 {}
 
 void ForwardingSproutletTsx::forward_request(pjsip_msg* req)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1290,6 +1290,7 @@ ExceptionHandler* exception_handler = NULL;
 AlarmManager* alarm_manager = NULL;
 AnalyticsLogger* analytics_logger = NULL;
 ChronosConnection* chronos_connection = NULL;
+ImpiStore* impi_store = NULL;
 
 /*
  * main()
@@ -1301,7 +1302,6 @@ int main(int argc, char* argv[])
 
   SIPResolver* sip_resolver = NULL;
   Store* remote_data_store = NULL;
-  ImpiStore* impi_store = NULL;
   HttpConnection* ralf_connection = NULL;
   ACRFactory* pcscf_acr_factory = NULL;
   pj_bool_t websockets_enabled = PJ_FALSE;
@@ -2018,6 +2018,12 @@ int main(int argc, char* argv[])
     TRC_ERROR("Caught management HttpStack::Exception - %s - %d\n", e._func, e._rc);
     return 1;
   }
+
+  // Create an AV store using the local store and initialise the authentication
+  // sproutlet.  We don't create a AV store using the remote data store as
+  // Authentication Vectors are only stored for a short period after the
+  // relevant challenge is sent.
+  impi_store = new ImpiStore(local_data_store, opt.impi_store_mode);
 
   // Load the sproutlet plugins.
   PluginLoader* loader = new PluginLoader("/usr/share/clearwater/sprout/plugins",

--- a/src/registrarsproutlet.cpp
+++ b/src/registrarsproutlet.cpp
@@ -1150,10 +1150,12 @@ int RegistrarSproutlet::expiry_for_binding(pjsip_contact_hdr* contact,
 
 void RegistrarSproutletTsx::route_to_subscription(pjsip_msg* req)
 {
+  const pjsip_route_hdr* route = route_hdr();
+  pjsip_sip_uri* base_uri = (pjsip_sip_uri*)(route ? route->name_addr.uri : nullptr);
   pjsip_sip_uri* uri =
     (pjsip_sip_uri*)get_uri_for_service(_sproutlet->_next_hop_service,
                                         get_pool(req),
-                                        (pjsip_sip_uri*)route_hdr()->name_addr.uri);
+                                        base_uri);
   PJUtils::add_top_route_header(req, uri, get_pool(req));
   send_request(req);
 }

--- a/src/registrarsproutlet.cpp
+++ b/src/registrarsproutlet.cpp
@@ -75,6 +75,7 @@ extern "C" {
 RegistrarSproutlet::RegistrarSproutlet(const std::string& name,
                                        int port,
                                        const std::string& uri,
+                                       const std::string& next_hop_service,
                                        SubscriberDataManager* reg_sdm,
                                        std::vector<SubscriberDataManager*> reg_remote_sdms,
                                        HSSConnection* hss_connection,
@@ -93,7 +94,8 @@ RegistrarSproutlet::RegistrarSproutlet(const std::string& name,
   _max_expires(cfg_max_expires),
   _force_original_register_inclusion(force_original_register_inclusion),
   _reg_stats_tbls(reg_stats_tbls),
-  _third_party_reg_stats_tbls(third_party_reg_stats_tbls)
+  _third_party_reg_stats_tbls(third_party_reg_stats_tbls),
+  _next_hop_service(next_hop_service)
 {
 }
 
@@ -210,7 +212,7 @@ void RegistrarSproutletTsx::process_register_request(pjsip_msg *req)
   {
     num_contacts++;
     pjsip_expires_hdr* expires = (pjsip_expires_hdr*)pjsip_msg_find_hdr(req, PJSIP_H_EXPIRES, NULL);
-    expiry = expiry_for_binding(contact_hdr, expires, _sproutlet->_max_expires);
+    expiry = _sproutlet->expiry_for_binding(contact_hdr, expires);
 
     if ((contact_hdr->star) && (expiry != 0))
     {
@@ -882,7 +884,7 @@ SubscriberDataManager::AoRPair* RegistrarSproutletTsx::write_to_store(
     while (contact != NULL)
     {
       changed_bindings++;
-      expiry = expiry_for_binding(contact, expires, _sproutlet->_max_expires);
+      expiry = _sproutlet->expiry_for_binding(contact, expires);
 
       if (contact->star)
       {
@@ -1131,17 +1133,16 @@ void RegistrarSproutletTsx::log_bindings(const std::string& aor_name,
   }
 }
 
-int RegistrarSproutletTsx::expiry_for_binding(pjsip_contact_hdr* contact,
-                                              pjsip_expires_hdr* expires,
-                                              int max_expires)
+int RegistrarSproutlet::expiry_for_binding(pjsip_contact_hdr* contact,
+                                           pjsip_expires_hdr* expires)
 {
   int expiry = (contact->expires != -1) ? contact->expires :
                (expires != NULL) ? expires->ivalue :
-               max_expires;
-  if (expiry > max_expires)
+               _max_expires;
+  if (expiry > _max_expires)
   {
     // Expiry is too long, set it to the maximum.
-    expiry = max_expires;
+    expiry = _max_expires;
   }
 
   return expiry;
@@ -1149,10 +1150,10 @@ int RegistrarSproutletTsx::expiry_for_binding(pjsip_contact_hdr* contact,
 
 void RegistrarSproutletTsx::route_to_subscription(pjsip_msg* req)
 {
-  // TODO Route to a sensible URI.
   pjsip_sip_uri* uri =
-    (pjsip_sip_uri*)PJUtils::uri_from_string("sip:subscription.example.com;lr",
-                                             get_pool(req));
+    (pjsip_sip_uri*)get_uri_for_service(_sproutlet->_next_hop_service,
+                                        get_pool(req),
+                                        (pjsip_sip_uri*)route_hdr()->name_addr.uri);
   PJUtils::add_top_route_header(req, uri, get_pool(req));
   send_request(req);
 }

--- a/src/registrarsproutlet.cpp
+++ b/src/registrarsproutlet.cpp
@@ -187,6 +187,11 @@ void RegistrarSproutletTsx::on_rx_initial_request(pjsip_msg *req)
   }
 }
 
+void RegistrarSproutletTsx::on_rx_in_dialog_request(pjsip_msg* req)
+{
+  return route_to_subscription(req);
+}
+
 void RegistrarSproutletTsx::process_register_request(pjsip_msg *req)
 {
   pjsip_status_code st_code = PJSIP_SC_OK;

--- a/src/scscfplugin.cpp
+++ b/src/scscfplugin.cpp
@@ -246,12 +246,6 @@ bool SCSCFPlugin::load(struct options& opt, std::list<Sproutlet*>& sproutlets)
         SNMP::SuccessFailCountTable::create("non_register_auth_success_fail_count",
                                             ".1.2.826.0.1.1578918.9.3.17");
 
-
-      // Create an AV store using the local store and initialise the
-      // authentication sproutlet.  We don't create a AV store using the remote
-      // data store as Authentication Vectors are only stored for a short period
-      // after the relevant challenge is sent.
-      _impi_store = new ImpiStore(local_data_store, opt.impi_store_mode);
       _auth_sproutlet =
         new AuthenticationSproutlet(AUTHENTICATION_SERVICE_NAME,
                                     opt.port_scscf,
@@ -259,7 +253,7 @@ bool SCSCFPlugin::load(struct options& opt, std::list<Sproutlet*>& sproutlets)
                                     REGISTRAR_SERVICE_NAME,
                                     {"scscf"},
                                     opt.auth_realm,
-                                    _impi_store,
+                                    impi_store,
                                     hss_connection,
                                     chronos_connection,
                                     scscf_acr_factory,

--- a/src/scscfplugin.cpp
+++ b/src/scscfplugin.cpp
@@ -39,6 +39,8 @@
  * as those licenses appear in the file LICENSE-OPENSSL.
  */
 
+#include <functional>
+
 #include "cfgoptions.h"
 #include "sproutletplugin.h"
 #include "impistore.h"
@@ -49,6 +51,11 @@
 #include "sprout_alarmdefinition.h"
 #include "sprout_pd_definitions.h"
 #include "log.h"
+
+const std::string PROXY_SERVICE_NAME = "scscf-proxy";
+const std::string AUTHENTICATION_SERVICE_NAME = "authentication";
+const std::string REGISTRAR_SERVICE_NAME = "registrar";
+const std::string SUBSCRIPTION_SERVICE_NAME = "subscription";
 
 class SCSCFPlugin : public SproutletPlugin
 {
@@ -98,7 +105,7 @@ SCSCFPlugin::~SCSCFPlugin()
 /// Loads the S-CSCF plug-in, returning the supported Sproutlets.
 bool SCSCFPlugin::load(struct options& opt, std::list<Sproutlet*>& sproutlets)
 {
-  bool plugin_loaded = true;
+  bool ok = true;
 
   // Create the SNMP tables here - they should exist based on whether the
   // plugin is loaded, not whether the Sproutlet is enabled, in order to
@@ -161,12 +168,12 @@ bool SCSCFPlugin::load(struct options& opt, std::list<Sproutlet*>& sproutlets)
                                    &CL_SPROUT_SESS_CONT_AS_COMM_FAILURE,
                                    &CL_SPROUT_SESS_CONT_AS_COMM_SUCCESS);
 
-    _scscf_sproutlet = new SCSCFSproutlet("scscf-proxy",
+    _scscf_sproutlet = new SCSCFSproutlet(PROXY_SERVICE_NAME,
                                           opt.uri_scscf,
                                           scscf_node_uri,
                                           icscf_uri,
                                           opt.uri_bgcf,
-                                          opt.port_scscf,
+                                          0,
                                           opt.uri_scscf,
                                           local_sdm,
                                           {remote_sdm},
@@ -180,22 +187,21 @@ bool SCSCFPlugin::load(struct options& opt, std::list<Sproutlet*>& sproutlets)
                                           opt.session_terminated_timeout_ms,
                                           sess_term_as_tracker,
                                           sess_cont_as_tracker);
+    ok = ok && _scscf_sproutlet->init();
+    sproutlets.push_front(_scscf_sproutlet);
 
-    plugin_loaded = _scscf_sproutlet->init();
-
-    sproutlets.push_back(_scscf_sproutlet);
-
-    _subscription_sproutlet = new SubscriptionSproutlet("subscription",
-                                                        opt.port_scscf,
+    _subscription_sproutlet = new SubscriptionSproutlet(SUBSCRIPTION_SERVICE_NAME,
+                                                        0,
                                                         opt.uri_scscf,
+                                                        PROXY_SERVICE_NAME,
                                                         local_sdm,
                                                         {remote_sdm},
                                                         hss_connection,
                                                         scscf_acr_factory,
                                                         analytics_logger,
                                                         opt.sub_max_expires);
-
-    sproutlets.push_back(_subscription_sproutlet);
+    ok = ok && _subscription_sproutlet->init();
+    sproutlets.push_front(_subscription_sproutlet);
 
     reg_stats_tbls.init_reg_tbl = SNMP::SuccessFailCountTable::create("initial_reg_success_fail_count",
                                                                        ".1.2.826.0.1.1578918.9.3.9");
@@ -211,9 +217,10 @@ bool SCSCFPlugin::load(struct options& opt, std::list<Sproutlet*>& sproutlets)
     third_party_reg_stats_tbls.de_reg_tbl = SNMP::SuccessFailCountTable::create("third_party_de_reg_success_fail_count",
                                                                                  ".1.2.826.0.1.1578918.9.3.14");
 
-    _registrar_sproutlet = new RegistrarSproutlet(opt.prefix_scscf,
-                                                  opt.port_scscf,
+    _registrar_sproutlet = new RegistrarSproutlet(REGISTRAR_SERVICE_NAME,
+                                                  0,
                                                   opt.uri_scscf,
+                                                  SUBSCRIPTION_SERVICE_NAME,
                                                   local_sdm,
                                                   {remote_sdm},
                                                   hss_connection,
@@ -224,12 +231,8 @@ bool SCSCFPlugin::load(struct options& opt, std::list<Sproutlet*>& sproutlets)
                                                   &reg_stats_tbls,
                                                   &third_party_reg_stats_tbls);
 
-    plugin_loaded = _registrar_sproutlet->init();
-
-    // We want to prioritise choosing the S-CSCF in ambiguous situations, so
-    // make sure it's at the front of the sproutlet list
+    ok = ok && _registrar_sproutlet->init();
     sproutlets.push_front(_registrar_sproutlet);
-    sproutlets.push_front(_subscription_sproutlet);
 
     if (opt.auth_enabled)
     {
@@ -249,29 +252,31 @@ bool SCSCFPlugin::load(struct options& opt, std::list<Sproutlet*>& sproutlets)
       // data store as Authentication Vectors are only stored for a short period
       // after the relevant challenge is sent.
       _impi_store = new ImpiStore(local_data_store, opt.impi_store_mode);
-      _auth_sproutlet = new AuthenticationSproutlet("authentication",
-                                                    0,
-                                                    opt.uri_scscf,
-                                                    opt.auth_realm,
-                                                    _impi_store,
-                                                    hss_connection,
-                                                    chronos_connection,
-                                                    scscf_acr_factory,
-                                                    opt.non_register_auth_mode,
-                                                    analytics_logger,
-                                                    &auth_stats_tbls,
-                                                    opt.nonce_count_supported,
-                                                    NULL); // TODO sort this out.
-      if (_auth_sproutlet != nullptr)
-      {
-        _auth_sproutlet->init();
-        // TODO cope with this failing.
-        sproutlets.push_back(_auth_sproutlet);
-      }
+      _auth_sproutlet =
+        new AuthenticationSproutlet(AUTHENTICATION_SERVICE_NAME,
+                                    opt.port_scscf,
+                                    opt.uri_scscf,
+                                    REGISTRAR_SERVICE_NAME,
+                                    {"scscf"},
+                                    opt.auth_realm,
+                                    _impi_store,
+                                    hss_connection,
+                                    chronos_connection,
+                                    scscf_acr_factory,
+                                    opt.non_register_auth_mode,
+                                    analytics_logger,
+                                    &auth_stats_tbls,
+                                    opt.nonce_count_supported,
+                                    std::bind(&RegistrarSproutlet::expiry_for_binding,
+                                              _registrar_sproutlet,
+                                              std::placeholders::_1,
+                                              std::placeholders::_2));
+      ok = ok && _auth_sproutlet->init();
+      sproutlets.push_front(_auth_sproutlet);
     }
   }
 
-  return plugin_loaded;
+  return ok;
 }
 
 

--- a/src/scscfplugin.cpp
+++ b/src/scscfplugin.cpp
@@ -174,7 +174,7 @@ bool SCSCFPlugin::load(struct options& opt, std::list<Sproutlet*>& sproutlets)
                                           icscf_uri,
                                           opt.uri_bgcf,
                                           0,
-                                          opt.uri_scscf,
+                                          "",
                                           local_sdm,
                                           {remote_sdm},
                                           hss_connection,
@@ -192,7 +192,7 @@ bool SCSCFPlugin::load(struct options& opt, std::list<Sproutlet*>& sproutlets)
 
     _subscription_sproutlet = new SubscriptionSproutlet(SUBSCRIPTION_SERVICE_NAME,
                                                         0,
-                                                        opt.uri_scscf,
+                                                        "",
                                                         PROXY_SERVICE_NAME,
                                                         local_sdm,
                                                         {remote_sdm},
@@ -219,7 +219,7 @@ bool SCSCFPlugin::load(struct options& opt, std::list<Sproutlet*>& sproutlets)
 
     _registrar_sproutlet = new RegistrarSproutlet(REGISTRAR_SERVICE_NAME,
                                                   0,
-                                                  opt.uri_scscf,
+                                                  "",
                                                   SUBSCRIPTION_SERVICE_NAME,
                                                   local_sdm,
                                                   {remote_sdm},
@@ -249,7 +249,7 @@ bool SCSCFPlugin::load(struct options& opt, std::list<Sproutlet*>& sproutlets)
       _auth_sproutlet =
         new AuthenticationSproutlet(AUTHENTICATION_SERVICE_NAME,
                                     opt.port_scscf,
-                                    opt.uri_scscf,
+                                    "",
                                     REGISTRAR_SERVICE_NAME,
                                     {"scscf"},
                                     opt.auth_realm,

--- a/src/scscfsproutlet.cpp
+++ b/src/scscfsproutlet.cpp
@@ -1347,12 +1347,6 @@ void SCSCFSproutletTsx::route_to_as(pjsip_msg* req, const std::string& server_na
     pj_strdup2(get_pool(req), &odi_uri->user, odi_value.c_str());
     odi_uri->transport_param = as_uri->transport_param;  // Use same transport as AS, in case it can only cope with one.
 
-    pjsip_param* services_p = PJ_POOL_ALLOC_T(get_pool(req), pjsip_param);
-    pj_strdup(get_pool(req), &services_p->name, &STR_SERVICE);
-    pj_list_insert_before(&odi_uri->other_param, services_p);
-    std::string services = _scscf->service_name();
-    pj_strdup2(get_pool(req), &services_p->value, services.c_str());
-
     if (_session_case->is_originating())
     {
       pjsip_param *orig_param = PJ_POOL_ALLOC_T(get_pool(req), pjsip_param);
@@ -1773,7 +1767,9 @@ void SCSCFSproutletTsx::add_to_dialog(pjsip_msg* msg,
   pjsip_route_hdr* rr = NULL;
   if (!_record_routed)
   {
-    pjsip_sip_uri* uri = get_reflexive_uri(pool);
+    // Get the cluster URI. Don't use `get_reflexive_uri` here as we want to
+    // record route the entire S-CSCF service, not just this sproutlet.
+    pjsip_sip_uri* uri = (pjsip_sip_uri*)pjsip_uri_clone(pool, _scscf->scscf_cluster_uri());
 
     rr = pjsip_rr_hdr_create(pool);
     rr->name_addr.uri = (pjsip_uri*)uri;

--- a/src/scscfsproutlet.cpp
+++ b/src/scscfsproutlet.cpp
@@ -1770,6 +1770,7 @@ void SCSCFSproutletTsx::add_to_dialog(pjsip_msg* msg,
     // Get the cluster URI. Don't use `get_reflexive_uri` here as we want to
     // record route the entire S-CSCF service, not just this sproutlet.
     pjsip_sip_uri* uri = (pjsip_sip_uri*)pjsip_uri_clone(pool, _scscf->scscf_cluster_uri());
+    uri->lr_param = 1;
 
     rr = pjsip_rr_hdr_create(pool);
     rr->name_addr.uri = (pjsip_uri*)uri;

--- a/src/sproutletproxy.cpp
+++ b/src/sproutletproxy.cpp
@@ -373,8 +373,8 @@ pjsip_sip_uri* SproutletProxy::create_sproutlet_uri(pj_pool_t* pool,
   // TODO We should really commonalize the two create_sproutlet_uri methods but
   // the other one is not guaranteed to route to a unique sproutlet.
 
-  pjsip_sip_uri* uri =
-    (pjsip_sip_uri*)pjsip_uri_clone(pool, existing_uri);
+  pjsip_sip_uri* base_uri = ((existing_uri != nullptr) ? existing_uri : _root_uri);
+  pjsip_sip_uri* uri = (pjsip_sip_uri*)pjsip_uri_clone(pool, base_uri);
   pj_strdup(pool, &uri->host, &_root_uri->host);
   uri->port = 0;
   uri->lr_param = 1;

--- a/src/sproutletproxy.cpp
+++ b/src/sproutletproxy.cpp
@@ -364,13 +364,6 @@ pjsip_sip_uri* SproutletProxy::create_sproutlet_uri(pj_pool_t* pool,
     uri = (pjsip_sip_uri*)pjsip_uri_clone(pool, it->second);
     uri->lr_param = 1;
 
-    TRC_DEBUG("Add services parameter");
-    pjsip_param* p = PJ_POOL_ALLOC_T(pool, pjsip_param);
-    pj_strdup(pool, &p->name, &STR_SERVICE);
-    pj_list_insert_before(&uri->other_param, p);
-    std::string services = sproutlet->service_name();
-    pj_strdup2(pool, &p->value, services.c_str());
-
     TRC_DEBUG("Constructed URI %s",
               PJUtils::uri_to_string(PJSIP_URI_IN_ROUTING_HDR, (pjsip_uri*)uri).c_str());
   }

--- a/src/sproutletproxy.cpp
+++ b/src/sproutletproxy.cpp
@@ -377,12 +377,11 @@ pjsip_sip_uri* SproutletProxy::create_sproutlet_uri(pj_pool_t* pool,
   return uri;
 }
 
-pjsip_sip_uri* SproutletProxy::create_sproutlet_uri(pj_pool_t* pool,
-                                                    const std::string& name,
-                                                    pjsip_sip_uri* existing_uri) const
+pjsip_sip_uri* SproutletProxy::create_internal_sproutlet_uri(pj_pool_t* pool,
+                                                             const std::string& name,
+                                                             pjsip_sip_uri* existing_uri) const
 {
-  // TODO We should really commonalize the two create_sproutlet_uri methods but
-  // the other one is not guaranteed to route to a unique sproutlet.
+  TRC_DEBUG("Creating URI for service %s", name.c_str());
 
   pjsip_sip_uri* base_uri = ((existing_uri != nullptr) ? existing_uri : _root_uri);
   pjsip_sip_uri* uri = (pjsip_sip_uri*)pjsip_uri_clone(pool, base_uri);
@@ -400,6 +399,9 @@ pjsip_sip_uri* SproutletProxy::create_sproutlet_uri(pj_pool_t* pool,
   }
 
   pj_strdup2(pool, &p->value, name.c_str());
+
+  TRC_DEBUG("Constructed URI %s",
+              PJUtils::uri_to_string(PJSIP_URI_IN_ROUTING_HDR, (pjsip_uri*)uri).c_str());
 
   return uri;
 }
@@ -1569,7 +1571,7 @@ pjsip_sip_uri* SproutletWrapper::get_uri_for_service(const std::string& service,
                                                      pj_pool_t* pool,
                                                      pjsip_sip_uri* existing_uri) const
 {
-  return _proxy->create_sproutlet_uri(pool, service, existing_uri);
+  return _proxy->create_internal_sproutlet_uri(pool, service, existing_uri);
 }
 
 void SproutletWrapper::rx_request(pjsip_tx_data* req)

--- a/src/subscriptionsproutlet.cpp
+++ b/src/subscriptionsproutlet.cpp
@@ -719,10 +719,12 @@ void SubscriptionSproutletTsx::log_subscriptions(const std::string& aor_name,
 
 void SubscriptionSproutletTsx::route_to_scscf_proxy(pjsip_msg* req)
 {
+  const pjsip_route_hdr* route = route_hdr();
+  pjsip_sip_uri* base_uri = (pjsip_sip_uri*)(route ? route->name_addr.uri : nullptr);
   pjsip_sip_uri* uri =
     (pjsip_sip_uri*)get_uri_for_service(_sproutlet->_next_hop_service,
                                         get_pool(req),
-                                        (pjsip_sip_uri*)route_hdr()->name_addr.uri);
+                                        base_uri);
   PJUtils::add_top_route_header(req, uri, get_pool(req));
   send_request(req);
 }

--- a/src/ut/authentication_test.cpp
+++ b/src/ut/authentication_test.cpp
@@ -122,8 +122,6 @@ public:
                                           sproutlets,
                                           std::set<std::string>());
 
-    add_host_mapping("registrar.example.com", "10.10.10.1");
-
     _tp = new TransportFlow(TransportFlow::Protocol::TCP,
                             stack_data.scscf_port,
                             "0.0.0.0",
@@ -278,6 +276,8 @@ class AuthenticationTest : public BaseAuthenticationTest
       new AuthenticationSproutlet("authentication",
                                   stack_data.scscf_port,
                                   "sip:authentication.homedomain",
+                                  "registrar",
+                                  { "scscf" },
                                   "homedomain",
                                   _impi_store,
                                   _hss_connection,
@@ -307,6 +307,8 @@ class AuthenticationPxyAuthHdrTest : public BaseAuthenticationTest
       new AuthenticationSproutlet("authentication",
                                   0,
                                   "sip:authentication.homedomain",
+                                  "registrar",
+                                  { "scscf" },
                                   "homedomain",
                                   _impi_store,
                                   _hss_connection,
@@ -341,6 +343,8 @@ class AuthenticationNonceCountDisabledTest : public BaseAuthenticationTest
       new AuthenticationSproutlet("authentication",
                                   0,
                                   "sip:authentication.homedomain",
+                                  "registrar",
+                                  { "scscf" },
                                   "homedomain",
                                   _impi_store,
                                   _hss_connection,
@@ -1968,6 +1972,53 @@ TEST_F(AuthenticationTest, AuthCorruptAV)
   EXPECT_EQ(0,((SNMP::FakeSuccessFailCountTable*)SNMP::FAKE_AUTHENTICATION_STATS_TABLES.sip_digest_auth_tbl)->_attempts);
   EXPECT_EQ(0,((SNMP::FakeSuccessFailCountTable*)SNMP::FAKE_AUTHENTICATION_STATS_TABLES.ims_aka_auth_tbl)->_attempts);
   free_txdata();
+
+  _hss_connection->delete_result("/impi/6505550001%40homedomain/av?impu=sip%3A6505550001%40homedomain");
+}
+
+
+TEST_F(AuthenticationTest, AuthSproutletCanRegisterForAliases)
+{
+  pjsip_tx_data* tdata;
+
+  // Set up the HSS response for the AV query using a default private user identity.
+  _hss_connection->set_result("/impi/6505550001%40homedomain/av?impu=sip%3A6505550001%40homedomain",
+                              "{\"digest\":{\"realm\":\"homedomain\",\"qop\":\"auth\",\"ha1\":\"12345678123456781234567812345678\"}}");
+
+  // Send in a REGISTER request with no authentication header.  This triggers
+  // Digest authentication.
+  AuthenticationMessage msg1("REGISTER");
+  msg1._auth_hdr = false;
+  msg1._route = "sip:scscf.sprout.homedomain:5058;transport=TCP";
+  inject_msg(msg1.get(), _tp);
+
+  // Expect a 401 Not Authorized response.
+  ASSERT_EQ(1, txdata_count());
+  tdata = current_txdata();
+  RespMatcher(401).matches(tdata->msg);
+
+  // Extract the nonce, nc, cnonce and qop fields from the WWW-Authenticate header.
+  std::string auth = get_headers(tdata->msg, "WWW-Authenticate");
+  std::map<std::string, std::string> auth_params;
+  parse_www_authenticate(auth, auth_params);
+  free_txdata();
+
+  // Send a new REGISTER request with an authentication header including the
+  // response.
+  AuthenticationMessage msg2("REGISTER");
+  msg2._algorithm = "MD5";
+  msg2._key = "12345678123456781234567812345678";
+  msg2._nonce = auth_params["nonce"];
+  msg2._opaque = auth_params["opaque"];
+  msg2._nc = "00000001";
+  msg2._cnonce = "8765432187654321";
+  msg2._qop = "auth";
+  msg2._integ_prot = "ip-assoc-pending";
+  msg1._route = "sip:scscf.sprout.homedomain:5058;transport=TCP";
+  inject_msg(msg2.get(), _tp);
+
+  // The authentication module lets the request through.
+  auth_sproutlet_allows_request();
 
   _hss_connection->delete_result("/impi/6505550001%40homedomain/av?impu=sip%3A6505550001%40homedomain");
 }

--- a/src/ut/mocktsxhelper.h
+++ b/src/ut/mocktsxhelper.h
@@ -76,6 +76,9 @@ public:
   MOCK_METHOD3(schedule_timer, bool(void*, TimerID&, int));
   MOCK_METHOD1(cancel_timer, void(TimerID));
   MOCK_METHOD1(timer_running, bool(TimerID));
+  MOCK_CONST_METHOD3(get_uri_for_service, pjsip_sip_uri*(const std::string& service,
+                                                         pj_pool_t* pool,
+                                                         pjsip_sip_uri* existing_uri));
 };
 
 #endif

--- a/src/ut/registrar_test.cpp
+++ b/src/ut/registrar_test.cpp
@@ -180,7 +180,6 @@ public:
   {
     SipTest::SetUpTestCase();
     SipTest::SetScscfUri("sip:all.the.sprout.nodes:5058;transport=TCP");
-    add_host_mapping("subscription.example.com", "10.8.8.2");
 
     _chronos_connection = new FakeChronosConnection();
     _local_data_store = new LocalStore();
@@ -234,6 +233,7 @@ public:
     _registrar_sproutlet = new RegistrarSproutlet("registrar",
                                                   5058,
                                                   "sip:registrar.homedomain:5058;transport=tcp",
+                                                  "subscription",
                                                   _sdm,
                                                   _remote_sdms,
                                                   _hss_connection,
@@ -244,7 +244,7 @@ public:
                                                   &SNMP::FAKE_REGISTRATION_STATS_TABLES,
                                                   &SNMP::FAKE_THIRD_PARTY_REGISTRATION_STATS_TABLES);
 
-    _registrar_sproutlet->init();
+    EXPECT_TRUE(_registrar_sproutlet->init());
 
     std::list<Sproutlet*> sproutlets;
     sproutlets.push_back(_registrar_sproutlet);
@@ -2660,6 +2660,7 @@ public:
     _registrar_sproutlet = new RegistrarSproutlet("registrar",
                                                   5058,
                                                   "sip:registrar.homedomain:5058;transport=tcp",
+                                                  "subscription",
                                                   _sdm,
                                                   {},
                                                   _hss_connection,

--- a/src/ut/scscf_test.cpp
+++ b/src/ut/scscf_test.cpp
@@ -305,7 +305,7 @@ public:
 
     // Create the S-CSCF Sproutlet.
     _scscf_sproutlet = new SCSCFSproutlet("scscf",
-                                          "sip:homedomain:5058",
+                                          "sip:scscf.homedomain:5058;transport=tcp",
                                           "sip:127.0.0.1:5058",
                                           "",
                                           "sip:bgcf@homedomain:5058",
@@ -653,7 +653,7 @@ void SCSCFTest::doFourAppServerFlow(std::string record_route_regex, bool app_ser
   tpAS1.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:6505551234@homedomain", r1.uri());
   EXPECT_THAT(get_headers(out, "Route"),
-              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;orig;service=scscf>"));
+              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;orig>"));
 
   // ---------- AS1 sends a 100 Trying to indicate it has received the request.
   string fresp1 = respond_to_txdata(current_txdata(), 100);
@@ -690,7 +690,7 @@ void SCSCFTest::doFourAppServerFlow(std::string record_route_regex, bool app_ser
   tpAS2.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:6505551234@homedomain", r1.uri());
   EXPECT_THAT(get_headers(out, "Route"),
-              testing::MatchesRegex("Route: <sip:4\\.2\\.3\\.4:56788;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;orig;service=scscf>"));
+              testing::MatchesRegex("Route: <sip:4\\.2\\.3\\.4:56788;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;orig>"));
 
   // ---------- AS2 sends a 100 Trying to indicate it has received the request.
   string fresp2 = respond_to_txdata(current_txdata(), 100);
@@ -725,7 +725,7 @@ void SCSCFTest::doFourAppServerFlow(std::string record_route_regex, bool app_ser
   tpAS3.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:6505551234@homedomain", r1.uri());
   EXPECT_THAT(get_headers(out, "Route"),
-              testing::MatchesRegex("Route: <sip:5\\.2\\.3\\.4:56787;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;service=scscf>"));
+              testing::MatchesRegex("Route: <sip:5\\.2\\.3\\.4:56787;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr>"));
 
   // ---------- AS3 sends a 100 Trying to indicate it has received the request.
   string fresp3 = respond_to_txdata(current_txdata(), 100);
@@ -760,7 +760,7 @@ void SCSCFTest::doFourAppServerFlow(std::string record_route_regex, bool app_ser
   tpAS4.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:6505551234@homedomain", r1.uri());
   EXPECT_THAT(get_headers(out, "Route"),
-              testing::MatchesRegex("Route: <sip:6\\.2\\.3\\.4:56786;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;service=scscf>"));
+              testing::MatchesRegex("Route: <sip:6\\.2\\.3\\.4:56786;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr>"));
 
   // ---------- AS4 sends a 100 Trying to indicate it has received the request.
   string fresp4 = respond_to_txdata(current_txdata(), 100);
@@ -1275,7 +1275,7 @@ TEST_F(SCSCFTest, ReqURIMatchesSproutletPort)
   register_uri(_sdm, _hss_connection, "6505551234", "homedomain", "sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob");
   Message msg;
   msg._requri = "sip:254.253.252.251:5058";
-  msg._route = "Route: <sip:homedomain;transport=tcp;lr;service=scscf;billing-role=charge-term>";
+  msg._route = "Route: <sip:homedomain;transport=tcp;lr;billing-role=charge-term>";
   list<HeaderMatcher> hdrs;
   doSuccessfulFlow(msg, testing::MatchesRegex("sip:254.253.252.251:5058"), hdrs, false);
 }
@@ -1472,7 +1472,7 @@ TEST_F(SCSCFTest, TestTelURIWildcard)
 
   tpAS1.expect_target(tdata, false);
   EXPECT_THAT(get_headers(out, "Route"),
-              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;service=scscf>"));
+              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr>"));
 
   string fresp1 = respond_to_txdata(tdata, 404);
   inject_msg(fresp1, &tpAS1);
@@ -2411,7 +2411,7 @@ TEST_F(SCSCFTest, SimpleISCMainline)
   tpAS1.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:6505551234@homedomain", r1.uri());
   EXPECT_THAT(get_headers(out, "Route"),
-              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;orig;service=scscf>"));
+              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;orig>"));
   EXPECT_THAT(get_headers(out, "P-Served-User"),
               testing::MatchesRegex("P-Served-User: <sip:6505551000@homedomain>;sescase=orig;regstate=unreg"));
 
@@ -2521,7 +2521,7 @@ TEST_F(SCSCFTest, ISCMultipleResponses)
   tpAS1.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:6505551234@homedomain", r1.uri());
   EXPECT_THAT(get_headers(out, "Route"),
-              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;orig;service=scscf>"));
+              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;orig>"));
   EXPECT_THAT(get_headers(out, "P-Served-User"),
               testing::MatchesRegex("P-Served-User: <sip:6505551000@homedomain>;sescase=orig;regstate=unreg"));
 
@@ -2808,7 +2808,7 @@ TEST_F(SCSCFTest, SimpleISCTwoRouteHeaders)
   tpAS1.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:6505551234@homedomain", r1.uri());
   EXPECT_THAT(get_headers(out, "Route"),
-              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;orig;service=scscf>\r\nRoute: <sip:abcde.com>"));
+              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;orig>\r\nRoute: <sip:abcde.com>"));
 
   // ---------- AS1 sends a 100 Trying to indicate it has received the request.
   string fresp = respond_to_txdata(current_txdata(), 100);
@@ -2999,7 +2999,7 @@ TEST_F(SCSCFTest, SimpleNextOrigFlow)
   tpAS1.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:6505551234@homedomain", r1.uri());
   EXPECT_THAT(get_headers(out, "Route"),
-              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;orig;service=scscf>"));
+              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;orig>"));
 
   // ---------- AS1 sends a 100 Trying to indicate it has received the request.
   string fresp = respond_to_txdata(current_txdata(), 100);
@@ -3095,7 +3095,7 @@ TEST_F(SCSCFTest, SimpleReject)
   tpAS1.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:6505551234@homedomain", r1.uri());
   EXPECT_THAT(get_headers(out, "Route"),
-              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;service=scscf>"));
+              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr>"));
 
   // ---------- AS1 rejects it.
   string fresp = respond_to_txdata(current_txdata(), 404);
@@ -3182,7 +3182,7 @@ TEST_F(SCSCFTest, SimpleNonLocalReject)
   tpAS1.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:6505551234@homedomain", r1.uri());
   EXPECT_THAT(get_headers(out, "Route"),
-              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;service=scscf>"));
+              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr>"));
 
   // ---------- AS1 rejects it.
   string fresp = respond_to_txdata(current_txdata(), 404);
@@ -3270,7 +3270,7 @@ TEST_F(SCSCFTest, SimpleAccept)
   tpAS1.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:6505551234@homedomain", r1.uri());
   EXPECT_THAT(get_headers(out, "Route"),
-              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;service=scscf>"));
+              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr>"));
 
   // ---------- AS1 accepts it with 200.
   string fresp = respond_to_txdata(current_txdata(), 200);
@@ -3358,7 +3358,7 @@ TEST_F(SCSCFTest, SimpleRedirect)
   tpAS1.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:6505551234@homedomain", r1.uri());
   EXPECT_THAT(get_headers(out, "Route"),
-              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;service=scscf>"));
+              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr>"));
 
   // ---------- AS1 redirects it to another user on the same server.
   string fresp = respond_to_txdata(current_txdata(), 302, "", "Contact: sip:6505559876@homedomain");
@@ -3448,7 +3448,7 @@ TEST_F(SCSCFTest, DefaultHandlingTerminate)
   tpAS1.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:6505551234@homedomain", r1.uri());
   EXPECT_THAT(get_headers(out, "Route"),
-              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;service=scscf>"));
+              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr>"));
 
   // ---------- AS1 rejects it with a 408 error.
   string fresp = respond_to_txdata(current_txdata(), 408);
@@ -3851,7 +3851,7 @@ TEST_F(SCSCFTest, DefaultHandlingContinueNonResponsive)
   tpAS1.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:6505551234@homedomain", r1.uri());
   EXPECT_THAT(get_headers(out, "Route"),
-              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;service=scscf>"));
+              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr>"));
 
   // ---------- AS1 rejects it with a 408 error.
   string fresp = respond_to_txdata(current_txdata(), 408);
@@ -3940,7 +3940,7 @@ TEST_F(SCSCFTest, DefaultHandlingContinueImmediateError)
   tpAS1.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:6505551234@homedomain", r1.uri());
   EXPECT_THAT(get_headers(out, "Route"),
-              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;service=scscf>"));
+              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr>"));
 
   // ---------- AS1 immediately rejects the request with a 500 response.  This
   // gets returned to the caller because the 183 indicated the AS is live.
@@ -4034,7 +4034,7 @@ TEST_F(SCSCFTest, DefaultHandlingContinue100ThenError)
   tpAS1.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:6505551234@homedomain", r1.uri());
   EXPECT_THAT(get_headers(out, "Route"),
-              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;service=scscf>"));
+              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr>"));
 
   // ---------- AS1 sends a 100 Trying to indicate it is processing the
   // request.  This does NOT disable the default handling.
@@ -4133,7 +4133,7 @@ TEST_F(SCSCFTest, DefaultHandlingContinue1xxThenError)
   tpAS1.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:6505551234@homedomain", r1.uri());
   EXPECT_THAT(get_headers(out, "Route"),
-              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;service=scscf>"));
+              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr>"));
 
   // ---------- AS1 sends a 183 Session Progress to indicate it is processing the
   // request.  This will disable the default handling.
@@ -4242,7 +4242,7 @@ TEST_F(SCSCFTest, DefaultHandlingContinueInviteReturnedThenError)
   tpAS1.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:6505551234@homedomain", r1.uri());
   EXPECT_THAT(get_headers(out, "Route"),
-              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;service=scscf>"));
+              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr>"));
 
   // ---------- AS1 sends a 100 Trying to indicate it has received the request.
   string resp_100 = respond_to_txdata(current_txdata(), 100);
@@ -4627,12 +4627,12 @@ TEST_F(SCSCFTest, RecordRoutingTest)
   // - AS4's Record-Route
   // - on end of terminating handling
 
-  doFourAppServerFlow("Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;service=scscf;billing-role=charge-term>\r\n"
+  doFourAppServerFlow("Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;billing-role=charge-term>\r\n"
                       "Record-Route: <sip:6.2.3.4>\r\n"
                       "Record-Route: <sip:5.2.3.4>\r\n"
                       "Record-Route: <sip:4.2.3.4>\r\n"
                       "Record-Route: <sip:1.2.3.4>\r\n"
-                      "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;service=scscf;billing-role=charge-orig>", true);
+                      "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;billing-role=charge-orig>", true);
   free_txdata();
 }
 
@@ -4653,14 +4653,14 @@ TEST_F(SCSCFTest, RecordRoutingTestStartAndEnd)
   // - AS4's Record-Route
   // - on end of terminating handling
 
-  doFourAppServerFlow("Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;service=scscf;billing-role=charge-term>\r\n"
+  doFourAppServerFlow("Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;billing-role=charge-term>\r\n"
                       "Record-Route: <sip:6.2.3.4>\r\n"
                       "Record-Route: <sip:5.2.3.4>\r\n"
-                      "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;service=scscf>\r\n"
-                      "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;service=scscf>\r\n"
+                      "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr>\r\n"
+                      "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr>\r\n"
                       "Record-Route: <sip:4.2.3.4>\r\n"
                       "Record-Route: <sip:1.2.3.4>\r\n"
-                      "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;service=scscf;billing-role=charge-orig>", true);
+                      "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;billing-role=charge-orig>", true);
   stack_data.record_route_on_completion_of_originating = false;
   stack_data.record_route_on_initiation_of_terminating = false;
 }
@@ -4691,16 +4691,16 @@ TEST_F(SCSCFTest, RecordRoutingTestEachHop)
   // AS3, we'd have two - one for conclusion of originating processing
   // and one for initiation of terminating processing) but we don't
   // split originating and terminating handling like that yet.
-  doFourAppServerFlow("Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;service=scscf;billing-role=charge-term>\r\n"
+  doFourAppServerFlow("Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;billing-role=charge-term>\r\n"
                       "Record-Route: <sip:6.2.3.4>\r\n"
-                      "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;service=scscf>\r\n"
+                      "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr>\r\n"
                       "Record-Route: <sip:5.2.3.4>\r\n"
-                      "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;service=scscf>\r\n"
-                      "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;service=scscf>\r\n"
+                      "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr>\r\n"
+                      "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr>\r\n"
                       "Record-Route: <sip:4.2.3.4>\r\n"
-                      "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;service=scscf>\r\n"
+                      "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr>\r\n"
                       "Record-Route: <sip:1.2.3.4>\r\n"
-                      "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;service=scscf;billing-role=charge-orig>", true);
+                      "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;billing-role=charge-orig>", true);
 
   stack_data.record_route_on_initiation_of_terminating = false;
   stack_data.record_route_on_completion_of_originating = false;
@@ -4713,8 +4713,8 @@ TEST_F(SCSCFTest, RecordRoutingTestEachHop)
 TEST_F(SCSCFTest, RecordRoutingTestCollapse)
 {
   // Expect 1 Record-Route
-  doFourAppServerFlow("Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;service=scscf;billing-role=charge-term>\r\n"
-                      "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;service=scscf;billing-role=charge-orig>", false);
+  doFourAppServerFlow("Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;billing-role=charge-term>\r\n"
+                      "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;billing-role=charge-orig>", false);
 }
 
 // Test that even when Sprout is configured to Record-Route itself on each
@@ -4724,11 +4724,11 @@ TEST_F(SCSCFTest, RecordRoutingTestCollapseEveryHop)
 {
   stack_data.record_route_on_every_hop = true;
   // Expect 1 Record-Route
-  doFourAppServerFlow("Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;service=scscf;billing-role=charge-term>\r\n"
-                      "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;service=scscf>\r\n"
-                      "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;service=scscf>\r\n"
-                      "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;service=scscf>\r\n"
-                      "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;service=scscf;billing-role=charge-orig>", false);
+  doFourAppServerFlow("Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;billing-role=charge-term>\r\n"
+                      "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr>\r\n"
+                      "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr>\r\n"
+                      "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr>\r\n"
+                      "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;billing-role=charge-orig>", false);
   stack_data.record_route_on_every_hop = false;
 }
 
@@ -4812,7 +4812,7 @@ void SCSCFTest::doAsOriginated(const std::string& msg, bool expect_orig)
     tpAS1.expect_target(current_txdata(), false);
     EXPECT_EQ("sip:6505551234@homedomain", r1.uri());
     EXPECT_THAT(get_headers(out, "Route"),
-                testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;orig;service=scscf>"));
+                testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;orig>"));
 
     // ---------- AS1 sends a 100 Trying to indicate it has received the request.
     string fresp1 = respond_to_txdata(current_txdata(), 100);
@@ -4842,7 +4842,7 @@ void SCSCFTest::doAsOriginated(const std::string& msg, bool expect_orig)
   tpAS2.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:6505551234@homedomain", r1.uri());
   EXPECT_THAT(get_headers(out, "Route"),
-              testing::MatchesRegex("Route: <sip:5\\.2\\.3\\.4:56787;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;service=scscf>"));
+              testing::MatchesRegex("Route: <sip:5\\.2\\.3\\.4:56787;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr>"));
 
   // ---------- AS1 sends a 100 Trying to indicate it has received the request.
   string fresp2 = respond_to_txdata(current_txdata(), 100);
@@ -5011,7 +5011,7 @@ TEST_F(SCSCFTest, Cdiv)
   tpAS1.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:6505551234@homedomain", r1.uri());
   EXPECT_THAT(get_headers(out, "Route"),
-              testing::MatchesRegex("Route: <sip:5\\.2\\.3\\.4:56787;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;service=scscf>"));
+              testing::MatchesRegex("Route: <sip:5\\.2\\.3\\.4:56787;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr>"));
   EXPECT_THAT(get_headers(out, "P-Served-User"),
               testing::MatchesRegex("P-Served-User: <sip:6505551234@homedomain>;sescase=term;regstate=reg"));
 
@@ -5045,7 +5045,7 @@ TEST_F(SCSCFTest, Cdiv)
   tpAS2.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:6505555678@homedomain", r1.uri());
   EXPECT_THAT(get_headers(out, "Route"),
-              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;orig;service=scscf>"));
+              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;orig>"));
 
   // As the session case is "Originating_CDIV" we want to include the
   // "orig-div" header field parameter with just a name and no value
@@ -5321,7 +5321,7 @@ TEST_F(SCSCFTest, BothEndsWithEnumRewrite)
 
   EXPECT_EQ("sip:6505551234@homedomain", r1.uri());
   EXPECT_THAT(get_headers(out, "Route"),
-              testing::MatchesRegex("Route: <sip:5\\.2\\.3\\.4:56787;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;service=scscf>"));
+              testing::MatchesRegex("Route: <sip:5\\.2\\.3\\.4:56787;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr>"));
   EXPECT_THAT(get_headers(out, "P-Served-User"),
               testing::MatchesRegex("P-Served-User: <sip:6505551234@homedomain>;sescase=term;regstate=reg"));
 
@@ -5402,7 +5402,7 @@ TEST_F(SCSCFTest, TerminatingWithNoEnumRewrite)
 
   EXPECT_EQ("sip:1115551234@homedomain", r1.uri());
   EXPECT_THAT(get_headers(out, "Route"),
-              testing::MatchesRegex("Route: <sip:5\\.2\\.3\\.4:56787;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;service=scscf>"));
+              testing::MatchesRegex("Route: <sip:5\\.2\\.3\\.4:56787;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr>"));
   EXPECT_THAT(get_headers(out, "P-Served-User"),
               testing::MatchesRegex("P-Served-User: <sip:1115551234@homedomain>;sescase=term;regstate=reg"));
 
@@ -5528,7 +5528,7 @@ TEST_F(SCSCFTest, MmtelCdiv)
   tpAS2.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:6505555678@homedomain", r1.uri());
   EXPECT_THAT(get_headers(out, "Route"),
-              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;orig;service=scscf>"));
+              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;orig>"));
   EXPECT_THAT(get_headers(out, "P-Served-User"),
               testing::MatchesRegex("P-Served-User: <sip:6505551234@homedomain>;orig-cdiv"));
   EXPECT_THAT(get_headers(out, "History-Info"),
@@ -5740,7 +5740,7 @@ TEST_F(SCSCFTest, MmtelDoubleCdiv)
   tpAS2.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:6505559012@homedomain", r1.uri());
   EXPECT_THAT(get_headers(out, "Route"),
-              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;orig;service=scscf>"));
+              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;orig>"));
   EXPECT_THAT(get_headers(out, "P-Served-User"),
               testing::MatchesRegex("P-Served-User: <sip:6505555678@homedomain>;orig-cdiv"));
   EXPECT_THAT(get_headers(out, "History-Info"),
@@ -5836,7 +5836,7 @@ TEST_F(SCSCFTest, ExpiredChain)
   tpAS1.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:6505551234@homedomain", r1.uri());
   EXPECT_THAT(get_headers(out, "Route"),
-              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;orig;service=scscf>"));
+              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;orig>"));
 
   // ---------- AS1 gives final response, ending the transaction.
   string fresp = respond_to_txdata(current_txdata(), 404);
@@ -5974,7 +5974,7 @@ TEST_F(SCSCFTest, MmtelFlow)
   tpAS1.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:6505551234@homedomain", r1.uri());
   EXPECT_THAT(get_headers(out, "Route"),
-              testing::MatchesRegex("Route: <sip:5\\.2\\.3\\.4:56787;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;service=scscf>"));
+              testing::MatchesRegex("Route: <sip:5\\.2\\.3\\.4:56787;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr>"));
   EXPECT_EQ("Privacy: id; header; user", get_headers(out, "Privacy"));
 
   // ---------- AS1 turns it around (acting as proxy)
@@ -6155,7 +6155,7 @@ TEST_F(SCSCFTest, MmtelThenExternal)
   tpAS1.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:6505551234@homedomain", r1.uri());
   EXPECT_THAT(get_headers(out, "Route"),
-              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;orig;service=scscf>"));
+              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;orig>"));
   EXPECT_EQ("Privacy: id; header; user", get_headers(out, "Privacy"));
   EXPECT_THAT(get_headers(out, "P-Served-User"),
               testing::MatchesRegex("P-Served-User: <sip:6505551000@homedomain>;sescase=orig;regstate=unreg"));
@@ -6188,7 +6188,7 @@ TEST_F(SCSCFTest, MmtelThenExternal)
   tpAS2.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:6505551234@homedomain", r1.uri());
   EXPECT_THAT(get_headers(out, "Route"),
-              testing::MatchesRegex("Route: <sip:5\\.2\\.3\\.4:56787;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;service=scscf>"));
+              testing::MatchesRegex("Route: <sip:5\\.2\\.3\\.4:56787;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr>"));
   EXPECT_THAT(get_headers(out, "P-Served-User"),
               testing::MatchesRegex("P-Served-User: <sip:6505551234@homedomain>;sescase=term;regstate=reg"));
 
@@ -6385,7 +6385,7 @@ TEST_F(SCSCFTest, MultipleMmtelFlow)
   tpAS1.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:6505551234@homedomain", r1.uri());
   EXPECT_THAT(get_headers(out, "Route"),
-              testing::MatchesRegex("Route: <sip:5\\.2\\.3\\.4:56787;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;service=scscf>"));
+              testing::MatchesRegex("Route: <sip:5\\.2\\.3\\.4:56787;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr>"));
   EXPECT_EQ("Privacy: id; header; user", get_headers(out, "Privacy"));
 
   // ---------- AS1 turns it around (acting as proxy)
@@ -6471,7 +6471,7 @@ TEST_F(SCSCFTest, SimpleOptionsAccept)
   tpAS1.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:6505551234@homedomain", r1.uri());
   EXPECT_THAT(get_headers(out, "Route"),
-              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;service=scscf>"));
+              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr>"));
 
   // ---------- AS1 accepts it with 200.
   string fresp = respond_to_txdata(current_txdata(), 200);
@@ -6556,7 +6556,7 @@ TEST_F(SCSCFTest, TerminatingDiversionExternal)
   tpAS.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:6505501234@homedomain", r1.uri());
   EXPECT_THAT(get_headers(out, "Route"),
-              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;service=scscf>"));
+              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr>"));
   EXPECT_THAT(get_headers(out, "P-Served-User"),
               testing::MatchesRegex("P-Served-User: <sip:6505501234@homedomain>;sescase=term;regstate=reg"));
 
@@ -6703,7 +6703,7 @@ TEST_F(SCSCFTest, OriginatingExternal)
   tpAS.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:6505501234@ut.cw-ngv.com", r1.uri());
   EXPECT_THAT(get_headers(out, "Route"),
-              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;orig;service=scscf>"));
+              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;orig>"));
   EXPECT_THAT(get_headers(out, "P-Served-User"),
               testing::MatchesRegex("P-Served-User: <sip:6505551000@homedomain>;sescase=orig;regstate=reg"));
 
@@ -6860,7 +6860,7 @@ TEST_F(SCSCFTest, OriginatingTerminatingAS)
   tpAS.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:6505551234@homedomain", r1.uri());
   EXPECT_THAT(get_headers(out, "Route"),
-              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;orig;service=scscf>"));
+              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;orig>"));
   EXPECT_THAT(get_headers(out, "P-Served-User"),
               testing::MatchesRegex("P-Served-User: <sip:6505551000@homedomain>;sescase=orig;regstate=reg"));
 
@@ -6908,7 +6908,7 @@ TEST_F(SCSCFTest, OriginatingTerminatingAS)
   tpAS.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:6505551234@homedomain", r1.uri());
   EXPECT_THAT(get_headers(out, "Route"),
-              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;service=scscf>"));
+              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr>"));
   EXPECT_THAT(get_headers(out, "P-Served-User"),
               testing::MatchesRegex("P-Served-User: <sip:6505551234@homedomain>;sescase=term;regstate=reg"));
 
@@ -7078,7 +7078,7 @@ TEST_F(SCSCFTest, OriginatingTerminatingASTimeout)
   tpAS.expect_target(invite_txdata, false);
   EXPECT_EQ("sip:6505551234@homedomain", r1.uri());
   EXPECT_THAT(get_headers(out, "Route"),
-              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=TCP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=TCP;lr;orig;service=scscf>"));
+              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=TCP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=TCP;lr;orig>"));
   EXPECT_THAT(get_headers(out, "P-Served-User"),
               testing::MatchesRegex("P-Served-User: <sip:6505551000@homedomain>;sescase=orig;regstate=reg"));
 
@@ -7124,7 +7124,7 @@ TEST_F(SCSCFTest, OriginatingTerminatingASTimeout)
   tpAS.expect_target(invite_txdata, false);
   EXPECT_EQ("sip:6505551234@homedomain", r1.uri());
   EXPECT_THAT(get_headers(out, "Route"),
-              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=TCP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=TCP;lr;service=scscf>"));
+              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=TCP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=TCP;lr>"));
   EXPECT_THAT(get_headers(out, "P-Served-User"),
               testing::MatchesRegex("P-Served-User: <sip:6505551234@homedomain>;sescase=term;regstate=reg"));
 
@@ -7361,7 +7361,7 @@ TEST_F(SCSCFTest, OriginatingTerminatingMessageASTimeout)
   tpAS.expect_target(message_txdata, false);
   EXPECT_EQ("sip:6505551234@homedomain", r1.uri());
   EXPECT_THAT(get_headers(out, "Route"),
-              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=TCP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=TCP;lr;orig;service=scscf>"));
+              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=TCP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=TCP;lr;orig>"));
   EXPECT_THAT(get_headers(out, "P-Served-User"),
               testing::MatchesRegex("P-Served-User: <sip:6505551000@homedomain>;sescase=orig;regstate=reg"));
 
@@ -7406,7 +7406,7 @@ TEST_F(SCSCFTest, OriginatingTerminatingMessageASTimeout)
   tpAS.expect_target(message_txdata, false);
   EXPECT_EQ("sip:6505551234@homedomain", r1.uri());
   EXPECT_THAT(get_headers(out, "Route"),
-              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=TCP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=TCP;lr;service=scscf>"));
+              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=TCP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=TCP;lr>"));
   EXPECT_THAT(get_headers(out, "P-Served-User"),
               testing::MatchesRegex("P-Served-User: <sip:6505551234@homedomain>;sescase=term;regstate=reg"));
 
@@ -7568,7 +7568,7 @@ TEST_F(SCSCFTest, TerminatingDiversionExternalOrigCdiv)
   tpAS.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:6505501234@homedomain", r1.uri());
   EXPECT_THAT(get_headers(out, "Route"),
-              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;service=scscf>"));
+              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr>"));
   EXPECT_THAT(get_headers(out, "P-Served-User"),
               testing::MatchesRegex("P-Served-User: <sip:6505501234@homedomain>;sescase=term;regstate=reg"));
 
@@ -7617,7 +7617,7 @@ TEST_F(SCSCFTest, TerminatingDiversionExternalOrigCdiv)
   tpAS.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:6505501234@ut2.cw-ngv.com", r1.uri());
   EXPECT_THAT(get_headers(out, "Route"),
-              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;orig;service=scscf>"));
+              testing::MatchesRegex("Route: <sip:1\\.2\\.3\\.4:56789;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;orig>"));
   EXPECT_THAT(get_headers(out, "P-Served-User"),
               testing::MatchesRegex("P-Served-User: <sip:6505501234@homedomain>;orig-cdiv"));
 

--- a/src/ut/sproutletproxy_test.cpp
+++ b/src/ut/sproutletproxy_test.cpp
@@ -1142,7 +1142,7 @@ TEST_F(SproutletProxyTest, SimpleSproutletForwarderRR)
             get_headers(tdata->msg, "Route"));
 
   // Check a Record-Route header has been added.
-  EXPECT_EQ("Record-Route: <sip:fwdrr.proxy1.homedomain;transport=tcp;lr;service=fwdrr;hello=world>",
+  EXPECT_EQ("Record-Route: <sip:fwdrr.proxy1.homedomain;transport=tcp;lr;hello=world>",
             get_headers(tdata->msg, "Record-Route"));
 
   // Send a 200 OK response.

--- a/src/ut/subscription_test.cpp
+++ b/src/ut/subscription_test.cpp
@@ -66,7 +66,6 @@ public:
     SipTest::SetUpTestCase();
     SipTest::SetScscfUri("sip:all.the.sprout.nodes:5058;transport=TCP");
     add_host_mapping("sprout.example.com", "10.8.8.1");
-    add_host_mapping("scscf-proxy.example.com", "10.8.8.2");
 
     _chronos_connection = new FakeChronosConnection();
     _local_data_store = new LocalStore();
@@ -105,12 +104,14 @@ public:
     _subscription_sproutlet = new SubscriptionSproutlet("subscription",
                                                         5058,
                                                         "sip:subscription.homedomain:5058;transport=tcp",
+                                                        "scscf-proxy",
                                                         _sdm,
                                                         {_remote_sdm},
                                                         _hss_connection,
                                                         _acr_factory,
                                                         _analytics,
                                                         300);
+    EXPECT_TRUE(_subscription_sproutlet->init());
 
     std::list<Sproutlet*> sproutlets;
     sproutlets.push_back(_subscription_sproutlet);
@@ -931,7 +932,6 @@ public:
     SipTest::SetUpTestCase();
     SipTest::SetScscfUri("sip:all.the.sprout.nodes:5058;transport=TCP");
     add_host_mapping("sprout.example.com", "10.8.8.1");
-    add_host_mapping("scscf-proxy.example.com", "10.8.8.2");
   }
 
   void SetUp()
@@ -951,6 +951,7 @@ public:
     _subscription_sproutlet = new SubscriptionSproutlet("subscription",
                                                         5058,
                                                         "sip:subscription.homedomain:5058;transport=tcp",
+                                                        "scscf-proxy",
                                                         _sdm,
                                                         {},
                                                         _hss_connection,


### PR DESCRIPTION
This PR contains the code to plumb the new authentication, registrar and subscription sproutlets together with the existing S-CSCF proxy sproutlet. Please can you review:

* @sathiyan-sivathas please can you be the primary reviewer
* @eleanor-merry please can you cast you eyes over this and check it matched what we discussed. 

I have checked that all the UTs run, as do all the tests in clearwater-live-test (except the B2BUA test which I think might be just broken - though I'll check this when I'm back after Christmas).

You'll see that I have not removed the ability for the sproutlets to specify what ports and URis they want to register. Instead the SCSCF plugin just does not configure these. This is for two reasons:

1. Removing the URi and port makes the sproutlets really awkward to UT in isolation. 
2. One of the benefits of sproutlets is the ability to re-use them. Having sproutlets that can't specify ports and URIs isn't really in keeping with this vision. 
