### PR TITLE
make upload scripts need sudo

### DIFF
--- a/sprout-base.root/usr/share/clearwater/clearwater-config-manager/scripts/upload_enum_json
+++ b/sprout-base.root/usr/share/clearwater/clearwater-config-manager/scripts/upload_enum_json
@@ -10,6 +10,8 @@
 FILENAME=enum.json
 KEY=enum_json
 
+. /usr/share/clearwater/utils/check-root-permissions 1
+
 # Pass optional argument directly to upload_json, which checks for --allow-large
 # option that allows file upload larger than advisable
 /usr/share/clearwater/clearwater-config-manager/scripts/upload_json $FILENAME $KEY $1

--- a/sprout-base.root/usr/share/clearwater/clearwater-config-manager/scripts/upload_scscf_json
+++ b/sprout-base.root/usr/share/clearwater/clearwater-config-manager/scripts/upload_scscf_json
@@ -10,6 +10,8 @@
 FILENAME=s-cscf.json
 KEY=scscf_json
 
+. /usr/share/clearwater/utils/check-root-permissions 1
+
 # Pass optional argument directly to upload_json, which checks for --allow-large
 # option that allows file upload larger than advisable
 /usr/share/clearwater/clearwater-config-manager/scripts/upload_json $FILENAME $KEY $1

--- a/sprout-bgcf.root/usr/share/clearwater/clearwater-config-manager/scripts/upload_bgcf_json
+++ b/sprout-bgcf.root/usr/share/clearwater/clearwater-config-manager/scripts/upload_bgcf_json
@@ -10,6 +10,8 @@
 FILENAME=bgcf.json
 KEY=bgcf_json
 
+. /usr/share/clearwater/utils/check-root-permissions 1
+
 # Pass optional argument directly to upload_json, which checks for --allow-large
 # option that allows file upload larger than advisable
 /usr/share/clearwater/clearwater-config-manager/scripts/upload_json $FILENAME $KEY $1


### PR DESCRIPTION
I added lines to make the following commands require sudo:
cw-upload_scscf_json
cw-upload_bgcf_json
cw-upload_enum_json

I've live tested these changes, and confirmed you now need sudo to run these commands