### PR TITLE
[Reviewer: Ellie] Include margin in default subscription expiry.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1559,7 +1559,7 @@ int main(int argc, char* argv[])
   if (opt.sub_max_expires == 0)
   {
     opt.sub_max_expires = opt.reg_max_expires + 161;
-    TRC_INFO("Subscription max expiry defaulted to %d based on registration max expiry %d",
+    TRC_INFO("Maximum subscription period defaulted to %d seconds, based maximum registration expiry %d seconds",
              opt.sub_max_expires, opt.reg_max_expires);
   }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1457,7 +1457,7 @@ int main(int argc, char* argv[])
   // also.
   opt.reg_max_expires = 300;
 
-  opt.sub_max_expires = 300;
+  opt.sub_max_expires = 0;
   opt.sas_server = "0.0.0.0";
   opt.record_routing_model = 1;
   opt.default_session_expires = 10 * 60;
@@ -1550,6 +1550,17 @@ int main(int argc, char* argv[])
   if (status != PJ_SUCCESS)
   {
     return 1;
+  }
+
+  // If sub_max_expires is unset, then allow a higher number than the
+  // maximum registration expiry, as required by TS 24.229 5.2.3.
+  // RFC 3680 suggests 3761 seconds for an expiry of 3600. We thus add
+  // 161 seconds for the maximum subscription expiry by default.
+  if (opt.sub_max_expires == 0)
+  {
+    opt.sub_max_expires = opt.reg_max_expires + 161;
+    TRC_INFO("Subscription max expiry defaulted to %d based on registration max expiry %d",
+             opt.sub_max_expires, opt.reg_max_expires);
   }
 
   if (opt.pidfile != "")


### PR DESCRIPTION
TS 24.229 suggests the P-CSCF should send a higher subscription max expiry than
the registration. Thus we default the max subscription expiry to a higher value.

RFC 3680 suggests 3761 for an expiry of 3600, so we just add 161 seconds to the registration max expiry.