### PR TITLE
[Reviewer: Ellie] BGCF phone number routing

### DIFF
--- a/src/bgcfsproutlet.cpp
+++ b/src/bgcfsproutlet.cpp
@@ -155,7 +155,18 @@ void BGCFSproutletTsx::on_rx_initial_request(pjsip_msg* req)
   {
     // Find the downstream routes based on the number.
     bgcf_routes = _bgcf->get_route_from_number(routing_value, trail());
-    routing_with_number = true;
+
+    // If there are no matching routes, just route based on the domain - this
+    // only matches any wild card routing set up
+    if (bgcf_routes.empty())
+    {
+      routing_value = "";
+      bgcf_routes = _bgcf->get_route_from_domain(routing_value, trail());
+    }
+    else
+    {
+      routing_with_number = true;
+    }
   }
   else if ((uri_class == LOCAL_PHONE_NUMBER) ||
            (uri_class == GLOBAL_PHONE_NUMBER))

--- a/src/ut/bgcf_test.cpp
+++ b/src/ut/bgcf_test.cpp
@@ -411,6 +411,36 @@ TEST_F(BGCFTest, TestSimpleTelURIUnmatched)
   doSuccessfulFlow(msg, testing::MatchesRegex(".*16505551234$"), hdrs);
 }
 
+// Test that Tel URI with a routing number that matches a number route is picked
+// up by that route
+TEST_F(BGCFTest, TestTelURINPMatched)
+{
+  add_host_mapping("ut.cw-ngv.com", "10.9.8.7");
+  SCOPED_TRACE("");
+  BGCFMessage msg;
+  msg._toscheme = "tel";
+  msg._to = "16505551234;npdi;rn=+16505551234";
+  msg._todomain = "";
+  list<HeaderMatcher> hdrs;
+  hdrs.push_back(HeaderMatcher("Route", ".*10.0.0.1:5060.*"));
+  doSuccessfulFlow(msg, testing::MatchesRegex(".*16505551234$"), hdrs);
+}
+
+// Test that Tel URI with a routing number that doesn't match  a number route is
+// picked up by the wildcard domain route
+TEST_F(BGCFTest, TestTelURINPNotMatched)
+{
+  add_host_mapping("ut.cw-ngv.com", "10.9.8.7");
+  SCOPED_TRACE("");
+  BGCFMessage msg;
+  msg._toscheme = "tel";
+  msg._to = "+16505551234;npdi;rn=16505551234";
+  msg._todomain = "";
+  list<HeaderMatcher> hdrs;
+  hdrs.push_back(HeaderMatcher("Route", ".*10.0.0.2:5060.*"));
+  doSuccessfulFlow(msg, testing::MatchesRegex(".*16505551234$"), hdrs);
+}
+
 TEST_F(BGCFTest, TestValidBGCFRoute)
 {
   SCOPED_TRACE("");


### PR DESCRIPTION
Fallback to wildcard domain route if there is one, if a phone number with routing number parameter doesn't match any configured phone number routes.

This ensures that the URIs tel:xxx and tel:yyy;rn=xxx will be routed the same.

There is a readthedocs change too in https://github.com/Metaswitch/clearwater-readthedocs/pull/241

### Testing
 - UTs added and verified they failed before the change and pass after.