### PR TITLE
[Reviewer: Rob] Clean up access logs and limit analytics logs

### DIFF
--- a/scripts/sprout-log-cleanup
+++ b/scripts/sprout-log-cleanup
@@ -6,4 +6,5 @@ max_log_directory_size=$ONE_GIG
 
 python2.7 /usr/share/clearwater/bin/log_cleanup.py /var/log/sprout --prefix sprout_ --maxsize $max_log_directory_size --count $WEEK_COUNT
 python2.7 /usr/share/clearwater/bin/log_cleanup.py /var/log/sprout --prefix log_ --maxsize $max_log_directory_size --count $WEEK_COUNT
-python2.7 /usr/share/clearwater/bin/log_cleanup.py /var/log/sprout --prefix analytics --maxsize $max_log_directory_size
+python2.7 /usr/share/clearwater/bin/log_cleanup.py /var/log/sprout --prefix access --maxsize $max_log_directory_size --count $WEEK_COUNT
+python2.7 /usr/share/clearwater/bin/log_cleanup.py /var/log/sprout --prefix analytics --maxsize $max_log_directory_size --count $WEEK_COUNT


### PR DESCRIPTION
Rob,

This changes the log cleanup script for sprout so that we limit the number of sprout access logs, and set a count limit on the analytics logs.

Note, this is still quite broken in a number of ways, but I'll address this in a separate change for dev only.

This partially reverts the change to log cleanup made in https://github.com/Metaswitch/sprout/pull/1572 and partially fixes the issues seen under https://github.com/Metaswitch/sprout/issues/1783