### PR TITLE
Use billing-role none to suppress unwanted ACRs

### DIFF
--- a/include/constants.h
+++ b/include/constants.h
@@ -106,6 +106,7 @@ const pj_str_t STR_SOS = pj_str((char*)"sos");
 const pj_str_t STR_USER = pj_str((char*)"user");
 const pj_str_t STR_CHARGE_ORIG = pj_str((char*)"charge-orig");
 const pj_str_t STR_CHARGE_TERM = pj_str((char*)"charge-term");
+const pj_str_t STR_CHARGE_NONE = pj_str((char*)"charge-none");
 const pj_str_t STR_METHODS = pj_str((char*)"methods");
 const pj_str_t STR_ACCEPT_CONTACT = pj_str((char*)"Accept-Contact");
 const pj_str_t STR_ACCEPT_CONTACT_SHORT = pj_str((char*)"a");

--- a/include/scscfsproutlet.h
+++ b/include/scscfsproutlet.h
@@ -341,7 +341,7 @@ private:
 
   /// Retrieve the billing role for the incoming message.  This should have been
   /// set during session initiation.
-  ACR::NodeRole get_billing_role();
+  bool get_billing_role(ACR::NodeRole& role);
 
   /// Adds a second P-Asserted-Identity header to a message when required.
   void add_second_p_a_i_hdr(pjsip_msg* msg);

--- a/include/scscfsproutlet.h
+++ b/include/scscfsproutlet.h
@@ -339,8 +339,10 @@ private:
                      bool billing_rr,
                      ACR::NodeRole billing_role);
 
-  /// Retrieve the billing role for the incoming message.  This should have been
-  /// set during session initiation.
+  // Inspects the charging-role in the top route header of the incoming message
+  // to determine whether this is a transaction that we should generate an ACR
+  // for. If it is then it returns true and sets role to one of ACR::NodeRole.
+  // Otherwise it returns false.
   bool get_billing_role(ACR::NodeRole& role);
 
   /// Adds a second P-Asserted-Identity header to a message when required.

--- a/src/scscfsproutlet.cpp
+++ b/src/scscfsproutlet.cpp
@@ -1850,6 +1850,7 @@ void SCSCFSproutletTsx::add_to_dialog(pjsip_msg* msg,
   }
   else
   {
+    assert(acr_billing_role == ACR::NODE_ROLE_TERMINATING);
     pjsip_billing_role = &STR_CHARGE_TERM;
   }
 

--- a/src/ut/scscf_test.cpp
+++ b/src/ut/scscf_test.cpp
@@ -4674,8 +4674,8 @@ TEST_F(SCSCFTest, RecordRoutingTestStartAndEnd)
   doFourAppServerFlow("Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;service=scscf;billing-role=charge-term>\r\n"
                       "Record-Route: <sip:6.2.3.4>\r\n"
                       "Record-Route: <sip:5.2.3.4>\r\n"
-                      "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;service=scscf>\r\n"
-                      "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;service=scscf>\r\n"
+                      "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;service=scscf;billing-role=charge-none>\r\n"
+                      "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;service=scscf;billing-role=charge-none>\r\n"
                       "Record-Route: <sip:4.2.3.4>\r\n"
                       "Record-Route: <sip:1.2.3.4>\r\n"
                       "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;service=scscf;billing-role=charge-orig>", true);
@@ -4711,12 +4711,12 @@ TEST_F(SCSCFTest, RecordRoutingTestEachHop)
   // split originating and terminating handling like that yet.
   doFourAppServerFlow("Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;service=scscf;billing-role=charge-term>\r\n"
                       "Record-Route: <sip:6.2.3.4>\r\n"
-                      "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;service=scscf>\r\n"
+                      "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;service=scscf;billing-role=charge-none>\r\n"
                       "Record-Route: <sip:5.2.3.4>\r\n"
-                      "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;service=scscf>\r\n"
-                      "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;service=scscf>\r\n"
+                      "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;service=scscf;billing-role=charge-none>\r\n"
+                      "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;service=scscf;billing-role=charge-none>\r\n"
                       "Record-Route: <sip:4.2.3.4>\r\n"
-                      "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;service=scscf>\r\n"
+                      "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;service=scscf;billing-role=charge-none>\r\n"
                       "Record-Route: <sip:1.2.3.4>\r\n"
                       "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;service=scscf;billing-role=charge-orig>", true);
 
@@ -4743,9 +4743,9 @@ TEST_F(SCSCFTest, RecordRoutingTestCollapseEveryHop)
   stack_data.record_route_on_every_hop = true;
   // Expect 1 Record-Route
   doFourAppServerFlow("Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;service=scscf;billing-role=charge-term>\r\n"
-                      "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;service=scscf>\r\n"
-                      "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;service=scscf>\r\n"
-                      "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;service=scscf>\r\n"
+                      "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;service=scscf;billing-role=charge-none>\r\n"
+                      "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;service=scscf;billing-role=charge-none>\r\n"
+                      "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;service=scscf;billing-role=charge-none>\r\n"
                       "Record-Route: <sip:scscf.homedomain:5058;transport=tcp;lr;service=scscf;billing-role=charge-orig>", false);
   stack_data.record_route_on_every_hop = false;
 }


### PR DESCRIPTION
This is a fix to issue #1667.  
- Previous log wasn't harmless (good spot @rkd).   We were actually generating billing-records for interim hops where we shouldn't have been, and furthermore we were incorrectly marking them as originating when some where in fact terminating.
- Fix is, when record-routing, to explicitly make routes as charge-none if we don't want to generate billing records for that hop, and then when processing an in-dialog request not generate an ACR if the top route header indicates charge-none.   We could have just done this when there was no billing-role specified, but this way is more explicit and allows us to continue to generate a warning if we get a request with a route header that doesn't correctly identify a billing-role.

UTs test that we correctly use charge-none in record-route headers and I've tested live to verify that we now send the correct ACRs to Ralf in a couple of different scenarios (simple call, and call diversion 408 from clearwater-live-test).

I've also raised an issue in the dirt-doc / with CNE tracking the fact that we don't have any regression tests that verify that we generate the correct Rf requests in different calling scenarios.