### PR TITLE
[Reviewer: Adam]Check upload json file size & Allow large file using third argument

### DIFF
--- a/sprout-base.root/usr/share/clearwater/clearwater-config-manager/scripts/upload_bgcf_json
+++ b/sprout-base.root/usr/share/clearwater/clearwater-config-manager/scripts/upload_bgcf_json
@@ -35,4 +35,7 @@
 FILENAME=bgcf.json
 KEY=bgcf_json
 
-/usr/share/clearwater/clearwater-config-manager/scripts/upload_json $FILENAME $KEY
+# Pass optional argument directly to upload_json, which checks for --allow-large
+# option that allows file upload larger than advisable
+/usr/share/clearwater/clearwater-config-manager/scripts/upload_json $FILENAME
+$KEY $1

--- a/sprout-base.root/usr/share/clearwater/clearwater-config-manager/scripts/upload_bgcf_json
+++ b/sprout-base.root/usr/share/clearwater/clearwater-config-manager/scripts/upload_bgcf_json
@@ -37,5 +37,4 @@ KEY=bgcf_json
 
 # Pass optional argument directly to upload_json, which checks for --allow-large
 # option that allows file upload larger than advisable
-/usr/share/clearwater/clearwater-config-manager/scripts/upload_json $FILENAME
-$KEY $1
+/usr/share/clearwater/clearwater-config-manager/scripts/upload_json $FILENAME $KEY $1

--- a/sprout-base.root/usr/share/clearwater/clearwater-config-manager/scripts/upload_enum_json
+++ b/sprout-base.root/usr/share/clearwater/clearwater-config-manager/scripts/upload_enum_json
@@ -37,5 +37,4 @@ KEY=enum_json
 
 # Pass optional argument directly to upload_json, which checks for --allow-large
 # option that allows file upload larger than advisable
-/usr/share/clearwater/clearwater-config-manager/scripts/upload_json $FILENAME
-$KEY $1
+/usr/share/clearwater/clearwater-config-manager/scripts/upload_json $FILENAME $KEY $1

--- a/sprout-base.root/usr/share/clearwater/clearwater-config-manager/scripts/upload_enum_json
+++ b/sprout-base.root/usr/share/clearwater/clearwater-config-manager/scripts/upload_enum_json
@@ -35,4 +35,7 @@
 FILENAME=enum.json
 KEY=enum_json
 
-/usr/share/clearwater/clearwater-config-manager/scripts/upload_json $FILENAME $KEY
+# Pass optional argument directly to upload_json, which checks for --allow-large
+# option that allows file upload larger than advisable
+/usr/share/clearwater/clearwater-config-manager/scripts/upload_json $FILENAME
+$KEY $1

--- a/sprout-base.root/usr/share/clearwater/clearwater-config-manager/scripts/upload_json
+++ b/sprout-base.root/usr/share/clearwater/clearwater-config-manager/scripts/upload_json
@@ -35,6 +35,7 @@
 CONFPATH=/etc/clearwater
 FILENAME=$1
 KEY=$2
+ALLOW_LARGE_UPLOADS =$3
 
 function usage() {
   echo "Usage: upload_json <filename> <key>"
@@ -64,6 +65,18 @@ fi
 if [[ ! -f $CONFPATH/$FILENAME ]]
 then
   echo "No configuration file at $CONFPATH/$FILENAME, unable to upload"
+  exit 2
+fi
+
+# Reject file that is too large for etcd. But allow larger file if the script is
+# called with --allow-large, so that the wrapper script is backward compatible.
+# All scripts calling this function will pass the optional argument directly to
+# this function to check if it's --allow-large
+uploadsize=10000
+filesize=$(wc -c <"$CONFPATH/$FILENAME")
+if [[ $filesize -ge $uploadsize && $MODE != "--allow-large" ]]
+then
+  echo "File is larger than the recommended size $uploadsize bytes, use --allow-large if you want to upload"
   exit 2
 fi
 

--- a/sprout-base.root/usr/share/clearwater/clearwater-config-manager/scripts/upload_scscf_json
+++ b/sprout-base.root/usr/share/clearwater/clearwater-config-manager/scripts/upload_scscf_json
@@ -37,5 +37,4 @@ KEY=scscf_json
 
 # Pass optional argument directly to upload_json, which checks for --allow-large
 # option that allows file upload larger than advisable
-/usr/share/clearwater/clearwater-config-manager/scripts/upload_json $FILENAME
-$KEY $1
+/usr/share/clearwater/clearwater-config-manager/scripts/upload_json $FILENAME $KEY $1

--- a/sprout-base.root/usr/share/clearwater/clearwater-config-manager/scripts/upload_scscf_json
+++ b/sprout-base.root/usr/share/clearwater/clearwater-config-manager/scripts/upload_scscf_json
@@ -35,4 +35,7 @@
 FILENAME=s-cscf.json
 KEY=scscf_json
 
-/usr/share/clearwater/clearwater-config-manager/scripts/upload_json $FILENAME $KEY
+# Pass optional argument directly to upload_json, which checks for --allow-large
+# option that allows file upload larger than advisable
+/usr/share/clearwater/clearwater-config-manager/scripts/upload_json $FILENAME
+$KEY $1


### PR DESCRIPTION
Fix according to Rob's suggestion in https://github.com/Metaswitch/clearwater-etcd/pull/409#issuecomment-281081813

In /usr/share/clearwater/clearwater-config-manager/scripts/upload_json, check if the file size is larger than specified (10KB) while NOT using third argument --allow-large. If so, print an error message and exit early.

Tested in real system by uploading a 7KB and 14KB enum.json (using upload_enum_json) and getting the key to see if the upload is successful. 7KB worked, 14KB threw the error message, and 14KB with --allow-large set in the upload_enum_json worked.

#1741 