### PR TITLE
[Reviewer: Richard] Getting orig-served-user is a read-only operation

### DIFF
--- a/include/pjutils.h
+++ b/include/pjutils.h
@@ -70,7 +70,7 @@ std::string default_private_id_from_uri(const pjsip_uri* uri);
 
 pj_str_t domain_from_uri(const std::string& uri_str, pj_pool_t* pool);
 
-pjsip_uri* orig_served_user(pjsip_msg* msg);
+pjsip_uri* orig_served_user(const pjsip_msg* msg);
 
 pjsip_uri* term_served_user(pjsip_msg* msg);
 

--- a/include/pjutils.h
+++ b/include/pjutils.h
@@ -72,7 +72,7 @@ pj_str_t domain_from_uri(const std::string& uri_str, pj_pool_t* pool);
 
 pjsip_uri* orig_served_user(const pjsip_msg* msg);
 
-pjsip_uri* term_served_user(pjsip_msg* msg);
+pjsip_uri* term_served_user(const pjsip_msg* msg);
 
 typedef enum {NO, YES, TLS_YES, TLS_PENDING, IP_ASSOC_YES, IP_ASSOC_PENDING, AUTH_DONE} Integrity;
 void add_integrity_protected_indication(pjsip_tx_data* tdata, PJUtils::Integrity integrity);

--- a/src/pjutils.cpp
+++ b/src/pjutils.cpp
@@ -315,7 +315,7 @@ pjsip_uri* PJUtils::orig_served_user(const pjsip_msg* msg)
 
 
 /// Determine the served user for terminating requests.
-pjsip_uri* PJUtils::term_served_user(pjsip_msg* msg)
+pjsip_uri* PJUtils::term_served_user(const pjsip_msg* msg)
 {
   // The served user for terminating requests is always determined from the
   // Request URI.

--- a/src/pjutils.cpp
+++ b/src/pjutils.cpp
@@ -271,7 +271,7 @@ pj_str_t PJUtils::domain_from_uri(const std::string& uri_str, pj_pool_t* pool)
 }
 
 /// Determine the served user for originating requests.
-pjsip_uri* PJUtils::orig_served_user(pjsip_msg* msg)
+pjsip_uri* PJUtils::orig_served_user(const pjsip_msg* msg)
 {
   // The served user for originating requests is determined from the
   // P-Served-User or P-Asserted-Identity headers.  For extra compatibility,


### PR DESCRIPTION
Self-explanatory. 

(Some of us like to scatter out sproutlet code with `const` at every opportunity.  I ran into this method when it stopped me from doing so.)