### PR TITLE
Fix extraneous NOTIFYs being sent to other subscribers when a subscriber re-SUBSCRIBEs.

### DIFF
--- a/include/subscriber_data_manager.h
+++ b/include/subscriber_data_manager.h
@@ -146,6 +146,10 @@ public:
       /// The call ID for the subscription dialog.
       std::string _cid;
 
+      /// The CSeq number of the last received SUBSCRIBE for this subscription.
+      /// A value of -1 means that no CSeq has yet been received.
+      int _last_cseq;
+
       /// The list of Record Route URIs from the subscription dialog.
       std::list<std::string> _route_uris;
 
@@ -485,29 +489,19 @@ public:
     // @param associated_uris
     //                     The IMPUs associated with this IRS
     // @param aor_pair     The AoR pair to send NOTIFYs for
+    // @param all_bnis     The list of bindings to include on the NOTIFY
+    // @param expired_binding_uris
+    //                     A list of URIs of expired bindings    
     // @param now          The current time
     // @param trail        SAS trail
     void send_notifys_for_expired_subscriptions(
                                    const std::string& aor_id,
                                    AssociatedURIs* associated_uris,
                                    SubscriberDataManager::AoRPair* aor_pair,
+                                   std::vector<NotifyUtils::BindingNotifyInformation*> all_bnis,
+                                   std::vector<std::string> expired_binding_uris,                                  
                                    int now,
                                    SAS::TrailId trail);
-
-    // Create and send any appropriate NOTIFYs for any current subscriptions
-    //
-    // @param aor_id       The AoR ID
-    // @param associated_uris
-    //                     The IMPUs associated with this IRS
-    // @param aor_pair     The AoR pair to send NOTIFYs for
-    // @param now          The current time
-    // @param trail        SAS trail
-    void send_notifys_for_current_subscriptions(
-                                      const std::string& aor_id,
-                                      AssociatedURIs* associated_uris,
-                                      SubscriberDataManager::AoRPair* aor_pair,
-                                      int now,
-                                      SAS::TrailId trail);
   };
 
   /// Tags to use when setting timers for nothing, for registration and for subscription.

--- a/include/subscriber_data_manager.h
+++ b/include/subscriber_data_manager.h
@@ -126,6 +126,8 @@ public:
     class Subscription
     {
     public:
+      Subscription(): _refreshed(false) {};
+
       /// The Contact URI for the subscription dialog (used as the Request URI
       /// of the NOTIFY)
       std::string _req_uri;
@@ -146,9 +148,8 @@ public:
       /// The call ID for the subscription dialog.
       std::string _cid;
 
-      /// The CSeq number of the last received SUBSCRIBE for this subscription.
-      /// A value of -1 means that no CSeq has yet been received.
-      int _last_cseq;
+      /// Whether the subscription has been refreshed since the last NOTIFY.
+      bool _refreshed;
 
       /// The list of Record Route URIs from the subscription dialog.
       std::list<std::string> _route_uris;
@@ -489,7 +490,8 @@ public:
     // @param associated_uris
     //                     The IMPUs associated with this IRS
     // @param aor_pair     The AoR pair to send NOTIFYs for
-    // @param all_bnis     The list of bindings to include on the NOTIFY
+    // @param binding_info_to_notify
+    //                     The list of bindings to include on the NOTIFY
     // @param expired_binding_uris
     //                     A list of URIs of expired bindings    
     // @param now          The current time
@@ -498,7 +500,7 @@ public:
                                    const std::string& aor_id,
                                    AssociatedURIs* associated_uris,
                                    SubscriberDataManager::AoRPair* aor_pair,
-                                   std::vector<NotifyUtils::BindingNotifyInformation*> all_bnis,
+                                   std::vector<NotifyUtils::BindingNotifyInformation*> binding_info_to_notify,
                                    std::vector<std::string> expired_binding_uris,                                  
                                    int now,
                                    SAS::TrailId trail);

--- a/include/subscriber_data_manager.h
+++ b/include/subscriber_data_manager.h
@@ -500,7 +500,7 @@ public:
                                    const std::string& aor_id,
                                    AssociatedURIs* associated_uris,
                                    SubscriberDataManager::AoRPair* aor_pair,
-                                   std::vector<NotifyUtils::BindingNotifyInformation*> binding_info_to_notify,
+                                   ClassifiedBindings binding_info_to_notify,
                                    std::vector<std::string> expired_binding_uris,                                  
                                    int now,
                                    SAS::TrailId trail);

--- a/src/subscriber_data_manager.cpp
+++ b/src/subscriber_data_manager.cpp
@@ -1619,13 +1619,14 @@ void SubscriberDataManager::NotifySender::send_notifys(
     std::string b_id = aor_orig_b.first;
 
     // Compare the original and current lists to see whether this binding has expired.
-    if ((!aor_orig_b.second->_emergency_registration) &&
+    if ((!b->_emergency_registration) &&
         (aor_pair->get_current()->bindings().find(b_id) == aor_pair->get_current()->bindings().end()))
     {
+      TRC_DEBUG("Binding %s has expired", b_id);
       expired_binding_uris.push_back(b->_uri);
       NotifyUtils::BindingNotifyInformation* bni =
-               new NotifyUtils::BindingNotifyInformation(aor_orig_b.first,
-                                                         aor_orig_b.second,
+               new NotifyUtils::BindingNotifyInformation(b_id,
+                                                         b,
                                                          NotifyUtils::ContactEvent::EXPIRED);      
       all_bnis.push_back(bni);
       bindings_changed = true;

--- a/src/subscriber_data_manager.cpp
+++ b/src/subscriber_data_manager.cpp
@@ -1764,7 +1764,7 @@ void SubscriberDataManager::NotifySender::send_notifys(
                                         PJUtils::pj_status_to_string(status);
           event.add_var_param(error_msg);
           SAS::report_event(event);
-        // LCOV_EXCL_STOP
+          // LCOV_EXCL_STOP
         }
       }      
     }
@@ -1777,7 +1777,7 @@ void SubscriberDataManager::NotifySender::send_notifys_for_expired_subscriptions
                                const std::string& aor_id,
                                AssociatedURIs* associated_uris,
                                SubscriberDataManager::AoRPair* aor_pair,
-                               std::vector<NotifyUtils::BindingNotifyInformation*> binding_info_to_notify,
+                               ClassifiedBindings binding_info_to_notify,
                                std::vector<std::string> expired_binding_uris,                               
                                int now,
                                SAS::TrailId trail)

--- a/src/subscriptionsproutlet.cpp
+++ b/src/subscriptionsproutlet.cpp
@@ -588,9 +588,6 @@ SubscriberDataManager::AoRPair* SubscriptionSproutletTsx::write_subscriptions_to
       // Update/create the subscription.
       subscription->_req_uri = contact_uri;
 
-      pjsip_cseq_hdr* cseq_hdr = (pjsip_cseq_hdr*)pjsip_msg_find_hdr(req, PJSIP_H_CSEQ, NULL);
-      subscription->_last_cseq = cseq_hdr->cseq;
-
       subscription->_route_uris.clear();
       pjsip_route_hdr* route_hdr = (pjsip_route_hdr*)pjsip_msg_find_hdr(req,
                                                                         PJSIP_H_RECORD_ROUTE,
@@ -614,6 +611,7 @@ SubscriberDataManager::AoRPair* SubscriptionSproutletTsx::write_subscriptions_to
       subscription->_to_tag = subscription_id;
       subscription->_from_uri = PJUtils::uri_to_string(PJSIP_URI_IN_FROMTO_HDR, from->uri);
       subscription->_from_tag = PJUtils::pj_str_to_string(&from->tag);
+      subscription->_refreshed = true;
 
       // Calculate the expiry period for the subscription.
       expiry = (expires != NULL) ?

--- a/src/subscriptionsproutlet.cpp
+++ b/src/subscriptionsproutlet.cpp
@@ -478,7 +478,7 @@ SubscriberDataManager::AoRPair* SubscriptionSproutletTsx::write_subscriptions_to
   Store::Status set_rc;
   SubscriberDataManager::AoRPair* aor_pair = NULL;
   std::string subscription_contact;
-  std::string subscription_id;  
+  std::string subscription_id;
 
   do
   {

--- a/src/subscriptionsproutlet.cpp
+++ b/src/subscriptionsproutlet.cpp
@@ -478,7 +478,7 @@ SubscriberDataManager::AoRPair* SubscriptionSproutletTsx::write_subscriptions_to
   Store::Status set_rc;
   SubscriberDataManager::AoRPair* aor_pair = NULL;
   std::string subscription_contact;
-  std::string subscription_id;
+  std::string subscription_id;  
 
   do
   {
@@ -574,7 +574,7 @@ SubscriberDataManager::AoRPair* SubscriptionSproutletTsx::write_subscriptions_to
       if (subscription_id == "")
       {
         // If there's no to tag, generate an unique one
-        // TODO: Should use unique depolyment and instance IDs here.
+        // TODO: Should use unique deployment and instance IDs here.
         subscription_id = std::to_string(Utils::generate_unique_integer(0, 0));
       }
 
@@ -587,6 +587,9 @@ SubscriberDataManager::AoRPair* SubscriptionSproutletTsx::write_subscriptions_to
 
       // Update/create the subscription.
       subscription->_req_uri = contact_uri;
+
+      pjsip_cseq_hdr* cseq_hdr = (pjsip_cseq_hdr*)pjsip_msg_find_hdr(req, PJSIP_H_CSEQ, NULL);
+      subscription->_last_cseq = cseq_hdr->cseq;
 
       subscription->_route_uris.clear();
       pjsip_route_hdr* route_hdr = (pjsip_route_hdr*)pjsip_msg_find_hdr(req,

--- a/src/ut/subscription_test.cpp
+++ b/src/ut/subscription_test.cpp
@@ -243,18 +243,32 @@ string SubscribeMessage::get()
   char buf[16384];
 
   std::string branch = _branch.empty() ? "Pjmo1aimuq33BAI4rjhgQgBr4sY" + std::to_string(_unique) : _branch;
-  std::string from_uri;
-  std::string to_uri;
+  char from_uri[256];
+  char to_uri[256];
 
   if (_scheme == "tel")
   {
-    from_uri = string(_scheme).append(":").append(_subscribing_user); 
-    to_uri = string(_scheme).append(":").append(_user);
+    snprintf(from_uri, sizeof(from_uri),
+             "%s:%s",
+             _scheme.c_str(),
+             _subscribing_user.c_str());
+    snprintf(to_uri, sizeof(to_uri),
+             "%s:%s",
+             _scheme.c_str(),
+             _user.c_str());
   }
   else
   {
-    from_uri = string(_scheme).append(":").append(_subscribing_user).append("@").append(_domain);
-    to_uri = string(_scheme).append(":").append(_user).append("@").append(_domain);
+    snprintf(from_uri, sizeof(from_uri),
+             "%s:%s@%s",
+             _scheme.c_str(),
+             _subscribing_user.c_str(),
+             _domain.c_str());
+    snprintf(to_uri, sizeof(to_uri),
+             "%s:%s@%s",
+             _scheme.c_str(),
+             _user.c_str(),
+             _domain.c_str());
   }
 
   int n = snprintf(buf, sizeof(buf),
@@ -285,7 +299,7 @@ string SubscribeMessage::get()
                    "%6$s",
 
                    /*  1 */ _method.c_str(),
-                   /*  2 */ to_uri.c_str(),
+                   /*  2 */ to_uri,
                    /*  3 */ _domain.c_str(),
                    /*  4 */ _content_type.empty() ? "" : string("Content-Type: ").append(_content_type).append("\r\n").c_str(),
                    /*  5 */ (int)_body.length(),
@@ -300,7 +314,7 @@ string SubscribeMessage::get()
                    /* 14 */ _to_tag.empty() ? "": string(";tag=").append(_to_tag).c_str(),
                    /* 15 */ branch.c_str(),
                    /* 16 */ _unique,
-                   /* 17 */ from_uri.c_str()
+                   /* 17 */ from_uri
     );
 
   EXPECT_LT(n, (int)sizeof(buf));


### PR DESCRIPTION
- Track the latest CSeq on a SUBSCRIBE received for each subscription.
- Only send NOTIFYs if the bindings have changed, the CSeq has changed or this is a new subscription.