### PR TITLE
[Reviewer: RKD] Allow list headers to have a trailing comma

### DIFF
--- a/src/ut/common_sip_processing_test.cpp
+++ b/src/ut/common_sip_processing_test.cpp
@@ -461,6 +461,50 @@ TEST_F(CommonProcessingTest, BadResponseDropped)
   ASSERT_EQ(0, txdata_count());
 }
 
+TEST_F(CommonProcessingTest, BadSupportedHeader1)
+{
+  // Tests that a trailing comma on request is accepted.
+  pjsip_tx_data* tdata;
+  pjsip_endpt_register_module(stack_data.endpt, &mod_ok);
+
+  // Inject a request with a trailing comma.
+  Message msg1;
+  msg1._extra = "Supported: timer,";
+  inject_msg(msg1.get_request(), _tp);
+
+  // Expect a response from mod_ok.
+  ASSERT_EQ(1, txdata_count());
+
+  tdata = current_txdata();
+  RespMatcher r1(200);
+  r1.matches(tdata->msg);
+
+  free_txdata();
+  pjsip_endpt_unregister_module(stack_data.endpt, &mod_ok);
+}
+
+TEST_F(CommonProcessingTest, BadSupportedHeader2)
+{
+  // Tests that a trailing comma on request is accepted.
+  pjsip_tx_data* tdata;
+  pjsip_endpt_register_module(stack_data.endpt, &mod_ok);
+
+  // Inject a request with a trailing comma.
+  Message msg1;
+  msg1._extra = "Supported: timer, path, ";
+  inject_msg(msg1.get_request(), _tp);
+
+  // Expect a response from mod_ok.
+  ASSERT_EQ(1, txdata_count());
+
+  tdata = current_txdata();
+  RespMatcher r1(200);
+  r1.matches(tdata->msg);
+
+  free_txdata();
+  pjsip_endpt_unregister_module(stack_data.endpt, &mod_ok);
+}
+
 // If:
 //  - an exception has already been hit
 //  - the health-checker runs a check

--- a/src/ut/common_sip_processing_test.cpp
+++ b/src/ut/common_sip_processing_test.cpp
@@ -461,47 +461,52 @@ TEST_F(CommonProcessingTest, BadResponseDropped)
   ASSERT_EQ(0, txdata_count());
 }
 
-TEST_F(CommonProcessingTest, BadSupportedHeader1)
+TEST_F(CommonProcessingTest, SupportedHeaderWithCommas)
 {
-  // Tests that a trailing comma on request is accepted.
-  pjsip_tx_data* tdata;
+  // Tests that a variety of Supported headers are accepted 
+  // including ones with trailing commas.
+    std::vector<std::string> headers = { 
+      "Supported: ",
+      "Supported: \n ",
+      "Supported: timer",
+      "Supported: timer\n   ",
+      "Supported: \n timer",
+      "Supported: timer, path",
+      "Supported: timer,\n path",
+      "Supported: timer\n ,",
+      "Supported: timer,",
+      "Supported: timer\n ,",
+      "Supported: timer,path, ",
+      "Supported: timer, \n path, ",
+      "Supported: \n timer,\n path, ",
+      "Supported: ,",
+      "Supported: ,,,,,,",
+      "Supported: ,,,\n ,,,",
+  };
+  
+  // Set up a new Load monitor with enough tokens for each test.
+  delete(_lm);
+  _lm = new LoadMonitor(0, headers.size(), 0, 0);
+  init_common_sip_processing(_lm, _requests_counter, _overload_counter, _health_checker);
+
   pjsip_endpt_register_module(stack_data.endpt, &mod_ok);
 
-  // Inject a request with a trailing comma.
-  Message msg1;
-  msg1._extra = "Supported: timer,";
-  inject_msg(msg1.get_request(), _tp);
+  for (std::string h: headers) {
+    SCOPED_TRACE(h);
+    // Inject a request with the latest header.
+    Message msg1;
+    msg1._extra = h;
+    inject_msg(msg1.get_request(), _tp);
 
-  // Expect a response from mod_ok.
-  ASSERT_EQ(1, txdata_count());
+    // Expect a response from mod_ok.
+    ASSERT_EQ(1, txdata_count());
 
-  tdata = current_txdata();
-  RespMatcher r1(200);
-  r1.matches(tdata->msg);
+    pjsip_tx_data* tdata = current_txdata();
+    RespMatcher r1(200);
+    r1.matches(tdata->msg);
 
-  free_txdata();
-  pjsip_endpt_unregister_module(stack_data.endpt, &mod_ok);
-}
-
-TEST_F(CommonProcessingTest, BadSupportedHeader2)
-{
-  // Tests that a trailing comma on request is accepted.
-  pjsip_tx_data* tdata;
-  pjsip_endpt_register_module(stack_data.endpt, &mod_ok);
-
-  // Inject a request with a trailing comma.
-  Message msg1;
-  msg1._extra = "Supported: timer, path, ";
-  inject_msg(msg1.get_request(), _tp);
-
-  // Expect a response from mod_ok.
-  ASSERT_EQ(1, txdata_count());
-
-  tdata = current_txdata();
-  RespMatcher r1(200);
-  r1.matches(tdata->msg);
-
-  free_txdata();
+    free_txdata();
+  }
   pjsip_endpt_unregister_module(stack_data.endpt, &mod_ok);
 }
 


### PR DESCRIPTION
Rob,

Could you review this change to the tests for the Supported: header with a trailing comma?  Passing direct to you since you've looked at this already - hope that's OK.

Note that I have not run the live tests against this fix as it seems fairly minor.  Let me know if you think I need to run them before releasing.

Neil