### PR TITLE
Fix missing include

### DIFF
--- a/include/uri_classifier.h
+++ b/include/uri_classifier.h
@@ -35,6 +35,8 @@
 #ifndef URI_CLASSIFIER_H
 #define URI_CLASSIFIER_H
 
+#include <string>
+
 extern "C" {
 #include <pjsip.h>
 #include <pjlib-util.h>


### PR DESCRIPTION
Recent changes to `uri_classifier` broke the Houdini build, due to a missing include.  The sprout build wasn't broken, so presumably `string` got included elsewhere when building sprout.

@sathiyan-sivathas - FYI