### PR TITLE
[No reviewer] Don't wait for 6 cycles before killing a process

### DIFF
--- a/bono.root/usr/share/clearwater/infrastructure/scripts/bono.monit
+++ b/bono.root/usr/share/clearwater/infrastructure/scripts/bono.monit
@@ -23,7 +23,7 @@ check process bono_process with pidfile /var/run/bono/bono.pid
 
   # Check the service's resource usage, and abort the process if it's too high. This will
   # generate a core file and trigger diagnostics collection. 
-  if memory > 80% for 6 cycles then exec "/etc/init.d/bono abort"
+  if memory > 80% then exec "/etc/init.d/bono abort"
 
 # Check the SIP interface. This depends on the Bono process (and so won't run
 # unless the Bono process is running)

--- a/sprout-base.root/usr/share/clearwater/infrastructure/scripts/sprout.monit
+++ b/sprout-base.root/usr/share/clearwater/infrastructure/scripts/sprout.monit
@@ -24,7 +24,7 @@ check process sprout_process with pidfile /var/run/sprout/sprout.pid
 
   # Check the service's resource usage, and abort the process if it's too high. This will
   # generate a core file and trigger diagnostics collection.
-  if memory > 80% for 6 cycles then exec "/bin/bash -c '/usr/share/clearwater/bin/issue-alarm monit 1000.3; /etc/init.d/sprout abort'"
+  if memory > 80% then exec "/bin/bash -c '/usr/share/clearwater/bin/issue-alarm monit 1000.3; /etc/init.d/sprout abort'"
 
 # Clear any alarms if the process has been running long enough.
 check program sprout_uptime with path /usr/share/clearwater/infrastructure/monit_uptime/check-sprout-uptime


### PR DESCRIPTION
There's no reason to think that if Sprout has exceeded 80% of the memory usage that it won't continue to do so in 6 cycles time. The only effect this has is that it takes longer to kill Sprout if it's memory usage is out of control (to the extent that it might have caused the entire box to run out of memory).

Agreed with @eleanor-merry that this was the right fix, so no review.