### PR TITLE
[Reviewer: Adam] Enum visual separators

### DIFF
--- a/src/ut/enumservice_test.cpp
+++ b/src/ut/enumservice_test.cpp
@@ -215,6 +215,16 @@ TEST_F(JSONEnumServiceTest, PrefixMatching)
   ET("+22228899", "tel:+22228899;four-digits-prefix-match;npdi").test(enum_);
 }
 
+// Test if prefix matching correctly ignores all visual separators
+TEST_F(JSONEnumServiceTest, StripSeparators)
+{
+  // Test enum file contains prefixes with visual separators
+  JSONEnumService enum_(string(UT_DIR).append("/test_enum_strip_separator.json"));
+  ET("+22338899", "tel:+22338899;two-digits-prefix-match;npdi").test(enum_);
+  ET("+22238899", "tel:+22238899;three-digits-prefix-match;npdi").test(enum_);
+  ET("+22228899", "tel:+22228899;four-digits-prefix-match;npdi").test(enum_);
+}
+
 struct ares_naptr_reply basic_naptr_reply[] = {
   {NULL, (unsigned char*)"u", (unsigned char*)"e2u+sip", 
                     (unsigned char*)"!(^.*$)!sip:\\1@ut.cw-ngv.com!", ".", 1, 1}

--- a/src/ut/test_enum_strip_separator.json
+++ b/src/ut/test_enum_strip_separator.json
@@ -1,0 +1,19 @@
+{
+  "number_blocks": [
+   {
+      "regex": "!(^.*$)!tel:\\1;two-digits-prefix-match;npdi!",
+      "prefix": "+2.2",
+      "name": "+22 Numbers"
+    },
+    {
+      "regex": "!(^.*$)!tel:\\1;three-digits-prefix-match;npdi!",
+      "prefix": "+2.2-2",
+      "name": "+222 Numbers"
+    },
+    {
+      "regex": "!(^.*$)!tel:\\1;four-digits-prefix-match;npdi!",
+      "prefix": "+2.2-(22)",
+      "name": "+2222 Numbers"
+    } 
+  ]
+}


### PR DESCRIPTION
Fixed #1622 to allow visual separators in enum json file, by using the same strip-separators functions as used in bgcfservice. Tested.