### PR TITLE
[Reviewer: Ellie] Have the init.d abort remove pidfile if it fails

### DIFF
--- a/debian/bono.init.d
+++ b/debian/bono.init.d
@@ -254,6 +254,11 @@ do_abort()
         #   other if a failure occurred
         start-stop-daemon --stop --quiet --retry=ABRT/60/KILL/5 --user $NAME --pidfile $PIDFILE --name $EXECNAME
         RETVAL="$?"
+        # If the abort failed, it may be because the PID in PIDFILE doesn't match the right process
+        # In this window condition, we may not recover, so remove the PIDFILE to get it running
+        if [ $RETVAL != 0 ]; then
+          rm -f $PIDFILE
+        fi
         return "$RETVAL"
 }
 

--- a/debian/restund.init.d
+++ b/debian/restund.init.d
@@ -145,9 +145,12 @@ do_abort()
         #   other if a failure occurred
         start-stop-daemon --stop --quiet --retry=ABRT/60/KILL/5 --name $NAME
         RETVAL="$?"
+        # If the abort failed, it may be because the PID in PIDFILE doesn't match the right process
+        # In this window condition, we may not recover, so remove the PIDFILE to get it running
+        if [ $RETVAL != 0 ]; then
+          rm -f $PIDFILE
+        fi
         [ "$RETVAL" = 2 ] && return 2
-        # Many daemons don't delete their pidfiles when they exit.
-        #rm -f $PIDFILE
         return "$RETVAL"
 }
 

--- a/debian/restund.init.d
+++ b/debian/restund.init.d
@@ -145,11 +145,6 @@ do_abort()
         #   other if a failure occurred
         start-stop-daemon --stop --quiet --retry=ABRT/60/KILL/5 --name $NAME
         RETVAL="$?"
-        # If the abort failed, it may be because the PID in PIDFILE doesn't match the right process
-        # In this window condition, we may not recover, so remove the PIDFILE to get it running
-        if [ $RETVAL != 0 ]; then
-          rm -f $PIDFILE
-        fi
         [ "$RETVAL" = 2 ] && return 2
         return "$RETVAL"
 }

--- a/sprout-base.root/etc/init.d/sprout
+++ b/sprout-base.root/etc/init.d/sprout
@@ -508,6 +508,11 @@ case "$1" in
   abort)
         log_daemon_msg "Aborting $DESC" "$NAME"
         do_abort
+        # If the abort failed, it may be because the PID in PIDFILE doesn't match the right process
+        # In this window condition, we may not recover, so remove the PIDFILE to get it running
+        if [ $? != 0 ]; then
+          rm -f $PIDFILE
+        fi
         ;;
   abort-restart)
         log_daemon_msg "Abort-Restarting $DESC" "$NAME"

--- a/sprout-base.root/etc/init.d/sprout
+++ b/sprout-base.root/etc/init.d/sprout
@@ -392,6 +392,11 @@ do_abort()
         #   other if a failure occurred
         start-stop-daemon --stop --quiet --retry=ABRT/60/KILL/5 --pidfile $PIDFILE --name $EXECNAME
         RETVAL="$?"
+        # If the abort failed, it may be because the PID in PIDFILE doesn't match the right process
+        # In this window condition, we may not recover, so remove the PIDFILE to get it running
+        if [ $RETVAL != 0 ]; then
+          rm -f $PIDFILE
+        fi
         return "$RETVAL"
 }
 
@@ -508,11 +513,6 @@ case "$1" in
   abort)
         log_daemon_msg "Aborting $DESC" "$NAME"
         do_abort
-        # If the abort failed, it may be because the PID in PIDFILE doesn't match the right process
-        # In this window condition, we may not recover, so remove the PIDFILE to get it running
-        if [ $? != 0 ]; then
-          rm -f $PIDFILE
-        fi
         ;;
   abort-restart)
         log_daemon_msg "Abort-Restarting $DESC" "$NAME"


### PR DESCRIPTION
If the abort command fails to kill a process, we attempt to remove the pidfile. 
This is to combine with https://github.com/Metaswitch/clearwater-monit/pull/47, to allow us to resolve #1326 . 
If there is no process running with the pid provided in the pidfile, and matching the expected process name, the abort will fail. We already have code in place to kill rogue processes that match on name, but not on pid. Removing the pidfile allows monit to realise the process is dead if we hit the referenced race condition, and kick off starting the process up again.

If you're happy with this I will go around and make the same change to the init.d scripts for our other processes. 