### PR TITLE
[Reviewer: Krista] Fix placeholder in ENT log.

### DIFF
--- a/include/sprout_pd_definitions.h
+++ b/include/sprout_pd_definitions.h
@@ -419,7 +419,7 @@ static const PDLog2<const char *, const char*> CL_SPROUT_SESS_CONT_AS_COMM_FAILU
   PDLogBase::CL_SPROUT_ID + 50,
   LOG_ERR,
   "Sprout is currently unable to successfully communicate with an Application Server that uses session continued default handling. The server's URI is %s. Failure reason: %s",
-  "Communication is failing to <URI>",
+  "Communication is failing to an Application server",
   "Probable minor degradation of service, or loss of a supplemental service. The precise impact will vary depending on the role of the Application Server in the deployment.",
   "Investigate why communication to this Application Server is failing. It might be due to failure of the AS, misconfiguration of Initial Filter Criteria, or network / DNS problems"
 );

--- a/include/sproutlet_options.h
+++ b/include/sproutlet_options.h
@@ -77,7 +77,7 @@
         else                                                                   \
         {                                                                      \
           CL_SPROUT_INVALID_PORT_SPROUTLET.log(NAME_AS_STR, pj_optarg);        \
-          TRC_ERROR(""#NAME_LOWER" port %s is invalid\n", pj_optarg);          \
+          TRC_ERROR(""#NAME_LOWER" port %s is invalid", pj_optarg);            \
           return -1;                                                           \
         }                                                                      \
         break;                                                                 \

--- a/src/hssconnection.cpp
+++ b/src/hssconnection.cpp
@@ -144,7 +144,7 @@ HTTPCode HSSConnection::get_json_object(const std::string& path,
 
     if (json_object->HasParseError())
     {
-      TRC_INFO("Failed to parse Homestead response:\nPath: %s\nData: %s\nError: %s\n",
+      TRC_INFO("Failed to parse Homestead response:\nPath: %s\nData: %s\nError: %s",
                path.c_str(),
                json_data.c_str(),
                rapidjson::GetParseError_En(json_object->GetParseError()));
@@ -170,7 +170,7 @@ rapidxml::xml_document<>* HSSConnection::parse_xml(std::string raw_data, const s
   catch (rapidxml::parse_error& err)
   {
     // report to the user the failure and their locations in the document.
-    TRC_WARNING("Failed to parse Homestead response:\n %s\n %s\n %s\n", url.c_str(), raw_data.c_str(), err.what());
+    TRC_WARNING("Failed to parse Homestead response:\n %s\n %s\n %s", url.c_str(), raw_data.c_str(), err.what());
     delete root;
     root = NULL;
   }

--- a/src/icscfrouter.cpp
+++ b/src/icscfrouter.cpp
@@ -233,7 +233,7 @@ int ICSCFRouter::parse_hss_response(rapidjson::Document*& rsp, bool queried_caps
                                  _hss_rsp.optional_caps)))
         {
           // Failed to parse capabilities, so reject with 480 response.
-          TRC_INFO("Malformed required capabilities returned by HSS\n");
+          TRC_INFO("Malformed required capabilities returned by HSS");
           status_code = PJSIP_SC_TEMPORARILY_UNAVAILABLE;
         }
       }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2254,7 +2254,7 @@ int main(int argc, char* argv[])
   {
     CL_SPROUT_HTTP_INTERFACE_FAIL.log(e._func, e._rc);
     closelog();
-    TRC_ERROR("Caught signaling HttpStack::Exception - %s - %d\n", e._func, e._rc);
+    TRC_ERROR("Caught signaling HttpStack::Exception - %s - %d", e._func, e._rc);
     return 1;
   }
 
@@ -2270,7 +2270,7 @@ int main(int argc, char* argv[])
   {
     CL_SPROUT_HTTP_INTERFACE_FAIL.log(e._func, e._rc);
     closelog();
-    TRC_ERROR("Caught management HttpStack::Exception - %s - %d\n", e._func, e._rc);
+    TRC_ERROR("Caught management HttpStack::Exception - %s - %d", e._func, e._rc);
     return 1;
   }
 
@@ -2431,7 +2431,7 @@ int main(int argc, char* argv[])
     catch (HttpStack::Exception& e)
     {
       CL_SPROUT_HTTP_INTERFACE_FAIL.log(e._func, e._rc);
-      TRC_ERROR("Caught signaling HttpStack::Exception - %s - %d\n", e._func, e._rc);
+      TRC_ERROR("Caught signaling HttpStack::Exception - %s - %d", e._func, e._rc);
       return 1;
     }
 
@@ -2451,7 +2451,7 @@ int main(int argc, char* argv[])
     catch (HttpStack::Exception& e)
     {
       CL_SPROUT_HTTP_INTERFACE_FAIL.log(e._func, e._rc);
-      TRC_ERROR("Caught management HttpStack::Exception - %s - %d\n", e._func, e._rc);
+      TRC_ERROR("Caught management HttpStack::Exception - %s - %d", e._func, e._rc);
       return 1;
     }
   }
@@ -2480,7 +2480,7 @@ int main(int argc, char* argv[])
     catch (HttpStack::Exception& e)
     {
       CL_SPROUT_HTTP_INTERFACE_STOP_FAIL.log(e._func, e._rc);
-      TRC_ERROR("Caught signaling HttpStack::Exception - %s - %d\n", e._func, e._rc);
+      TRC_ERROR("Caught signaling HttpStack::Exception - %s - %d", e._func, e._rc);
     }
 
     try
@@ -2491,7 +2491,7 @@ int main(int argc, char* argv[])
     catch (HttpStack::Exception& e)
     {
       CL_SPROUT_HTTP_INTERFACE_STOP_FAIL.log(e._func, e._rc);
-      TRC_ERROR("Caught management HttpStack::Exception - %s - %d\n", e._func, e._rc);
+      TRC_ERROR("Caught management HttpStack::Exception - %s - %d", e._func, e._rc);
     }
   }
 

--- a/src/ut/fakehssconnection.cpp
+++ b/src/ut/fakehssconnection.cpp
@@ -146,7 +146,7 @@ long FakeHSSConnection::get_json_object(const std::string& path,
     else
     {
       // report to the user the failure and their locations in the document.
-      TRC_ERROR("Failed to parse Homestead response:\n %s\n %s.\n Error offset: %d\n",
+      TRC_ERROR("Failed to parse Homestead response:\n %s\n %s.\n Error offset: %d",
                 path.c_str(),
                 i->second.c_str(),
                 object->GetErrorOffset());
@@ -200,7 +200,7 @@ long FakeHSSConnection::get_xml_object(const std::string& path,
              path.c_str(),
              i->second.c_str(),
              err.what());
-      TRC_ERROR("Failed to parse Homestead response:\n %s\n %s\n %s\n",
+      TRC_ERROR("Failed to parse Homestead response:\n %s\n %s\n %s",
                 path.c_str(),
                 i->second.c_str(),
                 err.what());

--- a/src/ut/siptest.cpp
+++ b/src/ut/siptest.cpp
@@ -708,7 +708,7 @@ void SipTest::poll()
   do
   {
     pj_status_t status = pjsip_endpt_handle_events2(stack_data.endpt, &delay, &count);
-    TRC_INFO("Poll found %d events, status %d\n", (int)count, (int)status);
+    TRC_INFO("Poll found %d events, status %d", (int)count, (int)status);
   }
   while (count != 0);
 }


### PR DESCRIPTION
The CL_SPROUT_SESS_CONT_AS_COMM_FAILURE ENT log has a placeholder in the Cause section. This PR makes the ENT log consistent with the other application server ENT logs.

Note - our current ENT log infrastructure only allows text replacement in the description section, so we can't make the Cause section more useful yet.

I've also fixed up some rogue newlines in logs as I was here.