### PR TITLE
[Reviewer: Graeme] Don't call original_request within Mangelwurzel

### DIFF
--- a/include/mangelwurzel/mangelwurzel.h
+++ b/include/mangelwurzel/mangelwurzel.h
@@ -134,10 +134,16 @@ public:
 
   /// Constructor.
   MangelwurzelTsx(SproutletTsxHelper* helper, Config& config) :
-    SproutletTsx(helper), _config(config) {}
+    SproutletTsx(helper),
+    _config(config),
+    _unmodified_request(original_request())
+  {}
 
   /// Destructor.
-  ~MangelwurzelTsx() {}
+  ~MangelwurzelTsx()
+  {
+    free_msg(_unmodified_request);
+  }
 
   /// Implementation of SproutletTsx methods in mangelwurzel.
   virtual void on_rx_initial_request(pjsip_msg* req);
@@ -147,6 +153,7 @@ public:
 private:
   /// The config object for this transaction.
   Config _config;
+  pjsip_msg* _unmodified_request;
 
   /// Helper functions for manipulating SIP messages.
   void mangle_dialog_identifiers(pjsip_msg* req, pj_pool_t* pool);

--- a/include/mangelwurzel/mangelwurzel.h
+++ b/include/mangelwurzel/mangelwurzel.h
@@ -153,6 +153,8 @@ public:
 private:
   /// The config object for this transaction.
   Config _config;
+
+  /// The original request that started this transaction.
   pjsip_msg* _unmodified_request;
 
   /// Helper functions for manipulating SIP messages.

--- a/src/mangelwurzel/mangelwurzel.cpp
+++ b/src/mangelwurzel/mangelwurzel.cpp
@@ -462,8 +462,7 @@ void MangelwurzelTsx::add_via_hdrs(pjsip_msg* rsp, pj_pool_t* pool)
 {
   // Copy all the via headers from the original request back onto the response
   // in the correct order.
-  pjsip_msg* req = original_request();
-  pjsip_via_hdr* via_hdr = (pjsip_via_hdr*)pjsip_msg_find_hdr(req,
+  pjsip_via_hdr* via_hdr = (pjsip_via_hdr*)pjsip_msg_find_hdr(_unmodified_request,
                                                               PJSIP_H_VIA,
                                                               NULL);
   while (via_hdr != NULL)
@@ -472,7 +471,7 @@ void MangelwurzelTsx::add_via_hdrs(pjsip_msg* rsp, pj_pool_t* pool)
                                                                     via_hdr);
     pjsip_msg_add_hdr(rsp, (pjsip_hdr*)cloned_via_hdr);
 
-    via_hdr = (pjsip_via_hdr*)pjsip_msg_find_hdr(req,
+    via_hdr = (pjsip_via_hdr*)pjsip_msg_find_hdr(_unmodified_request,
                                                  PJSIP_H_VIA,
                                                  via_hdr->next);
   }
@@ -524,13 +523,11 @@ void MangelwurzelTsx::edit_scscf_route_hdr(pjsip_msg* req, pj_pool_t* pool)
 /// one.
 void MangelwurzelTsx::mangle_record_routes(pjsip_msg* msg, pj_pool_t* pool)
 {
-  // Get the original request. We use this to calculate which Record-Route
-  // header might be mangelwurzel's.
-  pjsip_msg* original_req = original_request();
+  // Calculate which Record-Route header might be mangelwurzel's.
   int mangelwurzel_rr_index = 1;
 
   pjsip_rr_hdr* rr_hdr =
-    (pjsip_rr_hdr*)pjsip_msg_find_hdr(original_req,
+    (pjsip_rr_hdr*)pjsip_msg_find_hdr(_unmodified_request,
                                       PJSIP_H_RECORD_ROUTE,
                                       NULL);
 
@@ -540,7 +537,7 @@ void MangelwurzelTsx::mangle_record_routes(pjsip_msg* msg, pj_pool_t* pool)
     // mangelwurzel_rr_index. Once we've found all the original Record-Routes
     // we'll have the index of mangelwurzel's Record-Route on our message.
     mangelwurzel_rr_index++;
-    rr_hdr = (pjsip_rr_hdr*)pjsip_msg_find_hdr(original_req,
+    rr_hdr = (pjsip_rr_hdr*)pjsip_msg_find_hdr(_unmodified_request,
                                                PJSIP_H_RECORD_ROUTE,
                                                rr_hdr->next);
   }


### PR DESCRIPTION
I saw loads of messages like this in Mangelwurzel's logs:

```
19-02-2017 22:00:00.020 UTC Warning sproutletproxy.cpp:1184: Sproutlet mangelwurzel-0x7feeb01657d0 leaked 1 messages - reclaiming
19-02-2017 22:00:00.020 UTC Warning sproutletproxy.cpp:1187:   Leaked message - Request msg PRACK/cseq=2 (tdta0x7fee70253900)
19-02-2017 22:00:00.023 UTC Warning sproutletproxy.cpp:1184: Sproutlet mangelwurzel-0x7fee7c203e40 leaked 4 messages - reclaiming
19-02-2017 22:00:00.024 UTC Warning sproutletproxy.cpp:1187:   Leaked message - Request msg INVITE/cseq=1 (tdta0x7fee78020550)
19-02-2017 22:00:00.024 UTC Warning sproutletproxy.cpp:1187:   Leaked message - Request msg INVITE/cseq=1 (tdta0x7fee70048210)
19-02-2017 22:00:00.024 UTC Warning sproutletproxy.cpp:1187:   Leaked message - Request msg INVITE/cseq=1 (tdta0x7feea812fe90)
19-02-2017 22:00:00.024 UTC Warning sproutletproxy.cpp:1187:   Leaked message - Request msg INVITE/cseq=1 (tdta0x7feeb01180e0)
```

I think this is because when we call `original_request()`, that takes a clone of the original request, which it then isn't obvious that you have to free. This change avoids that.