### PR TITLE
[Reviewer: KH1] Pass through the sos flag on UAR

### DIFF
--- a/include/hssconnection.h
+++ b/include/hssconnection.h
@@ -78,6 +78,7 @@ public:
                                 const std::string& public_user_identity,
                                 const std::string& visited_network,
                                 const std::string& auth_type,
+                                const bool& emergency,
                                 rapidjson::Document*& object,
                                 SAS::TrailId trail);
   HTTPCode get_location_data(const std::string& public_user_identity,

--- a/include/icscfrouter.h
+++ b/include/icscfrouter.h
@@ -117,7 +117,8 @@ public:
                 const std::string& impi,
                 const std::string& impu,
                 const std::string& visited_network,
-                const std::string& auth_type);
+                const std::string& auth_type,
+                const bool& emergency);
   ~ICSCFUARouter();
 
 private:
@@ -136,6 +137,9 @@ private:
 
   /// The authorization type to be used on HSS queries.
   std::string _auth_type;
+
+  /// Whether to signal emergency on HSS queries.
+  bool _emergency;
 };
 
 

--- a/src/hssconnection.cpp
+++ b/src/hssconnection.cpp
@@ -802,6 +802,7 @@ HTTPCode HSSConnection::get_user_auth_status(const std::string& private_user_ide
                                              const std::string& public_user_identity,
                                              const std::string& visited_network,
                                              const std::string& auth_type,
+                                             const bool& emergency,
                                              rapidjson::Document*& user_auth_status,
                                              SAS::TrailId trail)
 {
@@ -826,6 +827,10 @@ HTTPCode HSSConnection::get_user_auth_status(const std::string& private_user_ide
   if (!auth_type.empty())
   {
     path += "&auth-type=" + Utils::url_escape(auth_type);
+  }
+  if (emergency)
+  {
+    path += "&sos=true";
   }
 
   HTTPCode rc = get_json_object(path, user_auth_status, trail);

--- a/src/icscfrouter.cpp
+++ b/src/icscfrouter.cpp
@@ -232,7 +232,7 @@ int ICSCFRouter::parse_hss_response(rapidjson::Document*& rsp, bool queried_caps
   else
   {
     int rc = (*rsp)["result-code"].GetInt();
-  
+
     if ((rc == 2001) ||
         (rc == 2002) ||
         (rc == 2003))
@@ -251,15 +251,15 @@ int ICSCFRouter::parse_hss_response(rapidjson::Document*& rsp, bool queried_caps
           (rsp->HasMember("optional-capabilities")) &&
           ((*rsp)["optional-capabilities"].IsArray()))
       {
-        // Response specifies capabilities - we might have explicitly 
-        // queried capabilities or implicitly because there was no 
+        // Response specifies capabilities - we might have explicitly
+        // queried capabilities or implicitly because there was no
         // server assigned.
         TRC_DEBUG("HSS returned capabilities");
         queried_caps = true;
-  
-        if ((!parse_capabilities((*rsp)["mandatory-capabilities"], 
+
+        if ((!parse_capabilities((*rsp)["mandatory-capabilities"],
                                  _hss_rsp.mandatory_caps)) ||
-            (!parse_capabilities((*rsp)["optional-capabilities"], 
+            (!parse_capabilities((*rsp)["optional-capabilities"],
                                  _hss_rsp.optional_caps)))
         {
           // Failed to parse capabilities, so reject with 480 response.
@@ -334,12 +334,14 @@ ICSCFUARouter::ICSCFUARouter(HSSConnection* hss,
                              const std::string& impi,
                              const std::string& impu,
                              const std::string& visited_network,
-                             const std::string& auth_type) :
+                             const std::string& auth_type,
+                             const bool& emergency) :
   ICSCFRouter(hss, scscf_selector, trail, acr, port),
   _impi(impi),
   _impu(impu),
   _visited_network(visited_network),
-  _auth_type(auth_type)
+  _auth_type(auth_type),
+  _emergency(emergency)
 {
 }
 
@@ -366,6 +368,7 @@ int ICSCFUARouter::hss_query()
                                           _impu,
                                           _visited_network,
                                           auth_type,
+                                          _emergency,
                                           rsp,
                                           _trail);
 

--- a/src/ut/hssconnection_test.cpp
+++ b/src/ut/hssconnection_test.cpp
@@ -535,8 +535,12 @@ TEST_F(HssConnectionTest, CorruptAuth)
 
 TEST_F(HssConnectionTest, EmergencyAuth)
 {
+  // Checks that when emergency is set to true that we query the HSS with the
+  // "sos=true" parameter.
   rapidjson::Document* actual;
   _hss.get_user_auth_status("privid69", "pubid44", "", "", true, actual, 0);
+  Request& request = fakecurl_requests["http://narcissus:80/impi/privid69/registration-status?impu=pubid44&sos=true"];
+  EXPECT_EQ("GET", request._method);
   ASSERT_TRUE(actual != NULL);
   EXPECT_EQ(std::string("server-name"), (*actual)["scscf"].GetString());
   delete actual;

--- a/src/ut/icscfsproutlet_test.cpp
+++ b/src/ut/icscfsproutlet_test.cpp
@@ -628,7 +628,6 @@ TEST_F(ICSCFSproutletTest, RouteEmergencyRegister)
   // Tests routing of REGISTER requests when the "sos" flag is set. This test
   // just tests that we correctly add the "sos=true" parameter to the HTTP GET
   // request that we send to Homestead.
-
   pjsip_tx_data* tdata;
 
   // Create a TCP connection to the I-CSCF listening port.
@@ -651,6 +650,9 @@ TEST_F(ICSCFSproutletTest, RouteEmergencyRegister)
   msg1._via = tp->to_string(false);
   msg1._extra = "Contact: <sip:6505551000@" +
                 tp->to_string(true) +
+                ";ob>;expires=300;+sip.ice;reg-id=1;+sip.instance=\"<urn:uuid:00000000-0000-0000-0000-b665231f1213>\"\n" +
+                "Contact: <sip:6505551001@" +
+                tp->to_string(true) +
                 ";ob;sos>;expires=300;+sip.ice;reg-id=1;+sip.instance=\"<urn:uuid:00000000-0000-0000-0000-b665231f1213>\"";
   inject_msg(msg1.get_request(), tp);
 
@@ -670,6 +672,10 @@ TEST_F(ICSCFSproutletTest, RouteEmergencyRegister)
   string route = get_headers(tdata->msg, "Route");
   ASSERT_EQ("", rr);
   ASSERT_EQ("", route);
+
+  // Check that the contact header still contains the sos parameter.
+  string contact = get_headers(tdata->msg, "Contact");
+  EXPECT_THAT(contact, HasSubstr("sos"));
 
   // Send a 200 OK response.
   inject_msg(respond_to_current_txdata(200));

--- a/src/ut/icscfsproutlet_test.cpp
+++ b/src/ut/icscfsproutlet_test.cpp
@@ -623,6 +623,72 @@ TEST_F(ICSCFSproutletTest, RouteRegisterHSSCaps)
 }
 
 
+TEST_F(ICSCFSproutletTest, RouteEmergencyRegister)
+{
+  // Tests routing of REGISTER requests when the "sos" flag is set. This test
+  // just tests that we correctly add the "sos=true" parameter to the HTTP GET
+  // request that we send to Homestead.
+
+  pjsip_tx_data* tdata;
+
+  // Create a TCP connection to the I-CSCF listening port.
+  TransportFlow* tp = new TransportFlow(TransportFlow::Protocol::TCP,
+                                        ICSCF_PORT,
+                                        "1.2.3.4",
+                                        49152);
+
+  // Set up the HSS response for the user registration status query using
+  // a default private user identity.
+  _hss_connection->set_result("/impi/6505551000%40homedomain/registration-status?impu=sip%3A6505551000%40homedomain&visited-network=homedomain&auth-type=REG&sos=true",
+                              "{\"result-code\": 2001,"
+                              " \"scscf\": \"sip:scscf1.homedomain:5058;transport=TCP\"}");
+
+  // Inject a REGISTER request.
+  Message msg1;
+  msg1._method = "REGISTER";
+  msg1._requri = "sip:homedomain";
+  msg1._to = msg1._from;        // To header contains AoR in REGISTER requests.
+  msg1._via = tp->to_string(false);
+  msg1._extra = "Contact: <sip:6505551000@" +
+                tp->to_string(true) +
+                ";ob;sos>;expires=300;+sip.ice;reg-id=1;+sip.instance=\"<urn:uuid:00000000-0000-0000-0000-b665231f1213>\"";
+  inject_msg(msg1.get_request(), tp);
+
+  // REGISTER request should be forwarded to the server named in the HSS
+  // response, scscf1.homedomain.
+  ASSERT_EQ(1, txdata_count());
+  tdata = current_txdata();
+  expect_target("TCP", "10.10.10.1", 5058, tdata);
+  ReqMatcher r1("REGISTER");
+  r1.matches(tdata->msg);
+
+  // Check the RequestURI has been altered to direct the message appropriately.
+  ASSERT_EQ("sip:scscf1.homedomain:5058;transport=TCP", str_uri(tdata->msg->line.req.uri));
+
+  // Check no Route or Record-Route headers have been added.
+  string rr = get_headers(tdata->msg, "Record-Route");
+  string route = get_headers(tdata->msg, "Route");
+  ASSERT_EQ("", rr);
+  ASSERT_EQ("", route);
+
+  // Send a 200 OK response.
+  inject_msg(respond_to_current_txdata(200));
+
+  // Check the response is forwarded back to the source.
+  ASSERT_EQ(1, txdata_count());
+  tdata = current_txdata();
+  expect_target("TCP", "1.2.3.4", 49152, tdata);
+  RespMatcher r2(200);
+  r2.matches(tdata->msg);
+
+  free_txdata();
+
+  _hss_connection->delete_result("/impi/6505551000%40homedomain/registration-status?impu=sip%3A6505551000%40homedomain&visited-network=homedomain&auth-type=REG;sos=true");
+
+  delete tp;
+}
+
+
 TEST_F(ICSCFSproutletTest, RouteRegisterHSSCapsNoMatch)
 {
   // Tests routing of REGISTER requests when the HSS responses with


### PR DESCRIPTION
Converts the "sos" parameter in the contact header of a register to the "sos=true" parameter on the UAR HTTP GET request to homestead.

Together with Metaswitch/homestead#446 this adds support for signalling to the HSS on the UAR that we are handling an emergency REGISTER.