### PR TITLE
[Reviewer: Ellie] Add locking to RalfACR

### DIFF
--- a/include/acr.h
+++ b/include/acr.h
@@ -172,8 +172,17 @@ public:
   /// @param session_id       The session ID to use.
   virtual void override_session_id(const std::string& session_id);
 
-  // Get/release the lock
+  /// Get a lock on the ACR.
+  ///
+  /// An ACR can be accessed from multiple threads (if there are multiple
+  /// SproutletTsx objects that use the same ACR), so those threads must call
+  /// lock() before accessing the ACR.
   virtual void lock();
+
+  /// Release the lock on the ACR.
+  ///
+  /// Should be called after a matching call to lock() once the ACR is no longer
+  /// being accessed.
   virtual void unlock();
 
   /// Called when the ACR message should be sent if it's not yet been

--- a/include/acr.h
+++ b/include/acr.h
@@ -172,6 +172,10 @@ public:
   /// @param session_id       The session ID to use.
   virtual void override_session_id(const std::string& session_id);
 
+  // Get/release the lock
+  virtual void lock();
+  virtual void unlock();
+
   /// Called when the ACR message should be sent if it's not yet been
   /// cancelled.  In general this will be when the relevant transaction or AS
   /// chain has ended.
@@ -304,6 +308,11 @@ public:
   ///
   /// @param session_id       The session ID to use.
   virtual void override_session_id(const std::string& session_id);
+
+  // Get/release the _acr_lock
+  virtual void lock();
+  virtual void unlock();
+
 private:
 
   /// Called when the Rf message should be triggered.  In general this will
@@ -409,6 +418,8 @@ private:
   void store_instance_id(pjsip_msg* msg);
 
   std::string hdr_contents(pjsip_hdr* hdr);
+
+  pthread_mutex_t _acr_lock;
 
   RalfProcessor* _ralf;
   SAS::TrailId _trail;

--- a/src/acr.cpp
+++ b/src/acr.cpp
@@ -96,6 +96,8 @@ void ACR::override_session_id(const std::string& session_id)
 {
 }
 
+// The lock and unlock functions are no-ops for the Null ACR (no need to lock if
+// there's no work to do)
 void ACR::lock()
 {
 }

--- a/src/acr.cpp
+++ b/src/acr.cpp
@@ -96,6 +96,14 @@ void ACR::override_session_id(const std::string& session_id)
 {
 }
 
+void ACR::lock()
+{
+}
+
+void ACR::unlock()
+{
+}
+
 std::string ACR::node_name(Node node_functionality)
 {
   switch (node_functionality)
@@ -173,12 +181,15 @@ RalfACR::RalfACR(RalfProcessor* ralf,
   _req_timestamp.sec = 0;
   _rsp_timestamp.sec = 0;
 
+  pthread_mutex_init(&_acr_lock, NULL);
+
   TRC_DEBUG("Created %s Ralf ACR",
             ACR::node_name(_node_functionality).c_str(), this);
 }
 
 RalfACR::~RalfACR()
 {
+  pthread_mutex_destroy(&_acr_lock);
 }
 
 void RalfACR::rx_request(pjsip_msg* req, pj_time_val timestamp)
@@ -1303,6 +1314,16 @@ void RalfACR::set_default_ccf(const std::string& default_ccf)
 void RalfACR::override_session_id(const std::string& session_id)
 {
   _user_session_id = session_id;
+}
+
+void RalfACR::lock()
+{
+  pthread_mutex_lock(&_acr_lock);
+}
+
+void RalfACR::unlock()
+{
+  pthread_mutex_unlock(&_acr_lock);
 }
 
 void RalfACR::encode_sdp_description(


### PR DESCRIPTION
The RalfACR can be accessed by multiple SCSCFSproutletTsxs, so we need to add locking.

This is a fix for issue #981 

#### Testing
 - tested on a machine that was hitting this crash under load before, and now doesn't