### PR TITLE
[Reviewer: AJH] Increment sproutlet tsx failure stat on timeout or transport failure

### DIFF
--- a/src/sproutletproxy.cpp
+++ b/src/sproutletproxy.cpp
@@ -1877,10 +1877,10 @@ void SproutletWrapper::rx_fork_error(pjsip_event_id_e event, int fork_id)
     if (status == PJ_SUCCESS)
     {
       if ((_sproutlet != NULL) &&
-          (_sproutlet->_incoming_sip_transactions_tbl != NULL))
+          (_sproutlet->_outgoing_sip_transactions_tbl != NULL))
       {
         // Update SNMP SIP transaction failure statistic for the Sproutlet.
-        _sproutlet->_incoming_sip_transactions_tbl->increment_failures(_req_type);
+        _sproutlet->_outgoing_sip_transactions_tbl->increment_failures(_req_type);
       }
 
       // Pass the response to the application.

--- a/src/sproutletproxy.cpp
+++ b/src/sproutletproxy.cpp
@@ -1876,6 +1876,13 @@ void SproutletWrapper::rx_fork_error(pjsip_event_id_e event, int fork_id)
 
     if (status == PJ_SUCCESS)
     {
+      if ((_sproutlet != NULL) &&
+          (_sproutlet->_incoming_sip_transactions_tbl != NULL))
+      {
+        // Update SNMP SIP transaction failure statistic for the Sproutlet.
+        _sproutlet->_incoming_sip_transactions_tbl->increment_failures(_req_type);
+      }
+
       // Pass the response to the application.
       register_tdata(rsp);
       _sproutlet_tsx->on_rx_response(rsp->msg, fork_id);


### PR DESCRIPTION
This updates the `rx_fork_error` function so that we log a failure to the outgoing SIP transactions table.

This fixes an issue where we don't log transaction failures in the cases of hitting a transport error or the request timing out.