### PR TITLE
Fix SCSCF plugin to correctly configure reg-max-expires

### DIFF
--- a/src/scscfplugin.cpp
+++ b/src/scscfplugin.cpp
@@ -225,7 +225,7 @@ bool SCSCFPlugin::load(struct options& opt, std::list<Sproutlet*>& sproutlets)
                                                   {remote_sdm},
                                                   hss_connection,
                                                   scscf_acr_factory,
-                                                  opt.sub_max_expires,
+                                                  opt.reg_max_expires,
                                                   opt.force_third_party_register_body,
                                                   &reg_stats_tbls,
                                                   &third_party_reg_stats_tbls);


### PR DESCRIPTION
It looks like when refactoring the SCSCF modules into sproutlets, we broken the reg-max-expires config option that controls how log a device can register for. Please can you review my (simple) fix. 

I ran into this problem when running the P-CSCF-emulating stress tests (the tests try to register for 1hr, but were only registering for 5mins so some calls didn't work). I've checked that with this fix (and an appropriate value for reg_max_expires) the tests now work. 