### PR TITLE
[Reviewer: EM] URI classification

### DIFF
--- a/include/uri_classifier.h
+++ b/include/uri_classifier.h
@@ -41,6 +41,13 @@ extern "C" {
 #include <pjlib.h>
 }
 
+// Forward declaration of PJUtils function.
+namespace PJUtils {
+
+std::string pj_str_to_string(const pj_str_t* pjstr);
+
+}
+
 enum URIClass
 {
   UNKNOWN = 0,

--- a/src/uri_classifier.cpp
+++ b/src/uri_classifier.cpp
@@ -38,6 +38,11 @@
 #include "stack.h"
 #include "constants.h"
 
+// Regexes that match global and local numbers:
+// - A global number starts with "+" followed by a combination of digits "0-9"
+//   and visual separators ",-()".
+// - A local number can contain a combination of hexdigits "0-9A-F", "*#" and
+//   visual separators ",-()".
 static const boost::regex CHARS_ALLOWED_IN_GLOBAL_NUM = boost::regex("\\+[0-9,\\-\\(\\)]*");
 static const boost::regex CHARS_ALLOWED_IN_LOCAL_NUM = boost::regex("[0-9A-F\\*#,\\-\\(\\)]*");
 

--- a/src/uri_classifier.cpp
+++ b/src/uri_classifier.cpp
@@ -33,9 +33,13 @@
  */
 
 #include <vector>
+#include <boost/regex.hpp>
 #include "uri_classifier.h"
 #include "stack.h"
 #include "constants.h"
+
+static const boost::regex CHARS_ALLOWED_IN_GLOBAL_NUM = boost::regex("\\+[0-9,\\-\\(\\)]*");
+static const boost::regex CHARS_ALLOWED_IN_LOCAL_NUM = boost::regex("[0-9A-F\\*#,\\-\\(\\)]*");
 
 std::vector<pj_str_t*> URIClassifier::home_domains;
 bool URIClassifier::enforce_global;
@@ -147,7 +151,9 @@ URIClass URIClassifier::classify_uri(const pjsip_uri* uri, bool prefer_sip, bool
   {
     // TEL URIs can only represent phone numbers - decide if it's a global (E.164) number or not
     pjsip_tel_uri* tel_uri = (pjsip_tel_uri*)uri;
-    if (tel_uri->number.slen > 0 && tel_uri->number.ptr[0] == '+')
+    std::string user = PJUtils::pj_str_to_string(&tel_uri->number);
+    boost::match_results<std::string::const_iterator> results;
+    if (boost::regex_match(user, results, CHARS_ALLOWED_IN_GLOBAL_NUM))
     {
       ret = GLOBAL_PHONE_NUMBER;
     }
@@ -177,13 +183,22 @@ URIClass URIClassifier::classify_uri(const pjsip_uri* uri, bool prefer_sip, bool
     if ((!pj_strcmp(&((pjsip_sip_uri*)uri)->user_param, &STR_USER_PHONE) ||
          (home_domain && treat_number_as_phone && !is_gruu)))
     {
-      if (sip_uri->user.slen > 0 && sip_uri->user.ptr[0] == '+')
+      // Get the user part minus any parameters.
+      std::string user = PJUtils::pj_str_to_string(&sip_uri->user);
+      std::vector<std::string> user_tokens;
+      Utils::split_string(user, ';', user_tokens, 0, true);
+      boost::match_results<std::string::const_iterator> results;
+      if (boost::regex_match(user_tokens[0], results, CHARS_ALLOWED_IN_GLOBAL_NUM))
       {
         ret = GLOBAL_PHONE_NUMBER;
       }
-      else
+      else if (boost::regex_match(user_tokens[0], results, CHARS_ALLOWED_IN_LOCAL_NUM))
       {
         ret = enforce_global ? LOCAL_PHONE_NUMBER : GLOBAL_PHONE_NUMBER;
+      }
+      else
+      {
+        ret = HOME_DOMAIN_SIP_URI;
       }
     }
     // Not a phone number - classify it based on domain

--- a/src/ut/uriclassifier_test.cpp
+++ b/src/ut/uriclassifier_test.cpp
@@ -134,6 +134,8 @@ TEST_F(URIClassiferTest, PreferSip)
             classify_uri_helper("sip:+1234@homedomain", false));
   EXPECT_EQ(URIClass::HOME_DOMAIN_SIP_URI,
             classify_uri_helper("sip:+1234@homedomain", true));
+  EXPECT_EQ(URIClass::HOME_DOMAIN_SIP_URI,
+            classify_uri_helper("sip:notaphonenumber@homedomain", false));
 }
 
 


### PR DESCRIPTION
This PR improves our URI classification to fix Metaswitch/clearwater-issues#1470.

There was a bug in the code that meant that if we didn't have enforce user=phone, and didn't enforce global only lookups, then we would always do an enum lookup on a URI, even if it was clearly not a phone number.

This PR improves our checking of the user part of SIP URIs to make sure that we actually have a phone number before classifying the URI as one. Please can you review.