### PR TITLE
[Reviewer: Seb] Disable lua and nodejs support in thrift

### DIFF
--- a/mk/thrift.mk
+++ b/mk/thrift.mk
@@ -9,7 +9,7 @@ ${THRIFT_CONFIGURE}:
 	cd ${THRIFT_DIR} && ./bootstrap.sh
 
 ${THRIFT_MAKEFILE}: ${THRIFT_CONFIGURE}
-	cd ${THRIFT_DIR} && ${THRIFT_CONFIGURE}  --prefix=${INSTALL_DIR} --without-csharp --without-java --without-erlang --without-python --without-perl --without-php --without-ruby --without-haskell --without-go --without-d
+	cd ${THRIFT_DIR} && ${THRIFT_CONFIGURE}  --prefix=${INSTALL_DIR} --without-csharp --without-java --without-erlang --without-python --without-perl --without-php --without-ruby --without-haskell --without-go --without-d --without-nodejs --without-lua
 
 thrift: ${INSTALL_DIR}/bin/thrift
 


### PR DESCRIPTION
This fixes issue #1786.

Thrift by default has bindings for a whole load of languages. If you attempt to build Sprout on a platform with npm installed, it attempts to create Javascript bindings. This can fail, and given we don't need them, it's easiest to just disable support for npm (and lua while we are here, as we don't need that either).