### PR TITLE
[Reviewer: Adam]Enum prefix matching

### DIFF
--- a/include/enumservice.h
+++ b/include/enumservice.h
@@ -121,6 +121,7 @@ private:
   };
 
   std::vector<NumberPrefix> _number_prefixes;
+  std::map<std::string, NumberPrefix> _prefix_regex_map;
   std::string _configuration;
   Updater<void, JSONEnumService>* _updater;
 
@@ -139,7 +140,8 @@ class DNSEnumService : public EnumService
 public:
   DNSEnumService(const std::vector<std::string>& dns_server,
                  const std::string& dns_suffix = ".e164.arpa",
-                 const DNSResolverFactory* resolver_factory = new DNSResolverFactory(),
+                 const DNSResolverFactory* resolver_factory = 
+                                                       new DNSResolverFactory(),
                  CommunicationMonitor* comm_monitor = NULL);
   ~DNSEnumService();
 

--- a/src/enumservice.cpp
+++ b/src/enumservice.cpp
@@ -172,6 +172,7 @@ void JSONEnumService::update_enum()
   try
   {
     std::vector<NumberPrefix> new_number_prefixes;
+    std::map<std::string, NumberPrefix> new_prefix_regex_map;
 
     JSON_ASSERT_CONTAINS(doc, "number_blocks");
     JSON_ASSERT_ARRAY(doc["number_blocks"]);
@@ -196,6 +197,7 @@ void JSONEnumService::update_enum()
         if (parse_regex_replace(regex, pfix.match, pfix.replace))
         {
           new_number_prefixes.push_back(pfix);
+          new_prefix_regex_map.insert(std::make_pair(prefix, pfix));
           TRC_STATUS("  Adding number prefix %s, regex=%s",
                      pfix.prefix.c_str(), regex.c_str());
         }
@@ -217,6 +219,7 @@ void JSONEnumService::update_enum()
     // Take a write lock on the mutex in RAII style
     boost::lock_guard<boost::shared_mutex> write_lock(_number_prefixes_rw_lock);
     _number_prefixes = new_number_prefixes;
+    _prefix_regex_map = new_prefix_regex_map;
   }
   catch (JsonFormatError err)
   {
@@ -293,24 +296,23 @@ std::string JSONEnumService::lookup_uri_from_user(const std::string &user, SAS::
 // the object.
 const JSONEnumService::NumberPrefix* JSONEnumService::prefix_match(const std::string& number) const
 {
-  // For simplicity this uses a linear scan since we don't expect too many
-  // entries.  Should shift to a radix tree at some point.
-  for (std::vector<NumberPrefix>::const_iterator it = _number_prefixes.begin();
-       it != _number_prefixes.end();
+  // Iterate through map in reverse order (already sorted by key length during 
+  // construction) to find the most specific matching prefix
+  for (std::map<std::string, NumberPrefix>::const_reverse_iterator it = 
+                                                     _prefix_regex_map.rbegin();
+       it != _prefix_regex_map.rend();
        it++)
   {
-    int len = std::min(number.size(), it->prefix.size());
+    int len = std::min(number.size(), (*it).first.size());
 
     TRC_DEBUG("Comparing first %d numbers of %s against prefix %s",
-              len, number.c_str(), it->prefix.c_str());
+              len, number.c_str(), (*it).first.c_str());
 
-    if (number.compare(0, len, it->prefix, 0, len) == 0)
+    if (number.compare(0, len, (*it).first, 0, len) == 0)
     {
-      // Found a match, so return it (at the moment we assume the entries are
-      // ordered with most specific matches first so we can stop as soon as we
-      // have one match).
+      // Found a match, so return it. 
       TRC_DEBUG("Match found");
-      return &*it;
+      return &((*it).second);
     }
   }
 

--- a/src/ut/test_enum_prefix_matching.json
+++ b/src/ut/test_enum_prefix_matching.json
@@ -1,0 +1,19 @@
+{
+  "number_blocks": [
+   {
+      "regex": "!(^.*$)!tel:\\1;two-digits-prefix-match;npdi!",
+      "prefix": "+22",
+      "name": "+22 Numbers"
+    },
+    {
+      "regex": "!(^.*$)!tel:\\1;four-digits-prefix-match;npdi!",
+      "prefix": "+2222",
+      "name": "+2222 Numbers"
+    },
+    {
+      "regex": "!(^.*$)!tel:\\1;three-digits-prefix-match;npdi!",
+      "prefix": "+222",
+      "name": "+222 Numbers"
+    } 
+  ]
+}


### PR DESCRIPTION
UT: added a json file where the more specific prefix comes later, test that EnumService is matching to the more specific prefix.
Implementation: current implementation uses a vector containing Pfix, I added a Map containing (prefix, Pfix) and do the matching search using the map, as Map is ordered by key length.

UT passed. 
#1609 