### PR TITLE
[Reviewer: Ellie] Only start the http stacks after we've bound the socket

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2283,8 +2283,8 @@ int main(int argc, char* argv[])
                                        &auth_timeout_handler);
       http_stack_sig->register_handler("^/registrations?*$",
                                        &deregistration_handler);
-      http_stack_sig->start(&reg_httpthread_with_pjsip);
       http_stack_sig->bind_tcp_socket(opt.http_address, opt.http_port);
+      http_stack_sig->start(&reg_httpthread_with_pjsip);
     }
     catch (HttpStack::Exception& e)
     {
@@ -2303,8 +2303,8 @@ int main(int argc, char* argv[])
                                         &get_subscriptions_handler);
       http_stack_mgmt->register_handler("^/impu/[^/]+$",
                                         &delete_impu_handler);
-      http_stack_mgmt->start(&reg_httpthread_with_pjsip);
       http_stack_mgmt->bind_unix_socket(SPROUT_HTTP_MGMT_SOCKET_PATH);
+      http_stack_mgmt->start(&reg_httpthread_with_pjsip);
     }
     catch (HttpStack::Exception& e)
     {


### PR DESCRIPTION
If we start before we bind to the socket, there's a race condition where the
worker threads might start before we've bound the socket, and in that scenario
they seem to be unable to handle the http requests.

This is what we do for all the other components that use the HttpStack, so it looks like the right thing to do.

This is a fix for issue #1713 

#### Testing
 - live tested