### PR TITLE
[Reviewer=HJS, AJH]  Add SAS logs detailing when MMF is invoked

### DIFF
--- a/include/sproutsasevent.h
+++ b/include/sproutsasevent.h
@@ -215,8 +215,8 @@ namespace SASEvent
 
   const int SIFC_NO_SET_FOR_ID = SPROUT_BASE + 0x0150;
 
-  const int MMF_INVOKE_BEFORE_AS = SPROUT_BASE + 0x0200;
-  const int MMF_INVOKE_AFTER_AS = SPROUT_BASE + 0x0201;
+  const int MMF_INVOKE_BEFORE_AS = SPROUT_BASE + 0x0160;
+  const int MMF_INVOKE_AFTER_AS = SPROUT_BASE + 0x0161;
 
 } //namespace SASEvent
 

--- a/include/sproutsasevent.h
+++ b/include/sproutsasevent.h
@@ -215,6 +215,9 @@ namespace SASEvent
 
   const int SIFC_NO_SET_FOR_ID = SPROUT_BASE + 0x0150;
 
+  const int MMF_INVOKE_BEFORE_AS = SPROUT_BASE + 0x0200;
+  const int MMF_INVOKE_AFTER_AS = SPROUT_BASE + 0x0201;
+
 } //namespace SASEvent
 
 #endif

--- a/src/scscfsproutlet.cpp
+++ b/src/scscfsproutlet.cpp
@@ -1637,6 +1637,11 @@ void SCSCFSproutletTsx::route_to_as(pjsip_msg* req, const std::string& server_na
                              get_pool(req));
 
       TRC_DEBUG("Adding top route header for post-AS MMF");
+
+      SAS::Event invoke_mmf(trail(), SASEvent::MMF_INVOKE_AFTER_AS, 0);
+      invoke_mmf.add_var_param(server_mmf_config->get_mmfcontext());
+      SAS::report_event(invoke_mmf);
+
       PJUtils::add_top_route_header(req, post_as_uri, get_pool(req));
     }
 
@@ -1656,6 +1661,10 @@ void SCSCFSproutletTsx::route_to_as(pjsip_msg* req, const std::string& server_na
                              server_mmf_config->get_mmfcontext(),
                              "pre-as",
                              get_pool(req));
+
+      SAS::Event invoke_mmf(trail(), SASEvent::MMF_INVOKE_BEFORE_AS, 0);
+      invoke_mmf.add_var_param(server_mmf_config->get_mmfcontext());
+      SAS::report_event(invoke_mmf);
 
       TRC_DEBUG("Adding top route header for pre-as MMF");
       PJUtils::add_top_route_header(req, pre_as_uri, get_pool(req));

--- a/src/scscfsproutlet.cpp
+++ b/src/scscfsproutlet.cpp
@@ -1639,6 +1639,7 @@ void SCSCFSproutletTsx::route_to_as(pjsip_msg* req, const std::string& server_na
       TRC_DEBUG("Adding top route header for post-AS MMF");
 
       SAS::Event invoke_mmf(trail(), SASEvent::MMF_INVOKE_AFTER_AS, 0);
+      invoke_mmf.add_var_param(server_domain_str);
       invoke_mmf.add_var_param(server_mmf_config->get_mmfcontext());
       SAS::report_event(invoke_mmf);
 
@@ -1663,6 +1664,7 @@ void SCSCFSproutletTsx::route_to_as(pjsip_msg* req, const std::string& server_na
                              get_pool(req));
 
       SAS::Event invoke_mmf(trail(), SASEvent::MMF_INVOKE_BEFORE_AS, 0);
+      invoke_mmf.add_var_param(server_domain_str);
       invoke_mmf.add_var_param(server_mmf_config->get_mmfcontext());
       SAS::report_event(invoke_mmf);
 


### PR DESCRIPTION
It was spotted the S-CSCF didn't raise SAS logs detailing when it was invoking MMF.  This PR adds these.

- SAS logs are only raised if MMF is being invoked - if MMF is switched off, then no logs are raised
- We raise separate SAS logs for pre-as and post-as MMF;  to combine these into a single SAS MMF log would require extra code, and wouldn't fit in as nicely to the current shape/ structure
- I am not sure of the policy for picking Sprout SAS log number ranges.  If I should be leaving more of a gap, please shout and I'll be happy to change

