### PR TITLE
Fix Sprout analytics logs

### DIFF
--- a/include/subscriber_data_manager.h
+++ b/include/subscriber_data_manager.h
@@ -56,7 +56,7 @@ extern "C" {
 #include "rapidjson/writer.h"
 #include "rapidjson/document.h"
 
-// We need to declare the parts of NotifyUtils needed below to avoid a 
+// We need to declare the parts of NotifyUtils needed below to avoid a
 // circular dependency between this and notify_utils.h
 namespace NotifyUtils { struct BindingNotifyInformation; };
 
@@ -628,7 +628,7 @@ private:
   void expire_subscriptions(AoRPair* aor_pair,
                             int now,
                             bool force_expire);
-  
+
   // Iterate over all original and current bindings in an AoR pair and
   // classify them as removed ("EXPIRED"), created ("CREATED"), refreshed ("REFRESHED"),
   // shortened ("SHORTENED") or unchanged ("REGISTERED").
@@ -639,14 +639,16 @@ private:
   void classify_bindings(const std::string& aor_id,
                          SubscriberDataManager::AoRPair* aor_pair,
                          ClassifiedBindings& classified_bindings);
-  
+
   // Iterate over a list of classified bindings, and emit registration logs for those
   // that are EXPIRED or SHORTENED.
-  void log_removed_or_shortened_bindings(ClassifiedBindings& classified_bindings);
+  void log_removed_or_shortened_bindings(ClassifiedBindings& classified_bindings,
+                                         int now);
 
   // Iterate over a list of classified bindings, and emit registration logs for those
   // that are CREATED or REFRESHED.
-  void log_new_or_extended_bindings(ClassifiedBindings& classified_bindings);
+  void log_new_or_extended_bindings(ClassifiedBindings& classified_bindings,
+                                    int now);
 
   static bool unused_bool;
   AnalyticsLogger* _analytics;

--- a/src/subscription.cpp
+++ b/src/subscription.cpp
@@ -139,7 +139,7 @@ SubscriberDataManager::AoRPair* write_subscriptions_to_store(
                                                               ///<backup stores to read from if no entry in store and no backup data
                    SAS::TrailId trail,                        ///<SAS trail
                    std::string public_id,                     ///
-                   bool send_ok,                              ///<Should we create an OK
+                   bool is_primary,                           ///Is this the primary SDM we are writing to?
                    ACR* acr,                                  ///
                    std::deque<std::string> ccfs,              ///
                    std::deque<std::string> ecfs)              ///
@@ -310,7 +310,7 @@ SubscriberDataManager::AoRPair* write_subscriptions_to_store(
     // Build and send the reply.
     pjsip_tx_data* tdata = NULL;
 
-    if (send_ok)
+    if (is_primary)
     {
       status = PJUtils::create_response(stack_data.endpt, rdata, PJSIP_SC_OK, NULL, &tdata);
       if (status != PJ_SUCCESS)
@@ -370,7 +370,7 @@ SubscriberDataManager::AoRPair* write_subscriptions_to_store(
   }
   while (set_rc == Store::DATA_CONTENTION);
 
-  if (analytics != NULL)
+  if ((analytics != NULL) && is_primary)
   {
     // Generate an analytics log for this subscription update.
     analytics->subscription(aor,

--- a/src/ut/mock_analytics_logger.h
+++ b/src/ut/mock_analytics_logger.h
@@ -1,8 +1,8 @@
 /**
- * @file analyticslogger.h Declaration of AnalyticsLogger class.
+ * @file mock_impi_store.h
  *
  * Project Clearwater - IMS in the Cloud
- * Copyright (C) 2013  Metaswitch Networks Ltd
+ * Copyright (C) 2016  Metaswitch Networks Ltd
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -34,49 +34,43 @@
  * as those licenses appear in the file LICENSE-OPENSSL.
  */
 
-///
-///
+#ifndef MOCK_ANALYTICS_LOGGER_H__
+#define MOCK_ANALYTICS_LOGGER_H__
 
-#ifndef ANALYTICSLOGGER_H__
-#define ANALYTICSLOGGER_H__
+#include "gmock/gmock.h"
+#include "analyticslogger.h"
 
-#include <sstream>
-
-class AnalyticsLogger
+class MockAnalyticsLogger : public AnalyticsLogger
 {
 public:
-  AnalyticsLogger();
-  virtual ~AnalyticsLogger();
+  MockAnalyticsLogger() {}
+  virtual ~MockAnalyticsLogger() {}
 
-  void log_with_tag_and_timestamp(char* log);
+  MOCK_METHOD4(registration, void(const std::string& aor,
+                                  const std::string& binding_id,
+                                  const std::string& contact,
+                                  int expires));
 
-  virtual void registration(const std::string& aor,
-                    const std::string& binding_id,
-                    const std::string& contact,
-                    int expires);
+  MOCK_METHOD4(subscription, void(const std::string& aor,
+                                  const std::string& subscription_id,
+                                  const std::string& contact,
+                                  int expires));
 
-  virtual void subscription(const std::string& aor,
-                    const std::string& subscription_id,
-                    const std::string& contact,
-                    int expires);
+  MOCK_METHOD2(auth_failure, void(const std::string& auth,
+                    const std::string& to));
 
-  virtual void auth_failure(const std::string& auth,
-                    const std::string& to);
-
-  virtual void call_connected(const std::string& from,
+  MOCK_METHOD3(call_connected, void(const std::string& from,
                       const std::string& to,
-                      const std::string& call_id);
+                      const std::string& call_id));
 
-  virtual void call_not_connected(const std::string& from,
+  MOCK_METHOD4(call_not_connected, void(const std::string& from,
                           const std::string& to,
                           const std::string& call_id,
-                          int reason);
+                          int reason));
 
-  virtual void call_disconnected(const std::string& call_id,
-                         int reason);
+  MOCK_METHOD2(call_disconnected, void(const std::string& call_id,
+                         int reason));
 
-private:
-  static const int BUFFER_SIZE = 1000;
 };
 
 #endif

--- a/src/ut/subscriber_data_manager_test.cpp
+++ b/src/ut/subscriber_data_manager_test.cpp
@@ -51,7 +51,7 @@
 #include "fakechronosconnection.hpp"
 #include "mock_chronos_connection.h"
 #include "mock_store.h"
-#include "analyticslogger.h"
+#include "mock_analytics_logger.h"
 
 using ::testing::_;
 using ::testing::DoAll;
@@ -90,7 +90,7 @@ class BasicSubscriberDataManagerTest : public SipTest
   {
     _chronos_connection = new FakeChronosConnection();
     _datastore = new LocalStore();
-    _analytics_logger = new AnalyticsLogger();
+    _analytics_logger = new MockAnalyticsLogger();
 
     SubscriberDataManager::SerializerDeserializer* serializer = new T();
     std::vector<SubscriberDataManager::SerializerDeserializer*> deserializers = {
@@ -132,7 +132,7 @@ class BasicSubscriberDataManagerTest : public SipTest
   FakeChronosConnection* _chronos_connection;
   LocalStore* _datastore;
   SubscriberDataManager* _store;
-  AnalyticsLogger* _analytics_logger;
+  MockAnalyticsLogger* _analytics_logger;
 };
 
 // BasicSubscriberDataManagerTest is parameterized over these types.
@@ -169,6 +169,11 @@ TYPED_TEST(BasicSubscriberDataManagerTest, BindingTests)
   // Add the AoR record to the store.
   std::vector<std::string> irs_impus;
   irs_impus.push_back("5102175698@cw-ngv.com");
+  EXPECT_CALL(*(this->_analytics_logger),
+              registration("5102175698@cw-ngv.com",
+                           "urn:uuid:00000000-0000-0000-0000-b4dd32817622:1",
+                           "<sip:5102175698@192.91.191.29:59934;transport=tcp;ob>",
+                           300)).Times(1);
   rc = this->_store->set_aor_data(irs_impus[0], irs_impus, aor_data1, 0);
   EXPECT_TRUE(rc);
   delete aor_data1; aor_data1 = NULL;
@@ -237,6 +242,11 @@ TYPED_TEST(BasicSubscriberDataManagerTest, BindingTests)
   EXPECT_EQ(1u, aor_data1->get_current()->bindings().size());
   aor_data1->get_current()->remove_binding(std::string("urn:uuid:00000000-0000-0000-0000-b4dd32817622:1"));
   EXPECT_EQ(0u, aor_data1->get_current()->bindings().size());
+  EXPECT_CALL(*(this->_analytics_logger),
+              registration("5102175698@cw-ngv.com",
+                           "urn:uuid:00000000-0000-0000-0000-b4dd32817622:1",
+                           "<sip:5102175698@192.91.191.29:59934;transport=tcp;ob>",
+                           0)).Times(1);
   rc = this->_store->set_aor_data(irs_impus[0], irs_impus, aor_data1, 0);
   EXPECT_TRUE(rc);
   delete aor_data1; aor_data1 = NULL;
@@ -534,7 +544,7 @@ class MultiFormatSubscriberDataManagerTest : public ::testing::Test
   {
     _chronos_connection = new FakeChronosConnection();
     _datastore = new LocalStore();
-    _analytics_logger = new AnalyticsLogger();
+    _analytics_logger = new MockAnalyticsLogger();
 
     {
       SubscriberDataManager::SerializerDeserializer* serializer = new T();
@@ -579,7 +589,7 @@ class MultiFormatSubscriberDataManagerTest : public ::testing::Test
   LocalStore* _datastore;
   SubscriberDataManager* _multi_store;
   SubscriberDataManager* _single_store;
-  AnalyticsLogger* _analytics_logger;
+  MockAnalyticsLogger* _analytics_logger;
 };
 
 // MultiFormatSubscriberDataManagerTest is parameterized over these types.
@@ -639,7 +649,7 @@ class SubscriberDataManagerCorruptDataTest : public ::testing::Test
   {
     _chronos_connection = new FakeChronosConnection();
     _datastore = new MockStore();
-    _analytics_logger = new AnalyticsLogger();
+    _analytics_logger = new MockAnalyticsLogger();
 
     {
       SubscriberDataManager::SerializerDeserializer* serializer =
@@ -669,7 +679,7 @@ class SubscriberDataManagerCorruptDataTest : public ::testing::Test
   FakeChronosConnection* _chronos_connection;
   MockStore* _datastore;
   SubscriberDataManager* _store;
-  AnalyticsLogger* _analytics_logger;
+  MockAnalyticsLogger* _analytics_logger;
 };
 
 
@@ -735,7 +745,7 @@ class SubscriberDataManagerChronosRequestsTest : public SipTest
   {
     _chronos_connection = new MockChronosConnection("chronos");
     _datastore = new LocalStore();
-    _analytics_logger = new AnalyticsLogger();
+    _analytics_logger = new MockAnalyticsLogger();
 
     SubscriberDataManager::SerializerDeserializer* serializer =
       new SubscriberDataManager::JsonSerializerDeserializer();
@@ -762,7 +772,7 @@ class SubscriberDataManagerChronosRequestsTest : public SipTest
   MockChronosConnection* _chronos_connection;
   LocalStore* _datastore;
   SubscriberDataManager* _store;
-  AnalyticsLogger* _analytics_logger;
+  MockAnalyticsLogger* _analytics_logger;
 };
 
 // Test that adding an AoR to the store generates a chronos POST request, and that

--- a/src/ut/subscriber_data_manager_test.cpp
+++ b/src/ut/subscriber_data_manager_test.cpp
@@ -52,6 +52,7 @@
 #include "mock_chronos_connection.h"
 #include "mock_store.h"
 #include "mock_analytics_logger.h"
+#include "analyticslogger.h"
 
 using ::testing::_;
 using ::testing::DoAll;
@@ -290,6 +291,11 @@ TYPED_TEST(BasicSubscriberDataManagerTest, SubscriptionTests)
   // Add the AoR record to the store.
   std::vector<std::string> irs_impus;
   irs_impus.push_back("5102175698@cw-ngv.com");
+  EXPECT_CALL(*(this->_analytics_logger),
+              registration("5102175698@cw-ngv.com",
+                           "urn:uuid:00000000-0000-0000-0000-b4dd32817622:1",
+                           "<sip:5102175698@192.91.191.29:59934;transport=tcp;ob>",
+                           300)).Times(1);
   rc = this->_store->set_aor_data(irs_impus[0], irs_impus, aor_data1, 0);
   EXPECT_TRUE(rc);
   delete aor_data1; aor_data1 = NULL;
@@ -496,6 +502,16 @@ TYPED_TEST(BasicSubscriberDataManagerTest, ExpiryTests)
   // Write the record to the store.
   std::vector<std::string> irs_impus;
   irs_impus.push_back("5102175698@cw-ngv.com");
+  EXPECT_CALL(*(this->_analytics_logger),
+              registration("5102175698@cw-ngv.com",
+                           "urn:uuid:00000000-0000-0000-0000-b4dd32817622:2",
+                           "<sip:5102175698@192.91.191.42:59934;transport=tcp;ob>",
+                           200));
+  EXPECT_CALL(*(this->_analytics_logger),
+              registration("5102175698@cw-ngv.com",
+                           "urn:uuid:00000000-0000-0000-0000-b4dd32817622:1",
+                           "<sip:5102175698@192.91.191.29:59934;transport=tcp;ob>",
+                           100));
   rc = this->_store->set_aor_data(irs_impus[0], irs_impus, aor_data1, 0);
   EXPECT_TRUE(rc);
   delete aor_data1; aor_data1 = NULL;
@@ -544,7 +560,7 @@ class MultiFormatSubscriberDataManagerTest : public ::testing::Test
   {
     _chronos_connection = new FakeChronosConnection();
     _datastore = new LocalStore();
-    _analytics_logger = new MockAnalyticsLogger();
+    _analytics_logger = new AnalyticsLogger();
 
     {
       SubscriberDataManager::SerializerDeserializer* serializer = new T();
@@ -589,7 +605,7 @@ class MultiFormatSubscriberDataManagerTest : public ::testing::Test
   LocalStore* _datastore;
   SubscriberDataManager* _multi_store;
   SubscriberDataManager* _single_store;
-  MockAnalyticsLogger* _analytics_logger;
+  AnalyticsLogger* _analytics_logger;
 };
 
 // MultiFormatSubscriberDataManagerTest is parameterized over these types.
@@ -649,7 +665,7 @@ class SubscriberDataManagerCorruptDataTest : public ::testing::Test
   {
     _chronos_connection = new FakeChronosConnection();
     _datastore = new MockStore();
-    _analytics_logger = new MockAnalyticsLogger();
+    _analytics_logger = new AnalyticsLogger();
 
     {
       SubscriberDataManager::SerializerDeserializer* serializer =
@@ -679,7 +695,7 @@ class SubscriberDataManagerCorruptDataTest : public ::testing::Test
   FakeChronosConnection* _chronos_connection;
   MockStore* _datastore;
   SubscriberDataManager* _store;
-  MockAnalyticsLogger* _analytics_logger;
+  AnalyticsLogger* _analytics_logger;
 };
 
 
@@ -745,7 +761,7 @@ class SubscriberDataManagerChronosRequestsTest : public SipTest
   {
     _chronos_connection = new MockChronosConnection("chronos");
     _datastore = new LocalStore();
-    _analytics_logger = new MockAnalyticsLogger();
+    _analytics_logger = new AnalyticsLogger();
 
     SubscriberDataManager::SerializerDeserializer* serializer =
       new SubscriberDataManager::JsonSerializerDeserializer();
@@ -772,7 +788,7 @@ class SubscriberDataManagerChronosRequestsTest : public SipTest
   MockChronosConnection* _chronos_connection;
   LocalStore* _datastore;
   SubscriberDataManager* _store;
-  MockAnalyticsLogger* _analytics_logger;
+  AnalyticsLogger* _analytics_logger;
 };
 
 // Test that adding an AoR to the store generates a chronos POST request, and that

--- a/src/ut/subscription_test.cpp
+++ b/src/ut/subscription_test.cpp
@@ -365,6 +365,11 @@ TEST_F(SubscriptionTest, SimpleMainlineWithTelURI)
 
   SubscribeMessage msg;
   msg._scheme = "tel";
+  EXPECT_CALL(*(this->_analytics),
+              subscription("tel:6505550231",
+                           _,
+                           "sip:f5cc3de4334589d89c661a7acf228ed7@10.114.61.213:5061;transport=tcp;ob",
+                           300)).Times(1);
   inject_msg(msg.get());
 
   std::string to_tag = check_OK_and_NOTIFY("active", std::make_pair("active", "registered"), irs_impus);
@@ -374,6 +379,11 @@ TEST_F(SubscriptionTest, SimpleMainlineWithTelURI)
   // final NOTIFY
   msg._to_tag = to_tag;
   msg._expires = "0";
+  EXPECT_CALL(*(this->_analytics),
+              subscription("tel:6505550231",
+                           _,
+                           "sip:f5cc3de4334589d89c661a7acf228ed7@10.114.61.213:5061;transport=tcp;ob",
+                           0)).Times(1);
   inject_msg(msg.get());
   check_OK_and_NOTIFY("active", std::make_pair("active", "registered"), irs_impus, true, "timeout");
 }
@@ -387,6 +397,11 @@ TEST_F(SubscriptionTest, OneShotSubscription)
   // a NOTIFY
   SubscribeMessage msg;
   msg._expires = "0";
+  EXPECT_CALL(*(this->_analytics),
+              subscription("sip:6505550231@homedomain",
+                           _,
+                           "sip:f5cc3de4334589d89c661a7acf228ed7@10.114.61.213:5061;transport=tcp;ob",
+                           0)).Times(1);
   inject_msg(msg.get());
 
   std::vector<std::string> irs_impus;
@@ -410,6 +425,11 @@ TEST_F(SubscriptionTest, SubscriptionWithNoBindings)
   // Set up a single subscription - this should generate a 200 OK then
   // a NOTIFY
   SubscribeMessage msg;
+  EXPECT_CALL(*(this->_analytics),
+              subscription("sip:6505550231@homedomain",
+                           _,
+                           "sip:f5cc3de4334589d89c661a7acf228ed7@10.114.61.213:5061;transport=tcp;ob",
+                           300)).Times(1);
   inject_msg(msg.get());
 
   // Get OK
@@ -465,6 +485,11 @@ TEST_F(SubscriptionTest, SubscriptionWithDataContention)
   // Set up a single subscription - this should generate a 200 OK then
   // a NOTIFY
   SubscribeMessage msg;
+  EXPECT_CALL(*(this->_analytics),
+              subscription("sip:6505550231@homedomain",
+                           _,
+                           "sip:f5cc3de4334589d89c661a7acf228ed7@10.114.61.213:5061;transport=tcp;ob",
+                           300)).Times(1);
   inject_msg(msg.get());
 
   std::vector<std::string> irs_impus;
@@ -515,6 +540,11 @@ TEST_F(SubscriptionTest, EmptyAcceptsHeader)
 
   SubscribeMessage msg;
   msg._accepts = "";
+  EXPECT_CALL(*(this->_analytics),
+              subscription("sip:6505550231@homedomain",
+                           _,
+                           "sip:f5cc3de4334589d89c661a7acf228ed7@10.114.61.213:5061;transport=tcp;ob",
+                           300)).Times(1);
   inject_msg(msg.get());
 
   std::vector<std::string> irs_impus;
@@ -548,6 +578,11 @@ TEST_F(SubscriptionTest, CorrectAcceptsHeader)
 
   SubscribeMessage msg;
   msg._accepts = "Accept: otherstuff,application/reginfo+xml";
+  EXPECT_CALL(*(this->_analytics),
+              subscription("sip:6505550231@homedomain",
+                           _,
+                           "sip:f5cc3de4334589d89c661a7acf228ed7@10.114.61.213:5061;transport=tcp;ob",
+                           300)).Times(1);
   inject_msg(msg.get());
 
   std::vector<std::string> irs_impus;
@@ -644,6 +679,11 @@ TEST_F(SubscriptionTest, NonPrimaryAssociatedUri)
                                    "  </InitialFilterCriteria>\n"
                                    "</ServiceProfile></IMSSubscription>");
 
+  EXPECT_CALL(*(this->_analytics),
+              subscription("sip:6505550233@homedomain",
+                           _,
+                           "sip:f5cc3de4334589d89c661a7acf228ed7@10.114.61.213:5061;transport=tcp;ob",
+                           300)).Times(1);
   inject_msg(msg.get());
 
   // We expect one registration element per IMPU in the Implicit Registration Set
@@ -695,6 +735,11 @@ TEST_F(SubscriptionTest, NoNotificationsForEmergencyRegistrations)
   check_subscriptions("sip:6505550231@homedomain", 0u);
 
   SubscribeMessage msg;
+  EXPECT_CALL(*(this->_analytics),
+              subscription("sip:6505550231@homedomain",
+                           _,
+                           "sip:f5cc3de4334589d89c661a7acf228ed7@10.114.61.213:5061;transport=tcp;ob",
+                           300)).Times(1);
   inject_msg(msg.get());
 
   ASSERT_EQ(2, txdata_count());
@@ -728,6 +773,11 @@ void SubscriptionTest::check_subscriptions(std::string aor, uint32_t expected)
 TEST_F(SubscriptionTest, CheckNotifyCseqs)
 {
   SubscribeMessage msg;
+  EXPECT_CALL(*(this->_analytics),
+              subscription("sip:6505550231@homedomain",
+                           _,
+                           "sip:f5cc3de4334589d89c661a7acf228ed7@10.114.61.213:5061;transport=tcp;ob",
+                           300)).Times(1);
   inject_msg(msg.get());
 
   // Receive the SUBSCRIBE 200 OK and NOTIFY, then send NOTIFY 200 OK.
@@ -754,6 +804,11 @@ TEST_F(SubscriptionTest, CheckNotifyCseqs)
 
   msg._expires = "0";
   msg._to_tag = to_tag;
+  EXPECT_CALL(*(this->_analytics),
+              subscription("sip:6505550231@homedomain",
+                           _,
+                           "sip:f5cc3de4334589d89c661a7acf228ed7@10.114.61.213:5061;transport=tcp;ob",
+                           0)).Times(1);
   inject_msg(msg.get());
 
   // Receive another SUBSCRIBE 200 OK and NOTIFY, then send NOTIFY 200 OK.
@@ -933,6 +988,11 @@ TEST_F(SubscriptionTestMockStore, SubscriberDataManagerWritesFail)
     .WillOnce(Return(Store::ERROR));
 
   SubscribeMessage msg;
+  EXPECT_CALL(*(this->_analytics),
+              subscription("sip:6505550231@homedomain",
+                           _,
+                           "sip:f5cc3de4334589d89c661a7acf228ed7@10.114.61.213:5061;transport=tcp;ob",
+                           300)).Times(1);
   inject_msg(msg.get());
 
   ASSERT_EQ(1, txdata_count());


### PR DESCRIPTION
Three parts to this...
- Fix REGISTER audit log issues introduced by https://github.com/Metaswitch/sprout/pull/1585/files 
  -  REGISTER audit log expires value should be the time interval (e.g. 300s).  The PR above inadvertently changed this to be the epoch time at which the register will expire
  - de-REGISTER should be logged as a REGISTER with expires=0.  The PR above inadvertently changed this so that it was the previous expiry time (i.e. the logs for a REGISTER and subsequent de-REGISTER were identical).

- Add UTs so that we don't break this again so easily in future.

- Adding UTs for Subscriptions to match those for Registers reveals that we are writing Subscription audit logs on both the primary and backup SDM.   This is inconsistent with what we do for Registers so fix it.
