### PR TITLE
[Reviewer: Adam] Better SIP error code on 500/503 from homestead

### DIFF
--- a/include/scscfsproutlet.h
+++ b/include/scscfsproutlet.h
@@ -142,8 +142,9 @@ private:
                       const std::string& binding_id,
                       SAS::TrailId trail);
 
-  /// Read data for a public user identity from the HSS.
-  bool read_hss_data(const std::string& public_id,
+  /// Read data for a public user identity from the HSS. Returns the HTTP result
+  /// code obtained from homestead.
+  long read_hss_data(const std::string& public_id,
                      const std::string& private_id,
                      const std::string& req_type,
                      bool cache_allowed,
@@ -305,8 +306,8 @@ private:
   void uri_translation(pjsip_msg* req);
 
   /// Gets the subscriber's associated URIs and iFCs for each URI from
-  /// the HSS. Returns true on success, false on failure.
-  bool get_data_from_hss(std::string public_id);
+  /// the HSS. Returns the HTTP result code received from homestead.
+  long get_data_from_hss(std::string public_id);
 
   /// Look up the registration state for the given public ID, using the
   /// per-transaction cache if possible (and caching them and the iFC otherwise).
@@ -322,9 +323,10 @@ private:
   bool get_aliases(std::string public_id,
                    std::vector<std::string>& aliases);
 
-  /// Look up the Ifcs for the given public ID.  The ifcs parameter is only
-  /// filled in correctly if this function returns true.
-  bool lookup_ifcs(std::string public_id,
+  /// Look up the Ifcs for the given public ID, and return the HTTP result code
+  /// from homestead.  The ifcs parameter is only filled in correctly if this
+  /// function returns HTTP_OK.
+  long lookup_ifcs(std::string public_id,
                    Ifcs& ifcs);
 
   /// Add the S-CSCF sproutlet into a dialog.  The third parameter

--- a/src/scscfsproutlet.cpp
+++ b/src/scscfsproutlet.cpp
@@ -273,7 +273,7 @@ void SCSCFSproutlet::remove_binding(const std::string& aor,
 
 
 /// Read data for a public user identity from the HSS.
-bool SCSCFSproutlet::read_hss_data(const std::string& public_id,
+long SCSCFSproutlet::read_hss_data(const std::string& public_id,
                                    const std::string& private_id,
                                    const std::string& req_type,
                                    bool cache_allowed,
@@ -299,14 +299,14 @@ bool SCSCFSproutlet::read_hss_data(const std::string& public_id,
                                                    ecfs,
                                                    cache_allowed,
                                                    trail);
-  if (http_code == 200)
+  if (http_code == HTTP_OK)
   {
     ifcs = ifc_map[public_id];
   }
 
   registered = (regstate == HSSConnection::STATE_REGISTERED);
 
-  return (http_code == 200);
+  return (http_code);
 }
 
 
@@ -983,7 +983,8 @@ pjsip_status_code SCSCFSproutletTsx::determine_served_user(pjsip_msg* req)
         }
 
         Ifcs ifcs;
-        if (lookup_ifcs(served_user, ifcs))
+        long http_code = lookup_ifcs(served_user, ifcs);
+        if (http_code == HTTP_OK)
         {
           TRC_DEBUG("Creating originating CDIV AS chain");
 
@@ -1005,7 +1006,17 @@ pjsip_status_code SCSCFSproutletTsx::determine_served_user(pjsip_msg* req)
         else
         {
           TRC_DEBUG("Failed to retrieve ServiceProfile for %s", served_user.c_str());
-          status_code = PJSIP_SC_NOT_FOUND;
+
+          if ((http_code == HTTP_SERVER_UNAVAILABLE) || (http_code == HTTP_GATEWAY_TIMEOUT))
+          {
+            // Send a SIP 504 response if we got a 500/503 HTTP response.
+            status_code = PJSIP_SC_SERVER_TIMEOUT;
+          }
+          else
+          {
+            status_code = PJSIP_SC_NOT_FOUND;
+          }
+
           SAS::Event no_ifcs(trail(), SASEvent::IFC_GET_FAILURE, 0);
           SAS::report_event(no_ifcs);
         }
@@ -1088,7 +1099,8 @@ pjsip_status_code SCSCFSproutletTsx::determine_served_user(pjsip_msg* req)
       TRC_DEBUG("Looking up iFCs for %s for new AS chain", served_user.c_str());
 
       Ifcs ifcs;
-      if (lookup_ifcs(served_user, ifcs))
+      long http_code = lookup_ifcs(served_user, ifcs);
+      if (http_code == HTTP_OK)
       {
         TRC_DEBUG("Successfully looked up iFCs");
         _as_chain_link = create_as_chain(ifcs, served_user, acr, trail());
@@ -1096,7 +1108,17 @@ pjsip_status_code SCSCFSproutletTsx::determine_served_user(pjsip_msg* req)
       else
       {
         TRC_DEBUG("Failed to retrieve ServiceProfile for %s", served_user.c_str());
-        status_code = PJSIP_SC_NOT_FOUND;
+
+        if ((http_code == HTTP_SERVER_UNAVAILABLE) || (http_code == HTTP_GATEWAY_TIMEOUT))
+        {
+          // Send a SIP 504 response if we got a 500/503 HTTP response.
+          status_code = PJSIP_SC_SERVER_TIMEOUT;
+        }
+        else
+        {
+          status_code = PJSIP_SC_NOT_FOUND;
+        }
+
         SAS::Event no_ifcs(trail(), SASEvent::IFC_GET_FAILURE, 1);
         SAS::report_event(no_ifcs);
 
@@ -1711,32 +1733,36 @@ void SCSCFSproutletTsx::route_to_ue_bindings(pjsip_msg* req)
 }
 
 /// Gets the subscriber's associated URIs and iFCs for each URI from
-/// the HSS and stores cached values. Returns true on success, false on failure.
-bool SCSCFSproutletTsx::get_data_from_hss(std::string public_id)
+/// the HSS and stores cached values. Returns the HTTP result code obtained from
+/// homestead.
+long SCSCFSproutletTsx::get_data_from_hss(std::string public_id)
 {
+  long http_code = HTTP_OK;
   if (!_hss_data_cached)
   {
     std::string req_type = _auto_reg ? HSSConnection::REG : HSSConnection::CALL;
     bool cache_allowed = !_auto_reg;
 
     // We haven't previous read data from the HSS, so read it now.
-    if (_scscf->read_hss_data(public_id,
-                              _impi,
-                              req_type,
-                              cache_allowed,
-                              _registered,
-                              _uris,
-                              _aliases,
-                              _ifcs,
-                              _ccfs,
-                              _ecfs,
-                              trail()))
+    http_code = _scscf->read_hss_data(public_id,
+                                      _impi,
+                                      req_type,
+                                      cache_allowed,
+                                      _registered,
+                                      _uris,
+                                      _aliases,
+                                      _ifcs,
+                                      _ccfs,
+                                      _ecfs,
+                                      trail());
+
+    if (http_code == HTTP_OK)
     {
       _hss_data_cached = true;
     }
   }
 
-  return _hss_data_cached;
+  return http_code;
 }
 
 
@@ -1744,8 +1770,8 @@ bool SCSCFSproutletTsx::get_data_from_hss(std::string public_id)
 /// per-transaction cache if possible (and caching them and the iFC otherwise).
 bool SCSCFSproutletTsx::is_user_registered(std::string public_id)
 {
-  bool success = get_data_from_hss(public_id);
-  if (success)
+  long http_code = get_data_from_hss(public_id);
+  if (http_code == HTTP_OK)
   {
     return _registered;
   }
@@ -1764,12 +1790,12 @@ bool SCSCFSproutletTsx::is_user_registered(std::string public_id)
 bool SCSCFSproutletTsx::get_associated_uris(std::string public_id,
                                             std::vector<std::string>& uris)
 {
-  bool success = get_data_from_hss(public_id);
-  if (success)
+  long http_code = get_data_from_hss(public_id);
+  if (http_code == HTTP_OK)
   {
     uris = _uris;
   }
-  return success;
+  return (http_code == HTTP_OK);
 }
 
 /// Look up the aliases for the given public ID, using the cache if
@@ -1779,28 +1805,29 @@ bool SCSCFSproutletTsx::get_associated_uris(std::string public_id,
 bool SCSCFSproutletTsx::get_aliases(std::string public_id,
                                     std::vector<std::string>& aliases)
 {
-  bool success = get_data_from_hss(public_id);
-  if (success)
+  long http_code = get_data_from_hss(public_id);
+  if (http_code == HTTP_OK)
   {
     aliases = _aliases;
   }
-  return success;
+  return (http_code == HTTP_OK);
 }
 
 
 
 /// Look up the Ifcs for the given public ID, using the cache if possible
 /// (and caching them and the associated URIs otherwise).
+/// Returns the HTTP result code obtained from homestead.
 /// The ifcs parameter is only filled in correctly if this function
-/// returns true,
-bool SCSCFSproutletTsx::lookup_ifcs(std::string public_id, Ifcs& ifcs)
+/// returns HTTP_OK.
+long SCSCFSproutletTsx::lookup_ifcs(std::string public_id, Ifcs& ifcs)
 {
-  bool success = get_data_from_hss(public_id);
-  if (success)
+  long http_code = get_data_from_hss(public_id);
+  if (http_code == HTTP_OK)
   {
     ifcs = _ifcs;
   }
-  return success;
+  return http_code;
 }
 
 

--- a/src/ut/scscf_test.cpp
+++ b/src/ut/scscf_test.cpp
@@ -8596,3 +8596,154 @@ TEST_F(SCSCFTest, TestSessionExpiresWhenNoRecordRoute)
   ASSERT_TRUE(get_headers(out, "Session-Expires").empty());
 }
 
+
+TEST_F(SCSCFTest, HSSTimeoutOnPutRegData)
+{
+  // Send originating INVITE
+  Message msg;
+  msg._route = "Route: <sip:homedomain;orig>";
+
+  // HSS will return a 503
+  _hss_connection->set_rc("/impu/sip%3A6505551000%40homedomain/reg-data", 503);
+
+  inject_msg(msg.get_request());
+
+  // 100 Trying goes out
+  pjsip_msg* out = current_txdata()->msg;
+  RespMatcher(100).matches(out);
+  free_txdata();
+
+  // Followed by a 504
+  out = current_txdata()->msg;
+  EXPECT_EQ(504, out->line.status.code);
+  EXPECT_EQ("Server Timeout", str_pj(out->line.status.reason));
+
+  _hss_connection->delete_rc("/impu/sip%3A6505551000%40homedomain/reg-data");
+}
+
+
+// Test that a failure to get IFCs due to a 503 error from homestead during Call
+// Diversion results in sprout sending a 504
+TEST_F(SCSCFTest, HSSTimeoutOnCdiv)
+{
+  _hss_connection->set_impu_result("sip:6505551234@homedomain", "call", HSSConnection::STATE_REGISTERED,
+                                R"(<IMSSubscription><ServiceProfile>
+                                <PublicIdentity><Identity>sip:6505551234@homedomain</Identity></PublicIdentity>
+                                  <InitialFilterCriteria>
+                                    <Priority>2</Priority>
+                                    <TriggerPoint>
+                                    <ConditionTypeCNF>0</ConditionTypeCNF>
+                                    <SPT>
+                                      <ConditionNegated>0</ConditionNegated>
+                                      <Group>0</Group>
+                                      <SessionCase>4</SessionCase>  <!-- originating-cdiv -->
+                                      <Extension></Extension>
+                                    </SPT>
+                                    <SPT>
+                                      <ConditionNegated>0</ConditionNegated>
+                                      <Group>0</Group>
+                                      <Method>INVITE</Method>
+                                      <Extension></Extension>
+                                    </SPT>
+                                  </TriggerPoint>
+                                  <ApplicationServer>
+                                    <ServerName>sip:1.2.3.4:56789;transport=UDP</ServerName>
+                                    <DefaultHandling>0</DefaultHandling>
+                                  </ApplicationServer>
+                                  </InitialFilterCriteria>
+                                  <InitialFilterCriteria>
+                                    <Priority>0</Priority>
+                                    <TriggerPoint>
+                                    <ConditionTypeCNF>0</ConditionTypeCNF>
+                                    <SPT>
+                                      <ConditionNegated>0</ConditionNegated>
+                                      <Group>0</Group>
+                                      <Method>INVITE</Method>
+                                      <Extension></Extension>
+                                    </SPT>
+                                    <SPT>
+                                      <ConditionNegated>0</ConditionNegated>
+                                      <Group>0</Group>
+                                      <SessionCase>1</SessionCase>  <!-- terminating-registered -->
+                                      <Extension></Extension>
+                                    </SPT>
+                                  </TriggerPoint>
+                                  <ApplicationServer>
+                                    <ServerName>sip:5.2.3.4:56787;transport=UDP</ServerName>
+                                    <DefaultHandling>0</DefaultHandling>
+                                  </ApplicationServer>
+                                  </InitialFilterCriteria>
+                                </ServiceProfile></IMSSubscription>)");
+
+  TransportFlow tpBono(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.99.88.11", 12345);
+  TransportFlow tpAS1(TransportFlow::Protocol::UDP, stack_data.scscf_port, "5.2.3.4", 56787);
+
+  // ---------- Send INVITE
+  // We're within the trust boundary, so no stripping should occur.
+  Message msg;
+  msg._via = "10.99.88.11:12345;transport=TCP";
+  msg._to = "6505551234@homedomain";
+  msg._todomain = "";
+  msg._route = "Route: <sip:homedomain>";
+  msg._requri = "sip:6505551234@homedomain";
+
+  msg._method = "INVITE";
+  inject_msg(msg.get_request(), &tpBono);
+  poll();
+  ASSERT_EQ(2, txdata_count());
+
+  // 100 Trying goes back to bono
+  pjsip_msg* out = current_txdata()->msg;
+  RespMatcher(100).matches(out);
+  tpBono.expect_target(current_txdata(), true);  // Requests always come back on same transport
+  msg.set_route(out);
+  free_txdata();
+
+  // INVITE passed on to AS1 (as terminating AS for Bob)
+  SCOPED_TRACE("INVITE (S)");
+  out = current_txdata()->msg;
+  ReqMatcher r1("INVITE");
+  ASSERT_NO_FATAL_FAILURE(r1.matches(out));
+
+  tpAS1.expect_target(current_txdata(), false);
+  EXPECT_EQ("sip:6505551234@homedomain", r1.uri());
+  EXPECT_THAT(get_headers(out, "Route"),
+              testing::MatchesRegex("Route: <sip:5\\.2\\.3\\.4:56787;transport=UDP;lr>\r\nRoute: <sip:odi_[+/A-Za-z0-9]+@127.0.0.1:5058;transport=UDP;lr;service=scscf>"));
+  EXPECT_THAT(get_headers(out, "P-Served-User"),
+              testing::MatchesRegex("P-Served-User: <sip:6505551234@homedomain>;sescase=term;regstate=reg"));
+
+  // ---------- AS1 sends a 100 Trying to indicate it has received the request.
+  string fresp1 = respond_to_txdata(current_txdata(), 100);
+  inject_msg(fresp1, &tpAS1);
+
+  // The next request to the HSS will get a 503 response
+  _hss_connection->delete_result("sip:6505551234@homedomain");
+  _hss_connection->set_rc("/impu/sip%3A6505551234%40homedomain/reg-data", 503);
+
+  // ---------- AS1 turns it around (acting as routing B2BUA by changing the target)
+  const pj_str_t STR_ROUTE = pj_str("Route");
+  pjsip_hdr* hdr = (pjsip_hdr*)pjsip_msg_find_hdr_by_name(out, &STR_ROUTE, NULL);
+  if (hdr)
+  {
+    pj_list_erase(hdr);
+  }
+  ((pjsip_sip_uri*)out->line.req.uri)->user = pj_str("6505555678");
+  inject_msg(out, &tpAS1);
+  free_txdata();
+
+  // 100 Trying goes back to AS1
+  out = current_txdata()->msg;
+  RespMatcher(100).matches(out);
+  tpAS1.expect_target(current_txdata(), true);  // Requests always come back on same transport
+  msg.set_route(out);
+  free_txdata();
+
+  // Followed by a 504 (since the IFC lookup has got a 503)
+  out = current_txdata()->msg;
+  RespMatcher(504).matches(out);
+  tpAS1.expect_target(current_txdata(), true);  // Requests always come back on same transport
+  free_txdata();
+
+  _hss_connection->delete_rc("/impu/sip%3A6505551000%40homedomain/reg-data");
+}
+

--- a/src/ut/scscf_test.cpp
+++ b/src/ut/scscf_test.cpp
@@ -8597,6 +8597,8 @@ TEST_F(SCSCFTest, TestSessionExpiresWhenNoRecordRoute)
 }
 
 
+// Test that getting a 503 error from homestead when looking up IFCs results in
+// sprout sending a 504 error.
 TEST_F(SCSCFTest, HSSTimeoutOnPutRegData)
 {
   // Send originating INVITE


### PR DESCRIPTION
Turn a 500/503 error from homestead when looking up IFCs into a SIP 504 error.

This only covers this specific case, not the more general problem of turning HTTP error codes into the correct SIP error code. We think we should be doing this kind of thing more generally, but we don't want to be making such a wide-reaching change at this point.

So the plan is to merge this to release-114-fixes and then dev, and then raise an issue against dev to ensure we look at a fuller fix for this in future.

#### Testing done
- UTs added to check we're sending a 504 in the 2 places that it was added
- manually live tested to ensure we actually send a 504 when we get a 503 response from homestead for the HTTP PUT that we send as part of the INVITE flow to set up a call
- clearwater-live-tests run over a deployment including this fix and verified to pass