### PR TITLE
[Reviewer: Seb] Don't configure LDAP or RTMP for curl

### DIFF
--- a/mk/curl.mk
+++ b/mk/curl.mk
@@ -8,7 +8,7 @@ ${CURL_CONFIGURE}:
 	cd ${CURL_DIR} && ./buildconf
 
 ${CURL_MAKEFILE}: ${CURL_CONFIGURE}
-	cd ${CURL_DIR} && ./configure --prefix=${INSTALL_DIR} --enable-ares=${INSTALL_DIR}
+	cd ${CURL_DIR} && ./configure --prefix=${INSTALL_DIR} --enable-ares=${INSTALL_DIR} --without-librtmp --disable-ldap --disable-ldaps
 
 curl: ${CURL_MAKEFILE}
 	${MAKE} -C ${CURL_DIR}


### PR DESCRIPTION
If we don't do this, we need to install extra libraries (librtmp, libldap liblber) to nodes running Sprout in order to ensure they run correctly.

As we don't need these protocols, we should just disable them at configure time.