### PR TITLE
[Reviewer=HJS] Fix following ST of mmf_targets JSON file

### DIFF
--- a/src/mmfservice.cpp
+++ b/src/mmfservice.cpp
@@ -101,7 +101,8 @@ void MMFService::update_config()
   }
   catch (JsonFormatError err)
   {
-    TRC_ERROR("Badly formed MMF configuration file - keep current config");
+    TRC_ERROR("Badly formed MMF targets configuration file. If good MMF targets "
+              "config was previously loaded, the S-CSCF will continue to use it.");
     CL_SPROUT_MMF_FILE_INVALID.log();
     set_alarm();
   }

--- a/src/mmfservice.cpp
+++ b/src/mmfservice.cpp
@@ -152,12 +152,15 @@ MMFService::MMFTargetPtr MMFService::get_config_for_server(std::string server_do
 {
   std::shared_ptr<MMFService::MMFMap> mmf_config = _mmf_config;
 
+  TRC_ERROR("JA4");
   if (mmf_config->find(server_domain) != mmf_config->end())
   {
+    TRC_ERROR("JA5");
     return mmf_config->at(server_domain);
   }
   else
   {
+    TRC_ERROR("JA6");
     return nullptr;
   }
 }

--- a/src/mmftargets.cpp
+++ b/src/mmftargets.cpp
@@ -1,5 +1,5 @@
 /**
- * @file mmf.cpp  class representing MMF Target configuration options
+ * @file mmftargets.cpp  class representing MMF Target configuration options
  *
  * Copyright (C) Metaswitch Networks 2017
  * If license terms are provided to you in a COPYING file in the root directory
@@ -25,10 +25,26 @@ MMFTarget::MMFTarget(const rapidjson::Value& config):
 void MMFTarget::parse_name(const rapidjson::Value& config)
 {
   TRC_DEBUG("Reading name");
+
   if (config.HasMember("name") && config["name"].IsString())
   {
-    TRC_DEBUG("Read name: %s", config["name"].GetString());
-    _name = config["name"].GetString();
+    std::string name = config["name"].GetString();
+    TRC_DEBUG("Read name: %s", name.c_str());
+
+    // The _name is used as the mmfcontext URI parameter in requests sent for
+    // MMF processing.  We only allow A-Z, a-z, 0-9, - and _.
+    for(char& s : name)
+    {
+      if(!(isalnum(s) || s == '_' || s == '-'))
+      {
+        TRC_ERROR("Invalid 'name' field: '%s' in MMF configuration.  The 'name' "
+                  "contains an invalid character.  It can only contain Alphanumerical"
+                  " characters, '-' and '_'", name.c_str());
+        JSON_FORMAT_ERROR();
+      }
+    }
+
+    _name = name;
   }
   else
   {
@@ -77,8 +93,8 @@ void MMFTarget::parse_pre_as(const rapidjson::Value& config)
   {
     if (config["pre-as"].IsBool())
     {
-      TRC_DEBUG("Read pre-as: %d", config["pre-as"].GetBool());
       _pre_as = config["pre-as"].GetBool();
+      TRC_DEBUG("Read pre-as: %s", _pre_as ? "true" : "false");
     }
     else
     {
@@ -89,8 +105,8 @@ void MMFTarget::parse_pre_as(const rapidjson::Value& config)
   }
   else
   {
-    TRC_STATUS("No 'pre-as' field present for the MMF target '%s'.  Defaulting "
-               "to 'false'", _name.c_str());
+    TRC_DEBUG("No 'pre-as' field present for the MMF target '%s'.  Defaulting "
+              "to 'false'", _name.c_str());
   }
 }
 
@@ -101,8 +117,8 @@ void MMFTarget::parse_post_as(const rapidjson::Value& config)
   {
     if (config["post-as"].IsBool())
     {
-      TRC_DEBUG("Read post-as: %d", config["post-as"].GetBool());
       _post_as = config["post-as"].GetBool();
+      TRC_DEBUG("Read post-as: %s", _post_as ? "true" : "false");
     }
     else
     {
@@ -113,7 +129,7 @@ void MMFTarget::parse_post_as(const rapidjson::Value& config)
   }
   else
   {
-    TRC_STATUS("No 'post-as' field present for the MMF target '%s'.  Defaulting "
-               "to 'false'", _name.c_str());
+    TRC_DEBUG("No 'post-as' field present for the MMF target '%s'.  Defaulting "
+              "to 'false'", _name.c_str());
   }
 }

--- a/src/mmftargets.cpp
+++ b/src/mmftargets.cpp
@@ -10,7 +10,10 @@
  */
 
 #include "mmftargets.h"
-
+#include <regex>
+#include <iostream>
+#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/regex.hpp>
 
 MMFTarget::MMFTarget(const rapidjson::Value& config):
   _pre_as(false),
@@ -31,17 +34,23 @@ void MMFTarget::parse_name(const rapidjson::Value& config)
     std::string name = config["name"].GetString();
     TRC_DEBUG("Read name: %s", name.c_str());
 
+    if (name.empty())
+    {
+      TRC_ERROR("Invalid 'name' field in MMF configuration.  The 'name' "
+                "must be a non-empty string");
+      JSON_FORMAT_ERROR();
+    }
+
+    const boost::regex allowed_chars = boost::regex("^[A-Za-z0-9_-]+$");
+
     // The _name is used as the mmfcontext URI parameter in requests sent for
     // MMF processing.  We only allow A-Z, a-z, 0-9, - and _.
-    for(char& s : name)
+    if (!boost::regex_match(name, allowed_chars))
     {
-      if(!(isalnum(s) || s == '_' || s == '-'))
-      {
-        TRC_ERROR("Invalid 'name' field: '%s' in MMF configuration.  The 'name' "
-                  "contains an invalid character.  It can only contain Alphanumerical"
-                  " characters, '-' and '_'", name.c_str());
-        JSON_FORMAT_ERROR();
-      }
+      TRC_ERROR("Invalid 'name' field: '%s' in MMF configuration.  The 'name' "
+                "contains an invalid character.  It can only contain Alphanumerical"
+                " characters, '-' and '_'", name.c_str());
+      JSON_FORMAT_ERROR();
     }
 
     _name = name;

--- a/src/ut/mmfservice_test.cpp
+++ b/src/ut/mmfservice_test.cpp
@@ -43,7 +43,9 @@ class MMFServiceTest : public ::testing::Test
 
   void check_invalid_config_log(CapturingTestLogger& _log)
   {
-    EXPECT_TRUE(_log.contains("Badly formed MMF configuration file - keep current config"));
+    std::string errorlog("Badly formed MMF targets configuration file. If good MMF targets "
+                         "config was previously loaded, the S-CSCF will continue to use it.");
+    EXPECT_TRUE(_log.contains(errorlog.c_str()));
   }
 };
 
@@ -183,6 +185,26 @@ TEST_F(MMFServiceTest, MissingName)
   check_invalid_config_log(_log);
 }
 
+// Test that we log appropriately if we have whitespace in the name field
+TEST_F(MMFServiceTest, WhitespaceName)
+{
+  CapturingTestLogger _log;
+  EXPECT_CALL(*_mock_alarm, set()).Times(AtLeast(1));
+  MMFService MMF(_mock_alarm, string(UT_DIR).append("/test_mmf_whitespace_name.json"));
+  EXPECT_TRUE(_log.contains("The 'name' contains an invalid character."));
+  check_invalid_config_log(_log);
+}
+
+// Test that we log appropriately if we have tab in the name field
+TEST_F(MMFServiceTest, TabName)
+{
+  CapturingTestLogger _log;
+  EXPECT_CALL(*_mock_alarm, set()).Times(AtLeast(1));
+  MMFService MMF(_mock_alarm, string(UT_DIR).append("/test_mmf_tab_name.json"));
+  EXPECT_TRUE(_log.contains("The 'name' contains an invalid character."));
+  check_invalid_config_log(_log);
+}
+
 // Test that we log appropriately if a set of MMF config has an invalid name field.
 TEST_F(MMFServiceTest, InvalidName)
 {
@@ -233,3 +255,4 @@ TEST_F(MMFServiceTest, DuplicateAddress)
   EXPECT_TRUE(_log.contains("Duplicate config present in the"));
   check_invalid_config_log(_log);
 }
+

--- a/src/ut/mmfservice_test.cpp
+++ b/src/ut/mmfservice_test.cpp
@@ -175,6 +175,16 @@ TEST_F(MMFServiceTest, InvalidPreAS)
   check_invalid_config_log(_log);
 }
 
+// Test that we log appropriately if a set of MMF config has an empty name field.
+TEST_F(MMFServiceTest, EmptyName)
+{
+  CapturingTestLogger _log;
+  EXPECT_CALL(*_mock_alarm, set()).Times(AtLeast(1));
+  MMFService MMF(_mock_alarm, string(UT_DIR).append("/test_mmf_empty_name.json"));
+  EXPECT_TRUE(_log.contains("The 'name' must be a non-empty string"));
+  check_invalid_config_log(_log);
+}
+
 // Test that we log appropriately if a set of MMF config has no name field.
 TEST_F(MMFServiceTest, MissingName)
 {

--- a/src/ut/test_mmf_empty_name.json
+++ b/src/ut/test_mmf_empty_name.json
@@ -1,0 +1,9 @@
+{
+    "mmf_targets" : [
+        {   "name" : "",
+            "addresses" : ["invalid"],
+            "pre-as" : false,
+            "post-as" : true
+        }
+    ]
+}

--- a/src/ut/test_mmf_tab_name.json
+++ b/src/ut/test_mmf_tab_name.json
@@ -1,0 +1,10 @@
+{
+    "mmf_targets" : [
+        {
+            "name": "contains\ttab",
+            "addresses" : ["invalid"],
+            "pre-as" : false,
+            "post-as" : true
+        }
+    ]
+}

--- a/src/ut/test_mmf_whitespace_name.json
+++ b/src/ut/test_mmf_whitespace_name.json
@@ -1,0 +1,10 @@
+{
+    "mmf_targets" : [
+        {
+            "name": "contains a space",
+            "addresses" : ["invalid"],
+            "pre-as" : false,
+            "post-as" : true
+        }
+    ]
+}


### PR DESCRIPTION
The fixes following ST of the new mmf_targets.json file.  They include:

- Amend the previous ERROR trace printed with every invalid config, to better explain the behaviour

- Only allow A-Z, a-z, 0-9, -, and _ characters in the 'name' field.  The value of this field is sent as the 'mmfcontext' URI parameter when requests are forwarded to the MMF server, so the characters allowed here must be restricted

- Fix up some STATUS and DEBUG logs