### PR TITLE
Fix up record-routing for AS default handling

### DIFF
--- a/include/scscfsproutlet.h
+++ b/include/scscfsproutlet.h
@@ -454,6 +454,19 @@ private:
 
   /// Class to handle session-expires processing.
   SessionExpiresHelper _se_helper;
+
+  /// The base request that the S-CSCF should use when retrying a request. This
+  /// is currently only used when invoking default handling for an Application
+  /// Server.
+  ///
+  /// This variable is updated when the S-CSCF record-routes itself into the
+  /// dialog. If the S-CSCF has not record-routed itself, then this pointer will
+  /// be NULL and the original request should be used instead (this is all
+  /// handled by the `get_base_request` utility method below).
+  pjsip_msg* _base_req;
+
+  /// Get the base request that the S-CSCF should use when retrying a request.
+  pjsip_msg* get_base_request();
 };
 
 #endif

--- a/src/scscfsproutlet.cpp
+++ b/src/scscfsproutlet.cpp
@@ -2197,7 +2197,7 @@ std::string SCSCFSproutletTsx::fork_failure_reason_as_string(int fork_id, int si
 
 pjsip_msg* SCSCFSproutletTsx::get_base_request()
 {
-  if (_base_req)
+  if (_base_req != nullptr)
   {
     return clone_msg(_base_req);
   }

--- a/src/scscfsproutlet.cpp
+++ b/src/scscfsproutlet.cpp
@@ -404,7 +404,8 @@ SCSCFSproutletTsx::SCSCFSproutletTsx(SproutletTsxHelper* helper,
   _video_call(false),
   _impi(),
   _auto_reg(false),
-  _se_helper(stack_data.default_session_expires)
+  _se_helper(stack_data.default_session_expires),
+  _base_req(nullptr)
 {
   TRC_DEBUG("S-CSCF Transaction (%p) created", this);
 }
@@ -443,6 +444,11 @@ SCSCFSproutletTsx::~SCSCFSproutletTsx()
   }
 
   _target_bindings.clear();
+
+  if (_base_req != nullptr)
+  {
+    free_msg(_base_req);
+  }
 }
 
 
@@ -683,7 +689,7 @@ void SCSCFSproutletTsx::on_rx_response(pjsip_msg* rsp, int fork_id)
           SAS::report_event(bypass_As);
 
           _as_chain_link = _as_chain_link.next();
-          pjsip_msg* req = original_request();
+          pjsip_msg* req = get_base_request();
           _record_routed = false;
           if (_session_case->is_originating())
           {
@@ -1903,6 +1909,14 @@ void SCSCFSproutletTsx::add_to_dialog(pjsip_msg* msg,
     // terminating hop.  Update the billing role.
     pj_strdup(pool, &param->value, pjsip_billing_role);
   }
+
+  // Store off the modified message - we may need it later if we need to invoke
+  // default handling for an AS.
+  if (_base_req != nullptr)
+  {
+    free_msg(_base_req);
+  }
+  _base_req = clone_msg(msg);
 }
 
 
@@ -1982,7 +1996,7 @@ void SCSCFSproutletTsx::on_timer_expiry(void* context)
       SAS::report_event(bypass_as);
 
       _as_chain_link = _as_chain_link.next();
-      pjsip_msg* req = original_request();
+      pjsip_msg* req = get_base_request();
       _record_routed = false;
       if (_session_case->is_originating())
       {
@@ -2000,7 +2014,7 @@ void SCSCFSproutletTsx::on_timer_expiry(void* context)
       SAS::report_event(as_failed);
 
       // Build and send a timeout response upstream.
-      pjsip_msg* req = original_request();
+      pjsip_msg* req = get_base_request();
       pjsip_msg* rsp = create_response(req,
                                        PJSIP_SC_REQUEST_TIMEOUT);
       free_msg(req);
@@ -2179,4 +2193,16 @@ std::string SCSCFSproutletTsx::fork_failure_reason_as_string(int fork_id, int si
   }
 
   return reason;
+}
+
+pjsip_msg* SCSCFSproutletTsx::get_base_request()
+{
+  if (_base_req)
+  {
+    return clone_msg(_base_req);
+  }
+  else
+  {
+    return original_request();
+  }
 }

--- a/src/ut/scscf_test.cpp
+++ b/src/ut/scscf_test.cpp
@@ -4886,6 +4886,10 @@ TEST_F(SCSCFTest, DefaultHandlingContinueFirstAsFailsRRTest)
 // This test configures two ASs for the terminating subscriber, and checks that
 // the S-CSCF still record-routes itself correctly when the first AS fails, is
 // bypassed, and the request is routed to the second AS.
+//
+// This test configured record routing at the start of terminating processing,
+// so we can check the terminating Record-Route is preserved when bypassing the
+// AS.
 TEST_F(SCSCFTest, DefaultHandlingContinueFirstTermAsFailsRRTest)
 {
   // Register an endpoint to act as the callee.
@@ -4937,10 +4941,10 @@ TEST_F(SCSCFTest, DefaultHandlingContinueFirstTermAsFailsRRTest)
   TransportFlow tpAS1(TransportFlow::Protocol::TCP, stack_data.scscf_port, "1.2.3.4", 56789);
   TransportFlow tpCallee(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.114.61.213", 5061);
 
+  bool old_rr_on_comp_of_orig = stack_data.record_route_on_completion_of_originating;
+  bool old_rr_on_init_of_term = stack_data.record_route_on_initiation_of_terminating;
   stack_data.record_route_on_initiation_of_terminating = true;
   stack_data.record_route_on_completion_of_originating = true;
-  stack_data.record_route_on_diversion = false;
-  stack_data.record_route_on_every_hop = false;
 
   // Caller sends INVITE
   Message msg;
@@ -4980,10 +4984,8 @@ TEST_F(SCSCFTest, DefaultHandlingContinueFirstTermAsFailsRRTest)
                            "Record-Route:.*billing-role=charge-orig.*"));
   free_txdata();
 
-  stack_data.record_route_on_initiation_of_terminating = false;
-  stack_data.record_route_on_completion_of_originating = false;
-  stack_data.record_route_on_diversion = false;
-  stack_data.record_route_on_every_hop = false;
+  stack_data.record_route_on_initiation_of_terminating = old_rr_on_init_of_term;
+  stack_data.record_route_on_completion_of_originating = old_rr_on_comp_of_orig;
 }
 
 // Test that when Sprout is configured to Record-Route itself only at

--- a/src/ut/scscf_test.cpp
+++ b/src/ut/scscf_test.cpp
@@ -4631,7 +4631,8 @@ TEST_F(SCSCFTest, DefaultHandlingMalformed)
 // Test DefaultHandling=CONTINUE for non-existent AS (where name does not resolve).
 //
 // This test configures an AS for the originating subscriber, and checks that
-// the S-CSCF still record-routes itself correctly.
+// the S-CSCF still record-routes itself correctly when the AS fails and is
+// bypassed.
 TEST_F(SCSCFTest, DefaultHandlingContinueNonExistentRRTest)
 {
   register_uri(_sdm, _hss_connection, "6505551234", "homedomain", "sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob");
@@ -4699,6 +4700,11 @@ TEST_F(SCSCFTest, DefaultHandlingContinueNonExistentRRTest)
   free_txdata();
 }
 
+// Test DefaultHandling=CONTINUE for an unresponsive AS.
+//
+// This test configures an AS for the originating subscriber, and checks that
+// the S-CSCF still record-routes itself correctly when the AS times out and is
+// bypassed.
 TEST_F(SCSCFTest, DefaultHandlingContinueTimeoutRRTest)
 {
   // Register an endpoint to act as the callee.
@@ -4787,6 +4793,11 @@ TEST_F(SCSCFTest, DefaultHandlingContinueTimeoutRRTest)
   free_txdata();
 }
 
+// Test DefaultHandling=CONTINUE for non-existent AS.
+//
+// This test configures two ASs for the originating subscriber, and checks that
+// the S-CSCF still record-routes itself correctly when the first AS fails, is
+// bypassed, and the request is routed to the second AS.
 TEST_F(SCSCFTest, DefaultHandlingContinueFirstAsFailsRRTest)
 {
   // Register an endpoint to act as the callee.
@@ -4870,6 +4881,11 @@ TEST_F(SCSCFTest, DefaultHandlingContinueFirstAsFailsRRTest)
   free_txdata();
 }
 
+// Test DefaultHandling=CONTINUE for non-existent AS.
+//
+// This test configures two ASs for the terminating subscriber, and checks that
+// the S-CSCF still record-routes itself correctly when the first AS fails, is
+// bypassed, and the request is routed to the second AS.
 TEST_F(SCSCFTest, DefaultHandlingContinueFirstTermAsFailsRRTest)
 {
   // Register an endpoint to act as the callee.


### PR DESCRIPTION
Previously we had an issue where if a session continued AS was bypassed, the onward request didn't have the correct record route headers. This is because we record-route when determining the served user, but then call `original_request` when retrying to the next AS. 

I've fixed this by saving off the request when the S-CSCF record-routes itself, and using this request as a baseline when bypassing an AS. 

I've reproduced the original error in UT, and used this to checked the fix works. 