### PR TITLE
[No reviewer] Add log to track hitting window condition

### DIFF
--- a/src/basicproxy.cpp
+++ b/src/basicproxy.cpp
@@ -1698,6 +1698,14 @@ void BasicProxy::UACTsx::send_request()
         start_timer_c();
       }
 
+      // If we got a failure return code, this indicates the window condition
+      // where we got a synchronous failure in pjsip_tsx_send_msg. We ignore
+      // this below, as acting on it can cause failures, but log to track it.
+      if (status != PJ_SUCCESS)
+      {
+        TRC_WARNING("pjsip_tsx_send_msg synchronously returned failure status code");
+      }
+
       // We do not want to take any action on a failure returned from
       // pjsip_tsx_send_msg, as it will have also triggered a call into
       // on_tsx_state. In the event of failure, this will, or already has


### PR DESCRIPTION
@rkd-msw 
This log should hopefully be triggered only when we encounter the synchronous failure in pjsip_tsx_send_msg, which was leading to the failures seen in #1607 .
I'm going to merge all the way down to dev, just to keep commits in line, so as and when you've tested this all i'll revert the change in a new commit if we decide we don't want to keep this log in.