### PR TITLE
[Reviewer: Seb] Abort if a plugin fails to load in any way.

### DIFF
--- a/src/pluginloader.cpp
+++ b/src/pluginloader.cpp
@@ -92,66 +92,78 @@ bool PluginLoader::load(std::list<Sproutlet*>& sproutlets)
 
       TRC_STATUS("Attempt to load plug-in %s", p.name.c_str());
 
+      // Clear any dynamic load errors
       dlerror();
+
       p.handle = dlopen(p.name.c_str(), RTLD_NOW);
-      if (p.handle != NULL)
-      {
-        p.plugin = static_cast<SproutletPlugin*>(dlsym(p.handle, "sproutlet_plugin"));
 
-        if (p.plugin != NULL)
-        {
-          std::list<Sproutlet*> plugin_sproutlets;
-          plugins_loaded = p.plugin->load(_opt, plugin_sproutlets);
-          TRC_STATUS("Plug-in %s has loaded %u Sproutlets", p.name.c_str(), plugin_sproutlets.size());
-
-          if (!plugins_loaded)
-          {
-            // There was an error loading one of the plugins. Return an error
-            // now so that Sprout is killed, rather than running with
-            // unexpected plugins.
-            TRC_ERROR("Failed to successfully load plug-in %s", p.name.c_str());
-            break;
-          }
-
-          for (std::list<Sproutlet*>::const_iterator i = plugin_sproutlets.begin();
-               i != plugin_sproutlets.end();
-               ++i)
-          {
-            Sproutlet* s = *i;
-            TRC_DEBUG("Sproutlet %s using API version %d",
-                      s->service_name().c_str(), s->api_version());
-            if (api_supported(s->api_version()))
-            {
-              // The API version required by the sproutlet is supported.
-              sproutlets.push_back(s);
-              TRC_STATUS("Loaded sproutlet %s using API version %d",
-                         s->service_name().c_str(), s->api_version());
-            }
-            else
-            {
-              // The API version required by the sproutlet is not supported.
-              TRC_ERROR("Sproutlet %s requires unsupported API version %d",
-                        s->service_name().c_str(), s->api_version());
-            }
-          }
-        }
-      }
-
-      if (p.plugin != NULL)
-      {
-        // Add shared object to the list of loaded plugins.
-        _loaded.push_back(p);
-      }
-      else
+      if (p.handle == NULL)
       {
         TRC_ERROR("Error loading Sproutlet plug-in %s - %s",
                   p.name.c_str(), dlerror());
-        if (p.handle != NULL)
+        plugins_loaded = false;
+        break;
+      }
+
+      // Clear any dynamic load errors
+      dlerror();
+
+      p.plugin = static_cast<SproutletPlugin*>(dlsym(p.handle, "sproutlet_plugin"));
+
+      if (p.plugin == NULL)
+      {
+        TRC_ERROR("Failed to load Sproutlet plug-in %s - %s",
+                  p.name.c_str(), dlerror());
+        plugins_loaded = false;
+        break;
+      }
+
+      std::list<Sproutlet*> plugin_sproutlets;
+      plugins_loaded = p.plugin->load(_opt, plugin_sproutlets);
+
+      if (!plugins_loaded)
+      {
+        // There was an error loading one of the plugins. Return an error
+        // now so that Sprout is killed, rather than running with
+        // unexpected plugins.
+        TRC_ERROR("Failed to successfully load plug-in %s", p.name.c_str());
+        break;
+      }
+
+      for (std::list<Sproutlet*>::const_iterator i = plugin_sproutlets.begin();
+           i != plugin_sproutlets.end();
+           ++i)
+      {
+        Sproutlet* s = *i;
+        TRC_DEBUG("Sproutlet %s using API version %d",
+                  s->service_name().c_str(), s->api_version());
+
+        if (api_supported(s->api_version()))
         {
-          dlclose(p.handle);
+          // The API version required by the sproutlet is supported.
+          sproutlets.push_back(s);
+          TRC_STATUS("Loaded sproutlet %s using API version %d",
+                     s->service_name().c_str(), s->api_version());
+        }
+        else
+        {
+          // The API version required by the sproutlet is not supported.
+          TRC_ERROR("Sproutlet %s requires unsupported API version %d",
+                    s->service_name().c_str(), s->api_version());
+          plugins_loaded = false;
+          break;
         }
       }
+
+      if (!plugins_loaded)
+      {
+        break;
+      }
+
+      // Add shared object to the list of loaded plugins.
+      _loaded.push_back(p);
     }
+
     closedir(d);
   }
 

--- a/src/pluginloader.cpp
+++ b/src/pluginloader.cpp
@@ -105,7 +105,12 @@ bool PluginLoader::load(std::list<Sproutlet*>& sproutlets)
         break;
       }
 
-      // Clear any dynamic load errors
+      // Clear any dynamic load errors. It's safest to simply call dlerror
+      // prior to any dl*() call. In theory, we could have succesfully
+      // loaded a shared object, which itself had an optional dependency on
+      // another shared object that failed to load. In order to prevent us
+      // seeing any spurious errors unrelated to the dsym call, clear out
+      // any dynamic load errors which have been stored off.
       dlerror();
 
       p.plugin = static_cast<SproutletPlugin*>(dlsym(p.handle, "sproutlet_plugin"));


### PR DESCRIPTION
Seb,

Currently there is a couple of scenarios where a Sprout plugin can fail to load, but Sprout still continues to run, without the plugin functionality.

This can make it possibly to upgrade a plugin (e.g. the BGCF sproutlet) and break the functionality if the new BGCF fails to load without any alarms being fired, and with monit reporting that everything is working correctly.

This fix resolves that:

- We now mark the plugins as having failed to load if `dlopen` fails on one of the .so files.

- We now mark the plugins as having failed if for a plugin we are unable to get a handle to the sproutlet plugin reference.

- We now mark the plugins as having failed to load if any of the sproutlets are using an unsupported API version.

There's no UTs for this code.

If we fail to load a plugin, we make no attempt to clear up. Given Sprout will simply exit when this happens, this isn't a big deal, but in theory we could attempt to tidy up. The old code didn't do so in any useful way, so I don't think this is a regression, but comments welcome.

On line 153->160, I use a `break; if (foo){ break; }` pattern. I could replace this with a `goto` or an exception, but this seemed a reasonable approach.