### PR TITLE
[Reviewer: Matt] Ignore PJ_FAILURE from pj_tsx_send_msg in send_request

### DIFF
--- a/src/basicproxy.cpp
+++ b/src/basicproxy.cpp
@@ -1697,15 +1697,13 @@ void BasicProxy::UACTsx::send_request()
       {
         start_timer_c();
       }
-      else
-      {
-        // We do not want to take any action on a failure returned from
-        // pjsip_tsx_send_msg, as it will have also triggered a call into
-        // on_tsx_state. In the event of failure, this will, or already has
-        // cause us to call into retry_request; we do not want to call into
-        // on_client_not_responding below.
-        status = PJ_SUCCESS;
-      }
+
+      // We do not want to take any action on a failure returned from
+      // pjsip_tsx_send_msg, as it will have also triggered a call into
+      // on_tsx_state. In the event of failure, this will, or already has
+      // cause us to call into retry_request; we do not want to call into
+      // on_client_not_responding below, so always return success.
+      status = PJ_SUCCESS;
     }
   }
 

--- a/src/basicproxy.cpp
+++ b/src/basicproxy.cpp
@@ -1697,6 +1697,15 @@ void BasicProxy::UACTsx::send_request()
       {
         start_timer_c();
       }
+      else
+      {
+        // We do not want to take any action on a failure returned from
+        // pjsip_tsx_send_msg, as it will have also triggered a call into
+        // on_tsx_state. In the event of failure, this will, or already has
+        // cause us to call into retry_request; we do not want to call into
+        // on_client_not_responding below.
+        status = PJ_SUCCESS;
+      }
     }
   }
 


### PR DESCRIPTION
As discussed, this is the small fix for send_request.

Just want to run this quickly by you in case it isn't what you were expecting. If you're happy i'll merge down and talk to Rob about system testing it properly. In the process of building it for a quick chef deployment test to make sure it isn't somehow completely broken.

I have opened #1687  to cover further checking in e.g. `retry_request`, to make sure that there aren't further window conditions.
As the issue states, the only location other than `retry_request` where we check the return value of `pjsip_tsx_send_msg` results in us writing a log if it fails, and so is not a serious concern; `retry_request` will want investigation, but as discussed, we are much less likely to hit any error there, as it is already in a retry branch.

