### PR TITLE
[Reviewer: Seb] Link to libdl when building curl

### DIFF
--- a/mk/curl.mk
+++ b/mk/curl.mk
@@ -8,7 +8,7 @@ ${CURL_CONFIGURE}:
 	cd ${CURL_DIR} && ./buildconf
 
 ${CURL_MAKEFILE}: ${CURL_CONFIGURE}
-	cd ${CURL_DIR} && ./configure --prefix=${INSTALL_DIR} --enable-ares=${INSTALL_DIR} --without-librtmp --disable-ldap --disable-ldaps
+	cd ${CURL_DIR} && LDFLAGS=-ldl ./configure --prefix=${INSTALL_DIR} --enable-ares=${INSTALL_DIR} --without-librtmp --disable-ldap --disable-ldaps
 
 curl: ${CURL_MAKEFILE}
 	${MAKE} -C ${CURL_DIR}


### PR DESCRIPTION
Seb,

This fixes the problem building Sprout you were seeing on Friday.

Curl doesn't build when not linking to libldap if we don't manually specify that we need to link to libdl.

This is an upstream bug in curl's configure script -
https://curl.haxx.se/mail/lib-2009-10/0375.html

It's not entirely clear to me why this does work when you *do* link to libldap without specifying "-ldl" anywhere.