### PR TITLE
[Reviewer: EM] Re-added listen_port to config options

### DIFF
--- a/sprout-base.root/etc/init.d/sprout
+++ b/sprout-base.root/etc/init.d/sprout
@@ -310,6 +310,7 @@ get_daemon_args()
         [ "$non_register_authentication" = "" ]   || DAEMON_ARGS="$DAEMON_ARGS --non-register-authentication=$non_register_authentication"
         [ "$impi_store_mode" = "" ]               || DAEMON_ARGS="$DAEMON_ARGS --impi-store-mode=$impi_store_mode"
         [ "$nonce_count_supported" != "Y" ]       || DAEMON_ARGS="$DAEMON_ARGS --nonce-count-supported"
+        [ "$listen_port" = "" ]                   || DAEMON_ARGS="$DAEMON_ARGS --listen-port=$listen_port"
 
         for script in /usr/share/clearwater/sprout/plugin_conf.d/*.plugin_conf
         do


### PR DESCRIPTION
listen_port is an old configuration option which specifies a port to be used for all sproutlets. This PR re-adds the option, as it is currently the easiest way to specify a port for a node only running a single, non-default sproutlet.
