### PR TITLE
[Reviewer: EM] Move listen_port from sproutlet_options to main

### DIFF
--- a/include/sproutlet_options.h
+++ b/include/sproutlet_options.h
@@ -145,13 +145,6 @@
       opt.sproutlet_ports.insert(opt.port_##NAME_LOWER);                       \
     }                                                                          \
   }                                                                            \
-  else if (opt.listen_port != 0)                                               \
-  {                                                                            \
-    TRC_INFO("All sproutlets enabled on %d", opt.listen_port);                 \
-    opt.port_##NAME_LOWER = opt.listen_port;                                   \
-    opt.enabled_##NAME_LOWER = true;                                           \
-    opt.sproutlet_ports.insert(opt.port_##NAME_LOWER);                         \
-  }                                                                            \
   else if (opt.port_##NAME_LOWER != 0)                                         \
   {                                                                            \
     TRC_INFO(""#NAME_LOWER" enabled on %d", opt.port_##NAME_LOWER);            \

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1465,6 +1465,12 @@ int main(int argc, char* argv[])
   std::vector<std::string> sproutlet_uris;
   SPROUTLET_MACRO(SPROUTLET_VERIFY_OPTIONS)
 
+  if (opt.listen_port != 0)
+  {
+    TRC_INFO("Opening port %d for non-default sproutlets", opt.listen_port);
+    opt.sproutlet_ports.insert(opt.listen_port);
+  }
+
   if (opt.sas_server == "0.0.0.0")
   {
     TRC_WARNING("SAS server option was invalid or not configured - SAS is disabled");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1159,7 +1159,12 @@ static pj_status_t init_options(int argc, char* argv[], struct options* options)
       options->chronos_hostname = std::string(pj_optarg);
 
     case OPT_LISTEN_PORT:
-      options->listen_port = atoi(pj_optarg);
+      {
+        int listen_port = atoi(pj_optarg);
+        options->sproutlet_ports.insert(listen_port);
+        TRC_INFO("Opening port %d for non-default sproutlets", listen_port);
+      }
+
       break;
 
     SPROUTLET_MACRO(SPROUTLET_OPTIONS)
@@ -1464,12 +1469,6 @@ int main(int argc, char* argv[])
 
   std::vector<std::string> sproutlet_uris;
   SPROUTLET_MACRO(SPROUTLET_VERIFY_OPTIONS)
-
-  if (opt.listen_port != 0)
-  {
-    TRC_INFO("Opening port %d for non-default sproutlets", opt.listen_port);
-    opt.sproutlet_ports.insert(opt.listen_port);
-  }
 
   if (opt.sas_server == "0.0.0.0")
   {


### PR DESCRIPTION
Following from pull request #1672, this removes the listen_port functionality from sproutlet_options so that it does not affect default sproutlets. This is replaced by a block in main which, if listen_port is set, adds the port to the list of ports to be configured. This allows for listen_port to be used to specify a port to be configured for non-default sproutlets without affecting any default sproutlets.