### PR TITLE
[Reviewer: Alex] plugins-deb prior to deb-only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ include build-infra/cw-deb.mk
 deb-only: plugins-deb-only
 
 .PHONY: deb
-deb: build deb-only plugins-deb
+deb: build plugins-deb deb-only
 
 .PHONY: all build test clean distclean
 


### PR DESCRIPTION
This means that plugins-deb-only won't get called before plugins-deb when performing make deb.

This only works with `make -j 1` (as we need to guarantee dependency ordering), but the full fix requires rotating our make file targets to ensure Debian build targets correctly depend on their dependencies.