### PR TITLE
[Reviewer: Ellie] Add a new option to control whether Sprout should send to Ralf

### DIFF
--- a/sprout-base.root/etc/init.d/sprout
+++ b/sprout-base.root/etc/init.d/sprout
@@ -86,6 +86,9 @@ get_settings()
         signaling_dns_server=127.0.0.1
         scscf_node_uri=""
 
+        # Should we send to Ralf? Y, N, or X => base on ralf hostname
+        sprout_ralf_enabled=X
+
         # Enable no-ENUM TEL URI translation fallback by default for backwards compatibility
         default_tel_uri_translation="Y"
 
@@ -131,7 +134,11 @@ get_daemon_args()
           [ -z "$xdms_hostname" ] || xdms_hostname_arg="--xdms=$xdms_hostname"
         fi
 
-        [ -z "$ralf_hostname" ] || ralf_arg="--ralf=$ralf_hostname"
+        if [ "$sprout_ralf_enabled" == "Y" ] || \
+           [ "$sprout_ralf_enabled" == "X" -a -n "$ralf_hostname" ]
+        then
+          ralf_arg="--ralf=$ralf_hostname"
+        fi
 
         [ "$authentication" != "Y" ] || authentication_arg="--authentication"
 


### PR DESCRIPTION
As discussed in, https://github.com/Metaswitch/ralf/pull/276, we think we should add a new config option to separate Ralf being configured, and whether Sprout should actually send to Ralf.

It can be set to Y or N to control the behavior, and is defaulted so that the existing behavior is fine over upgrade.