### PR TITLE
Fixed minor bugs for the check-upload-json-size commit Issue 1747.

### DIFF
--- a/sprout-base.root/usr/share/clearwater/clearwater-config-manager/scripts/upload_json
+++ b/sprout-base.root/usr/share/clearwater/clearwater-config-manager/scripts/upload_json
@@ -35,7 +35,7 @@
 CONFPATH=/etc/clearwater
 FILENAME=$1
 KEY=$2
-ALLOW_LARGE_UPLOADS =$3
+ALLOW_LARGE_UPLOADS=$3
 
 function usage() {
   echo "Usage: upload_json <filename> <key>"
@@ -74,7 +74,7 @@ fi
 # this function to check if it's --allow-large
 uploadsize=10000
 filesize=$(wc -c <"$CONFPATH/$FILENAME")
-if [[ $filesize -ge $uploadsize && $MODE != "--allow-large" ]]
+if [[ $filesize -ge $uploadsize && $ALLOW_LARGE_UPLOADS!= "--allow-large" ]]
 then
   echo "File is larger than the recommended size $uploadsize bytes, use --allow-large if you want to upload"
   exit 2


### PR DESCRIPTION
As @huws pointed out, removed a space between "ALLOW_LARGE_UPLOADS" and "=" and changed the variable reference to using the right name.
