### PR TITLE
[Reviewer: Richard] Perform PJUtils::send_request callbacks on a worker thread

### DIFF
--- a/include/pjutils.h
+++ b/include/pjutils.h
@@ -200,10 +200,21 @@ void set_dest_info(pjsip_tx_data* tdata, const AddrInfo& ai);
 
 void generate_new_branch_id(pjsip_tx_data* tdata);
 
+class Callback
+{
+public:
+  virtual void run() = 0;
+  virtual ~Callback() {}
+};
+
+// A function that takes a token and a pjsip_event, and returns a Callback
+// object that can safely be run on another thread.
+typedef Callback* (*send_callback_builder)(void* token, pjsip_event* event);
+
 pj_status_t send_request(pjsip_tx_data* tdata,
                          int retries=0,
                          void* token=NULL,
-                         pjsip_endpt_send_callback cb=NULL,
+                         send_callback_builder cb=NULL,
                          bool log_sas_branch = false);
 
 pj_status_t send_request_stateless(pjsip_tx_data* tdata,

--- a/include/thread_dispatcher.h
+++ b/include/thread_dispatcher.h
@@ -63,4 +63,6 @@ void unregister_thread_dispatcher(void);
 pj_status_t start_worker_threads();
 pj_status_t stop_worker_threads();
 
+void add_callback_to_queue(PJUtils::Callback*);
+
 #endif

--- a/include/thread_dispatcher.h
+++ b/include/thread_dispatcher.h
@@ -63,6 +63,8 @@ void unregister_thread_dispatcher(void);
 pj_status_t start_worker_threads();
 pj_status_t stop_worker_threads();
 
+// Add a Callback object to the queue, to be run on a worker thread.
+// This MUST be called from the main PJSIP transport thread.
 void add_callback_to_queue(PJUtils::Callback*);
 
 #endif

--- a/src/pjutils.cpp
+++ b/src/pjutils.cpp
@@ -60,6 +60,7 @@ extern "C" {
 #include "sproutsasevent.h"
 #include "enumservice.h"
 #include "uri_classifier.h"
+#include "thread_dispatcher.h"
 
 
 static const int DEFAULT_RETRIES = 5;
@@ -1069,7 +1070,7 @@ struct StatefulSendState
   int current_server;
 
   void* user_token;
-  pjsip_endpt_send_callback user_cb;
+  PJUtils::send_callback_builder cb_builder;
 };
 
 
@@ -1188,9 +1189,25 @@ static void on_tsx_state(pjsip_transaction* tsx, pjsip_event* event)
     TRC_DEBUG("Request transaction completed, status code = %d", tsx->status_code);
     tsx->mod_data[mod_sprout_util.id] = NULL;
 
-    if (sss->user_cb != NULL)
+    if (sss->cb_builder != NULL)
     {
-      (*sss->user_cb)(sss->user_token, event);
+      PJUtils::Callback* cb = (sss->cb_builder)(sss->user_token, event);
+#ifndef UNIT_TEST
+      if (is_pjsip_transport_thread())
+      {
+        // On a transport error, this callback will be on the main PJSIP thread,
+        // so we add the callback to the queue to get picked up by a worker
+        // thread.
+        add_callback_to_queue(cb);
+      }
+      else
+#endif
+      {
+        // If we're already on a worker thread (or in the UTs, which have a
+        // different threading model) we just run the Callback directly.
+        cb->run();
+        delete cb; cb = NULL;
+      }
     }
 
     // The transaction has completed, so decrement our reference to the tx_data
@@ -1206,7 +1223,7 @@ static void on_tsx_state(pjsip_transaction* tsx, pjsip_event* event)
 pj_status_t PJUtils::send_request(pjsip_tx_data* tdata,
                                   int retries,
                                   void* token,
-                                  pjsip_endpt_send_callback cb,
+                                  PJUtils::send_callback_builder cb,
                                   bool log_sas_branch)
 {
   pjsip_transaction* tsx;
@@ -1217,9 +1234,9 @@ pj_status_t PJUtils::send_request(pjsip_tx_data* tdata,
   // Allocate temporary storage for the request.
   StatefulSendState* sss = new StatefulSendState;
 
-  // Store the user supplied callback and token.
+  // Store the user supplied callback builder and token.
   sss->user_token = token;
-  sss->user_cb = cb;
+  sss->cb_builder = cb;
 
   if (tdata->tp_sel.type != PJSIP_TPSELECTOR_TRANSPORT)
   {
@@ -1708,7 +1725,7 @@ void PJUtils::mark_sas_call_branch_ids(const SAS::TrailId trail, pjsip_cid_hdr* 
                                 ((msg->line.req.method.id == PJSIP_REGISTER_METHOD) ||
                                  (pjsip_method_cmp(&msg->line.req.method, pjsip_get_subscribe_method()) == 0) ||
                                  (pjsip_method_cmp(&msg->line.req.method, pjsip_get_notify_method()) == 0)));
-  
+
   if (cid_hdr != NULL)
   {
     TRC_DEBUG("Logging SAS Call-ID marker, Call-ID %.*s", cid_hdr->id.slen, cid_hdr->id.ptr);

--- a/src/registration_utils.cpp
+++ b/src/registration_utils.cpp
@@ -132,9 +132,9 @@ public:
         }
       }
       else
-      // Count all failed registration attempts, not just ones that result in user
-      // being unsubscribed.
       {
+        // Count all failed registration attempts, not just ones that result in
+        // user being unsubscribed.
         if (_reg_data->expires == 0)
         {
           third_party_reg_stats_tables->de_reg_tbl->increment_failures();
@@ -307,7 +307,7 @@ void RegistrationUtils::register_with_application_servers(Ifcs& ifcs,
 static PJUtils::Callback* build_register_cb(void* token, pjsip_event* event)
 {
   RegisterCallback* cb = new RegisterCallback(token, event);
-  return (PJUtils::Callback*)cb;
+  return cb;
 }
 
 static void send_register_to_as(SubscriberDataManager* sdm,

--- a/src/thread_dispatcher.cpp
+++ b/src/thread_dispatcher.cpp
@@ -79,13 +79,29 @@ extern "C" {
 
 static std::vector<pj_thread_t*> worker_threads;
 
-// Queue for incoming messages.
-struct rx_msg_qe
+// An Event on the queue is either a SIP message or a callback
+enum EventType { MESSAGE, CALLBACK };
+
+union Event
 {
-  pjsip_rx_data* rdata;    // received message
-  Utils::StopWatch stop_watch;    // stop watch for tracking message latency
+  pjsip_rx_data* rdata;
+  PJUtils::Callback* callback;
 };
-eventq<struct rx_msg_qe> rx_msg_q;
+
+struct worker_thread_qe
+{
+  // The type of the event
+  EventType type;
+
+  // The event itself
+  Event event;
+
+  // A stop watch for tracking SIP message latency
+  Utils::StopWatch stop_watch;
+};
+
+// Queue for incoming events.
+eventq<struct worker_thread_qe> worker_thread_q;
 
 // Deadlock detection threshold for the message queue (in milliseconds).  This
 // is set to roughly twice the expected maximum service time for each message
@@ -139,78 +155,86 @@ static int worker_thread(void* p)
 
   TRC_DEBUG("Worker thread started");
 
-  struct rx_msg_qe qe = {0};
+  struct worker_thread_qe qe = { MESSAGE };
 
-  while (rx_msg_q.pop(qe))
+  while (worker_thread_q.pop(qe))
   {
-    pjsip_rx_data* rdata = qe.rdata;
-
-    if (rdata)
+    if (qe.type == MESSAGE)
     {
-      TRC_DEBUG("Worker thread dequeue message %p", rdata);
+      pjsip_rx_data* rdata = qe.event.rdata;
 
-      CW_TRY
+      if (rdata)
       {
-        pjsip_endpt_process_rx_data(stack_data.endpt, rdata, &rp, NULL);
-      }
-      CW_EXCEPT(exception_handler)
-      {
-        // Dump details about the exception.  Be defensive about reading these
-        // as we don't know much about the state we're in.
-        TRC_ERROR("Exception SAS Trail: %llu (maybe)", get_trail(rdata));
-        if (rdata->msg_info.cid != NULL)
+        CW_TRY
         {
-          TRC_ERROR("Exception Call-Id: %.*s (maybe)",
-                    ((pjsip_cid_hdr*)rdata->msg_info.cid)->id.slen,
-                    ((pjsip_cid_hdr*)rdata->msg_info.cid)->id.ptr);
+          pjsip_endpt_process_rx_data(stack_data.endpt, rdata, &rp, NULL);
         }
-        if (rdata->msg_info.cseq != NULL)
+        CW_EXCEPT(exception_handler)
         {
-          TRC_ERROR("Exception CSeq: %ld %.*s (maybe)",
-                    ((pjsip_cseq_hdr*)rdata->msg_info.cseq)->cseq,
-                    ((pjsip_cseq_hdr*)rdata->msg_info.cseq)->method.name.slen,
-                    ((pjsip_cseq_hdr*)rdata->msg_info.cseq)->method.name.ptr);
+          // Dump details about the exception.  Be defensive about reading these
+          // as we don't know much about the state we're in.
+          TRC_ERROR("Exception SAS Trail: %llu (maybe)", get_trail(rdata));
+          if (rdata->msg_info.cid != NULL)
+          {
+            TRC_ERROR("Exception Call-Id: %.*s (maybe)",
+                      ((pjsip_cid_hdr*)rdata->msg_info.cid)->id.slen,
+                      ((pjsip_cid_hdr*)rdata->msg_info.cid)->id.ptr);
+          }
+          if (rdata->msg_info.cseq != NULL)
+          {
+            TRC_ERROR("Exception CSeq: %ld %.*s (maybe)",
+                      ((pjsip_cseq_hdr*)rdata->msg_info.cseq)->cseq,
+                      ((pjsip_cseq_hdr*)rdata->msg_info.cseq)->method.name.slen,
+                      ((pjsip_cseq_hdr*)rdata->msg_info.cseq)->method.name.ptr);
+          }
+
+          // Make a 500 response to the rdata with a retry-after header of
+          // 10 mins if it's a request other than an ACK
+
+          if ((rdata->msg_info.msg->type == PJSIP_REQUEST_MSG) &&
+             (rdata->msg_info.msg->line.req.method.id != PJSIP_ACK_METHOD))
+          {
+            TRC_DEBUG("Returning 500 response following exception");
+            pjsip_retry_after_hdr* retry_after =
+                           pjsip_retry_after_hdr_create(rdata->tp_info.pool, 600);
+            PJUtils::respond_stateless(stack_data.endpt,
+                                     rdata,
+                                     PJSIP_SC_INTERNAL_SERVER_ERROR,
+                                     NULL,
+                                     (pjsip_hdr*)retry_after,
+                                     NULL);
+          }
+
+          if (num_worker_threads == 1)
+          {
+            // There's only one worker thread, so we can't sensibly proceed.
+            exit(1);
+          }
         }
+        CW_END
 
-        // Make a 500 response to the rdata with a retry-after header of
-        // 10 mins if it's a request other than an ACK
+        TRC_DEBUG("Worker thread completed processing message %p", rdata);
+        pjsip_rx_data_free_cloned(rdata);
 
-        if ((rdata->msg_info.msg->type == PJSIP_REQUEST_MSG) &&
-           (rdata->msg_info.msg->line.req.method.id != PJSIP_ACK_METHOD))
+        unsigned long latency_us = 0;
+        if (qe.stop_watch.read(latency_us))
         {
-          TRC_DEBUG("Returning 500 response following exception");
-          pjsip_retry_after_hdr* retry_after =
-                         pjsip_retry_after_hdr_create(rdata->tp_info.pool, 600);
-          PJUtils::respond_stateless(stack_data.endpt,
-                                   rdata,
-                                   PJSIP_SC_INTERNAL_SERVER_ERROR,
-                                   NULL,
-                                   (pjsip_hdr*)retry_after,
-                                   NULL);
+          TRC_DEBUG("Request latency = %ldus", latency_us);
+          latency_table->accumulate(latency_us);
+          load_monitor->request_complete(latency_us);
         }
-
-        if (num_worker_threads == 1)
+        else
         {
-          // There's only one worker thread, so we can't sensibly proceed.
-          exit(1);
+          TRC_ERROR("Failed to get done timestamp: %s", strerror(errno));
         }
       }
-      CW_END
-
-      TRC_DEBUG("Worker thread completed processing message %p", rdata);
-      pjsip_rx_data_free_cloned(rdata);
-
-      unsigned long latency_us = 0;
-      if (qe.stop_watch.read(latency_us))
-      {
-        TRC_DEBUG("Request latency = %ldus", latency_us);
-        latency_table->accumulate(latency_us);
-        load_monitor->request_complete(latency_us);
-      }
-      else
-      {
-        TRC_ERROR("Failed to get done timestamp: %s", strerror(errno));
-      }
+    }
+    else
+    {
+      // If this is a Callback, we just run it and then delete it.
+      PJUtils::Callback* cb = qe.event.callback;
+      cb->run();
+      delete cb; cb = NULL;
     }
   }
 
@@ -226,7 +250,7 @@ static pj_bool_t threads_on_rx_msg(pjsip_rx_data* rdata)
   SAS::report_event(event);
 
   // Check that the worker threads are not all deadlocked.
-  if (rx_msg_q.is_deadlocked())
+  if (worker_thread_q.is_deadlocked())
   {
     // The queue has not been serviced for sufficiently long to imply that
     // all the worker threads are deadlock, so exit the process so it will be
@@ -238,7 +262,8 @@ static pj_bool_t threads_on_rx_msg(pjsip_rx_data* rdata)
 
   // Before we start, get a timestamp.  This will track the time from
   // receiving a message to forwarding it on (or rejecting it).
-  struct rx_msg_qe qe;
+  struct worker_thread_qe qe = { MESSAGE };
+  Event queue_event;
   qe.stop_watch.start();
 
   // Clone the message and queue it to a scheduler thread.
@@ -262,11 +287,12 @@ static pj_bool_t threads_on_rx_msg(pjsip_rx_data* rdata)
   // have a queue per transport and round-robin them?
 
   TRC_DEBUG("Queuing cloned received message %p for worker threads", clone_rdata);
-  qe.rdata = clone_rdata;
+  queue_event.rdata = clone_rdata;
+  qe.event = queue_event;
 
   // Track the current queue size
-  queue_size_table->accumulate(rx_msg_q.size());
-  rx_msg_q.push(qe);
+  queue_size_table->accumulate(worker_thread_q.size());
+  worker_thread_q.push(qe);
 
   // return TRUE to flag that we have absorbed the incoming message.
   return PJ_TRUE;
@@ -283,7 +309,7 @@ pj_status_t init_thread_dispatcher(int num_worker_threads_arg,
   worker_threads.resize(num_worker_threads_arg);
 
   // Enable deadlock detection on the message queue.
-  rx_msg_q.set_deadlock_threshold(MSG_Q_DEADLOCK_TIME);
+  worker_thread_q.set_deadlock_threshold(MSG_Q_DEADLOCK_TIME);
 
   num_worker_threads = num_worker_threads_arg;
   latency_table = latency_table_arg;
@@ -323,7 +349,7 @@ void stop_worker_threads()
 {
   // Now it is safe to signal the worker threads to exit via the queue and to
   // wait for them to terminate.
-  rx_msg_q.terminate();
+  worker_thread_q.terminate();
   for (std::vector<pj_thread_t*>::iterator i = worker_threads.begin();
        i != worker_threads.end();
        ++i)
@@ -337,4 +363,19 @@ void unregister_thread_dispatcher(void)
 {
   pjsip_endpt_unregister_module(stack_data.endpt, &mod_thread_dispatcher);
 
+}
+
+void add_callback_to_queue(PJUtils::Callback* cb)
+{
+  // Create an Event to hold the Callback
+  Event queue_event;
+  queue_event.callback = cb;
+  worker_thread_qe qe = { CALLBACK };
+  qe.event = queue_event;
+
+  // Track the current queue size
+  queue_size_table->accumulate(worker_thread_q.size());
+
+  // Add the Event
+  worker_thread_q.push(qe);
 }

--- a/src/thread_dispatcher.cpp
+++ b/src/thread_dispatcher.cpp
@@ -165,6 +165,8 @@ static int worker_thread(void* p)
 
       if (rdata)
       {
+        TRC_DEBUG("Worker thread dequeue message %p", rdata);
+
         CW_TRY
         {
           pjsip_endpt_process_rx_data(stack_data.endpt, rdata, &rp, NULL);


### PR DESCRIPTION
When sending a request with PJUtils::send_request, the callback may be called on the main PJSIP transport thread (which happens if there is a transport error when trying to send the request).

Since the callback is specified by the sender, it may involve lots of work that we don't want done on the main thread e.g. when we send a register to an AS (if the register fails and the iFC has session terminate, then we deregister the user which is a blocking HTTP request to homestead).

So we want to push these callbacks onto the worker threads instead.

We do this by:

* Creating a `Callback` abstract class that represents a callback that we want to run on the worker threads (and must hold all the data it needs)
* implementing a `RegisterCallback` concrete subclass that we use for registers to an AS (the only case where we use this callback function at the moment)
    * this `RegisterCallback`'s run() method does the same as what was previously specified in the static `send_register_cb` function
* change the `send_request` function to take as a callback a function which build's a `Callback` object that can safely be run on a worker thread
* enhance the worker queue to take either messages or callbacks, and add a function to add callbacks to the queue

This is a fix for issue https://github.com/Metaswitch/clearwater-issues/issues/1452

#### Testing
* tested that register stress that repros the issue before doesn't repro it after the change
* make full_test passes
* live tests pass
* tested sending 400 registers a second through sprout to an AS, both with and without the change, and didn't see a noticeable performance impact (my sprout was between 60 and 70 percent CPU for both)
    * this is what you'd expect given that, in the mainline case, we're already on a worker thread and so the callback is just run directly
