### PR TITLE
[Reviewer RKD]: Emit json.tool output to screen to aid problem determination

### DIFF
--- a/sprout-base.root/usr/share/clearwater/clearwater-config-manager/scripts/upload_json
+++ b/sprout-base.root/usr/share/clearwater/clearwater-config-manager/scripts/upload_json
@@ -86,10 +86,11 @@ if [[ ! -s $CONFPATH/$FILENAME ]]
 then
   echo "The configuration file at $CONFPATH/$FILENAME is empty, uploading a blank file"
 else
-  python -m json.tool < $CONFPATH/$FILENAME > /dev/null 2>&1
+  jsoncheck=$(python -m json.tool < $CONFPATH/$FILENAME 2>&1)
   rc=$?
   if [ $rc != 0 ]; then
-    echo "The configuration file at $CONFPATH/$FILENAME contains invalid JSON"
+    echo "The configuration file at $CONFPATH/$FILENAME contains invalid JSON."
+    echo $jsoncheck
     echo "Please provide a valid configuration file, and re-run the command"
     exit 2
   fi

--- a/sprout-base.root/usr/share/clearwater/clearwater-config-manager/scripts/upload_json
+++ b/sprout-base.root/usr/share/clearwater/clearwater-config-manager/scripts/upload_json
@@ -89,9 +89,9 @@ else
   jsoncheck=$(python -m json.tool < $CONFPATH/$FILENAME 2>&1)
   rc=$?
   if [ $rc != 0 ]; then
-    echo "The configuration file at $CONFPATH/$FILENAME contains invalid JSON."
-    echo $jsoncheck
-    echo "Please provide a valid configuration file, and re-run the command"
+    echo "The configuration file at $CONFPATH/$FILENAME contains invalid JSON. The JSON parser reported the following error:"
+    echo - \"$jsoncheck\"
+    echo "Correct $CONFPATH/$FILENAME to use the documented syntax for this configuration file type, and re-run the command"
     exit 2
   fi
 fi


### PR DESCRIPTION
Hi Rob

Can you review this tweak to https://github.com/Metaswitch/sprout/pull/1803 to emit the error text from json.tool to the screen?

Tested live against a deliberately broken enum.json file, and the upload_enum_json tool now emits, e.g.

"The configuration file at /etc/clearwater/enum.json contains invalid JSON.
Expecting , delimiter: line 7 column 5 (char 173)
Please provide a valid configuration file, and re-run the command"

(I deleted one of the square brackets in the file.  line7 column 5 is the location of the mismatched remaining bracket)