### PR TITLE
[Reviewer: Alex] Test we can route * and # in To headers

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -145,7 +145,7 @@ sprout_test_SOURCES := ${SPROUT_COMMON_SOURCES} \
                        aschain_test.cpp \
                        sessioncase_test.cpp \
                        ifchandler_test.cpp \
-                       custom_headers_test.cpp \
+                       sip_parser_test.cpp \
                        connection_tracker_test.cpp \
                        quiescing_manager_test.cpp \
                        dialog_tracker_test.cpp \

--- a/src/ut/icscfsproutlet_test.cpp
+++ b/src/ut/icscfsproutlet_test.cpp
@@ -353,8 +353,88 @@ protected:
     EXPECT_EQ(network_successes, session_network_table->_successes);
     EXPECT_EQ(network_failures, session_network_table->_failures);
   }
+
+  void test_route_terminating_sip_uri_helper(const char* to_uri);
 };
 
+
+void ICSCFSproutletTest::test_route_terminating_sip_uri_helper(const char* to_uri)
+{
+  pjsip_tx_data* tdata;
+
+  // Create a TCP connection to the I-CSCF listening port.
+  TransportFlow* tp = new TransportFlow(TransportFlow::Protocol::TCP,
+                                        ICSCF_PORT,
+                                        "1.2.3.4",
+                                        49152);
+
+  // Set up the HSS responses for the terminating location query.
+  _hss_connection->set_result("/impu/tel%3A%2B16505551234/location",
+                              "{\"result-code\": 2001,"
+                              " \"scscf\": \"sip:scscf1.homedomain:5058;transport=TCP\"}");
+
+  // Inject an INVITE request to a sip URI representing a telephone number with a
+  // P-Served-User header.
+  //
+  // Add NP data to the SIP URI - it should be ignored for the purposes of SIP -> Tel URI
+  // conversion
+  Message msg1;
+  msg1._method = "INVITE";
+  msg1._requri = "sip:+16505551234;npdi;rn=567@homedomain";
+  msg1._to = to_uri;
+  msg1._via = tp->to_string(false);
+  msg1._extra = "Contact: sip:6505551000@" +
+                tp->to_string(true) +
+                ";ob;expires=300;+sip.ice;reg-id=1;+sip.instance=\"<urn:uuid:00000000-0000-0000-0000-b665231f1213>\"\r\n";
+  msg1._extra += "P-Served-User: <sip:6505551000@homedomain>";
+  msg1._route = "Route: <sip:homedomain>";
+  inject_msg(msg1.get_request(), tp);
+
+  // Expecting 100 Trying and forwarded INVITE
+  ASSERT_EQ(2, txdata_count());
+
+  // Check the 100 Trying.
+  tdata = current_txdata();
+  RespMatcher(100).matches(tdata->msg);
+  tp->expect_target(tdata);
+  free_txdata();
+
+  // INVITE request should be forwarded to the server named in the HSS
+  // response, scscf1.homedomain.
+  tdata = current_txdata();
+  expect_target("TCP", "10.10.10.1", 5058, tdata);
+  ReqMatcher r1("INVITE");
+  r1.matches(tdata->msg);
+
+  // Verify that the user parameters were carried through the SIP to Tel URI conversion successfully
+  ASSERT_EQ("tel:+16505551234;npdi;rn=567", str_uri(tdata->msg->line.req.uri));
+
+  // Check that a Route header has been added routing the INVITE to the
+  // selected S-CSCF.  This must include the orig parameter.
+  string route = get_headers(tdata->msg, "Route");
+  ASSERT_EQ("Route: <sip:scscf1.homedomain:5058;transport=TCP;lr>", route);
+
+  // Check that no Record-Route headers have been added.
+  string rr = get_headers(tdata->msg, "Record-Route");
+  ASSERT_EQ("", rr);
+
+  // Send a 200 OK response.
+  inject_msg(respond_to_current_txdata(200));
+
+  // Check the response is forwarded back to the source.
+  ASSERT_EQ(1, txdata_count());
+  tdata = current_txdata();
+  tp->expect_target(tdata);
+  RespMatcher r2(200);
+  r2.matches(tdata->msg);
+  free_txdata();
+
+  test_session_establishment_stats(1, 0, 1, 0);
+
+  _hss_connection->delete_result("/impu/sip%3A6505551234%40homedomain/location");
+
+  delete tp;
+}
 
 
 TEST_F(ICSCFSproutletTest, RouteRegisterHSSServerName)
@@ -3204,82 +3284,16 @@ TEST_F(ICSCFSproutletTest, RouteTermInviteLocalUserPhoneSuccess)
   delete tp;
 }
 
+
 TEST_F(ICSCFSproutletTest, RouteTermInviteNumericSIPURI)
 {
-  pjsip_tx_data* tdata;
+  test_route_terminating_sip_uri_helper("+16505551234");
+}
 
-  // Create a TCP connection to the I-CSCF listening port.
-  TransportFlow* tp = new TransportFlow(TransportFlow::Protocol::TCP,
-                                        ICSCF_PORT,
-                                        "1.2.3.4",
-                                        49152);
 
-  // Set up the HSS responses for the terminating location query.
-  _hss_connection->set_result("/impu/tel%3A%2B16505551234/location",
-                              "{\"result-code\": 2001,"
-                              " \"scscf\": \"sip:scscf1.homedomain:5058;transport=TCP\"}");
-
-  // Inject an INVITE request to a sip URI representing a telephone number with a
-  // P-Served-User header.
-  //
-  // Add NP data to the SIP URI - it should be ignored for the purposes of SIP -> Tel URI
-  // conversion
-  Message msg1;
-  msg1._method = "INVITE";
-  msg1._requri = "sip:+16505551234;npdi;rn=567@homedomain";
-  msg1._to = "+16505551234";
-  msg1._via = tp->to_string(false);
-  msg1._extra = "Contact: sip:6505551000@" +
-                tp->to_string(true) +
-                ";ob;expires=300;+sip.ice;reg-id=1;+sip.instance=\"<urn:uuid:00000000-0000-0000-0000-b665231f1213>\"\r\n";
-  msg1._extra += "P-Served-User: <sip:6505551000@homedomain>";
-  msg1._route = "Route: <sip:homedomain>";
-  inject_msg(msg1.get_request(), tp);
-
-  // Expecting 100 Trying and forwarded INVITE
-  ASSERT_EQ(2, txdata_count());
-
-  // Check the 100 Trying.
-  tdata = current_txdata();
-  RespMatcher(100).matches(tdata->msg);
-  tp->expect_target(tdata);
-  free_txdata();
-
-  // INVITE request should be forwarded to the server named in the HSS
-  // response, scscf1.homedomain.
-  tdata = current_txdata();
-  expect_target("TCP", "10.10.10.1", 5058, tdata);
-  ReqMatcher r1("INVITE");
-  r1.matches(tdata->msg);
-
-  // Verify that the user parameters were carried through the SIP to Tel URI conversion successfully
-  ASSERT_EQ("tel:+16505551234;npdi;rn=567", str_uri(tdata->msg->line.req.uri));
-
-  // Check that a Route header has been added routing the INVITE to the
-  // selected S-CSCF.  This must include the orig parameter.
-  string route = get_headers(tdata->msg, "Route");
-  ASSERT_EQ("Route: <sip:scscf1.homedomain:5058;transport=TCP;lr>", route);
-
-  // Check that no Record-Route headers have been added.
-  string rr = get_headers(tdata->msg, "Record-Route");
-  ASSERT_EQ("", rr);
-
-  // Send a 200 OK response.
-  inject_msg(respond_to_current_txdata(200));
-
-  // Check the response is forwarded back to the source.
-  ASSERT_EQ(1, txdata_count());
-  tdata = current_txdata();
-  tp->expect_target(tdata);
-  RespMatcher r2(200);
-  r2.matches(tdata->msg);
-  free_txdata();
-
-  test_session_establishment_stats(1, 0, 1, 0);
-
-  _hss_connection->delete_result("/impu/sip%3A6505551234%40homedomain/location");
-
-  delete tp;
+TEST_F(ICSCFSproutletTest, RouteTermInviteNumericSIPURIWithStarHashToURI)
+{
+  test_route_terminating_sip_uri_helper("*1234#");
 }
 
 

--- a/src/ut/sip_parser_test.cpp
+++ b/src/ut/sip_parser_test.cpp
@@ -1,5 +1,6 @@
 /**
- * @file custom_headers_test.cpp UT for custom header parsers.
+ * @file sip_parser_test.cpp UT for SIP parser testing. This checks custom
+ * header parsing, and other specific parser functionality.
  *
  * Copyright (C) Metaswitch Networks 2017
  * If license terms are provided to you in a COPYING file in the root directory
@@ -21,8 +22,8 @@ using namespace std;
 
 #define EXPECT_PJEQ(X, Y) EXPECT_EQ(PJUtils::pj_str_to_string(&X), string(Y))
 
-/// Fixture for Custom Header testing
-class CustomHeadersTest : public SipTest
+/// Fixture for SIP Parser testing
+class SipParserTest : public SipTest
 {
 public:
   static void SetUpTestCase()
@@ -36,7 +37,7 @@ public:
   }
 };
 
-TEST_F(CustomHeadersTest, PChargingVector)
+TEST_F(SipParserTest, PChargingVector)
 {
   string str("INVITE sip:6505554321@homedomain SIP/2.0\n"
              "Via: SIP/2.0/TCP 10.0.0.1:5060;rport;branch=z9hG4bKPjPtKqxhkZnvVKI2LUEWoZVFjFaqo.cOzf;alias\n"
@@ -97,7 +98,7 @@ TEST_F(CustomHeadersTest, PChargingVector)
   EXPECT_STREQ("P-Charging-Vector: icid-value=\"4815162542\";orig-ioi=homedomain;term-ioi=remotedomain;icid-generated-at=edge.proxy.net;other-param=test-value", buf);
 }
 
-TEST_F(CustomHeadersTest, PChargingVectorQuotedIcidValue)
+TEST_F(SipParserTest, PChargingVectorQuotedIcidValue)
 {
   string str("INVITE sip:6505554321@homedomain SIP/2.0\n"
              "Via: SIP/2.0/TCP 10.0.0.1:5060;rport;branch=z9hG4bKPjPtKqxhkZnvVKI2LUEWoZVFjFaqo.cOzf;alias\n"
@@ -143,7 +144,7 @@ TEST_F(CustomHeadersTest, PChargingVectorQuotedIcidValue)
   EXPECT_STREQ("P-Charging-Vector: icid-value=\"a2bb639b437cd5827a8f54fe39f3987c0:0:0:0:0:0:0:0\";orig-ioi=homedomain;term-ioi=remotedomain;icid-generated-at=edge.proxy.net;other-param=test-value", buf);
 }
 
-TEST_F(CustomHeadersTest, PChargingVectorHostnameIcidValue)
+TEST_F(SipParserTest, PChargingVectorHostnameIcidValue)
 {
   string str("INVITE sip:6505554321@homedomain SIP/2.0\n"
              "Via: SIP/2.0/TCP 10.0.0.1:5060;rport;branch=z9hG4bKPjPtKqxhkZnvVKI2LUEWoZVFjFaqo.cOzf;alias\n"
@@ -188,7 +189,7 @@ TEST_F(CustomHeadersTest, PChargingVectorHostnameIcidValue)
   EXPECT_STREQ("P-Charging-Vector: icid-value=\"subdomain.example.com\";orig-ioi=homedomain;term-ioi=remotedomain;icid-generated-at=edge.proxy.net;other-param=test-value", buf);
 }
 
-TEST_F(CustomHeadersTest, PChargingVectorIPv6IcidValue)
+TEST_F(SipParserTest, PChargingVectorIPv6IcidValue)
 {
   string str("INVITE sip:6505554321@homedomain SIP/2.0\n"
              "Via: SIP/2.0/TCP 10.0.0.1:5060;rport;branch=z9hG4bKPjPtKqxhkZnvVKI2LUEWoZVFjFaqo.cOzf;alias\n"
@@ -233,7 +234,7 @@ TEST_F(CustomHeadersTest, PChargingVectorIPv6IcidValue)
   EXPECT_STREQ("P-Charging-Vector: icid-value=\"[::1]\";orig-ioi=homedomain;term-ioi=remotedomain;icid-generated-at=edge.proxy.net;other-param=test-value", buf);
 }
 
-TEST_F(CustomHeadersTest, PChargingVectorEmptyIcidValue)
+TEST_F(SipParserTest, PChargingVectorEmptyIcidValue)
 {
   string str("INVITE sip:6505554321@homedomain SIP/2.0\n"
              "Via: SIP/2.0/TCP 10.0.0.1:5060;rport;branch=z9hG4bKPjPtKqxhkZnvVKI2LUEWoZVFjFaqo.cOzf;alias\n"
@@ -278,7 +279,7 @@ TEST_F(CustomHeadersTest, PChargingVectorEmptyIcidValue)
   EXPECT_STREQ("P-Charging-Vector: icid-value=\"\";orig-ioi=homedomain;term-ioi=remotedomain;icid-generated-at=edge.proxy.net;other-param=test-value", buf);
 }
 
-TEST_F(CustomHeadersTest, PChargingFunctionAddresses)
+TEST_F(SipParserTest, PChargingFunctionAddresses)
 {
   string str("INVITE sip:6505554321@homedomain SIP/2.0\n"
              "Via: SIP/2.0/TCP 10.0.0.1:5060;rport;branch=z9hG4bKPjPtKqxhkZnvVKI2LUEWoZVFjFaqo.cOzf;alias\n"
@@ -333,7 +334,7 @@ TEST_F(CustomHeadersTest, PChargingFunctionAddresses)
   EXPECT_STREQ("P-Charging-Function-Addresses: ccf=10.0.0.2;ccf=10.0.0.4;ecf=10.0.0.1;ecf=10.0.0.3;other-param=test-value", buf);
 }
 
-TEST_F(CustomHeadersTest, PChargingFunctionAddressesIPv6)
+TEST_F(SipParserTest, PChargingFunctionAddressesIPv6)
 {
   string str("INVITE sip:6505554321@homedomain SIP/2.0\n"
              "Via: SIP/2.0/TCP 10.0.0.1:5060;rport;branch=z9hG4bKPjPtKqxhkZnvVKI2LUEWoZVFjFaqo.cOzf;alias\n"
@@ -388,7 +389,7 @@ TEST_F(CustomHeadersTest, PChargingFunctionAddressesIPv6)
   EXPECT_STREQ("P-Charging-Function-Addresses: ccf=10.22.42.18;ccf=[FD5F:5D21:845:1C27:FF00::42:105]", buf);
 }
 
-TEST_F(CustomHeadersTest, PChargingFunctionAddressesOneIPv6)
+TEST_F(SipParserTest, PChargingFunctionAddressesOneIPv6)
 {
   string str("INVITE sip:6505554321@homedomain SIP/2.0\n"
              "Via: SIP/2.0/TCP 10.0.0.1:5060;rport;branch=z9hG4bKPjPtKqxhkZnvVKI2LUEWoZVFjFaqo.cOzf;alias\n"
@@ -444,7 +445,7 @@ TEST_F(CustomHeadersTest, PChargingFunctionAddressesOneIPv6)
 }
 
 
-TEST_F(CustomHeadersTest, SessionExpires)
+TEST_F(SipParserTest, SessionExpires)
 {
   string str("INVITE sip:6505554321@homedomain SIP/2.0\n"
              "Via: SIP/2.0/TCP 10.0.0.1:5060;rport;branch=z9hG4bKPjPtVFjqo;alias\n"
@@ -493,7 +494,7 @@ TEST_F(CustomHeadersTest, SessionExpires)
   EXPECT_STREQ("Session-Expires: 600;refresher=uas;other-param=10;more-param=42", buf);
 }
 
-TEST_F(CustomHeadersTest, SessionExpiresUAC)
+TEST_F(SipParserTest, SessionExpiresUAC)
 {
   string str("INVITE sip:6505554321@homedomain SIP/2.0\n"
              "Via: SIP/2.0/TCP 10.0.0.1:5060;rport;branch=z9hG4bKPjPtVFjqo;alias\n"
@@ -542,7 +543,7 @@ TEST_F(CustomHeadersTest, SessionExpiresUAC)
   EXPECT_STREQ("Session-Expires: 600;refresher=uac;other-param=10;more-param=42", buf);
 }
 
-TEST_F(CustomHeadersTest, AcceptContact)
+TEST_F(SipParserTest, AcceptContact)
 {
   pj_pool_t *main_pool = pjsip_endpt_create_pool(stack_data.endpt, "rtd%p",
                                                  PJSIP_POOL_RDATA_LEN,
@@ -625,7 +626,7 @@ TEST_F(CustomHeadersTest, AcceptContact)
   pj_pool_release(main_pool);
 }
 
-TEST_F(CustomHeadersTest, RejectContact)
+TEST_F(SipParserTest, RejectContact)
 {
   pj_pool_t *main_pool = pjsip_endpt_create_pool(stack_data.endpt, "rtd%p",
                                                  PJSIP_POOL_RDATA_LEN,
@@ -678,7 +679,7 @@ TEST_F(CustomHeadersTest, RejectContact)
   pj_pool_release(clone_pool);
 }
 
-TEST_F(CustomHeadersTest, PAssociatedURI)
+TEST_F(SipParserTest, PAssociatedURI)
 {
   pj_pool_t *main_pool = pjsip_endpt_create_pool(stack_data.endpt, "rtd%p",
                                                  PJSIP_POOL_RDATA_LEN,
@@ -748,7 +749,7 @@ TEST_F(CustomHeadersTest, PAssociatedURI)
   pj_pool_release(clone_pool);
 }
 
-TEST_F(CustomHeadersTest, PAssertedIdentity)
+TEST_F(SipParserTest, PAssertedIdentity)
 {
   pj_pool_t *main_pool = pjsip_endpt_create_pool(stack_data.endpt, "rtd%p",
                                                  PJSIP_POOL_RDATA_LEN,
@@ -820,7 +821,7 @@ TEST_F(CustomHeadersTest, PAssertedIdentity)
 
 // Test that you can create a P-Profile-Key header, parse it and clone it
 // without any issues
-TEST_F(CustomHeadersTest, PProfileKey)
+TEST_F(SipParserTest, PProfileKey)
 {
   pj_pool_t *main_pool = pjsip_endpt_create_pool(stack_data.endpt, "rtd%p",
                                                  PJSIP_POOL_RDATA_LEN,
@@ -870,7 +871,7 @@ TEST_F(CustomHeadersTest, PProfileKey)
   pj_pool_release(clone_pool);
 }
 
-TEST_F(CustomHeadersTest, ServiceRoute)
+TEST_F(SipParserTest, ServiceRoute)
 {
   pj_pool_t *main_pool = pjsip_endpt_create_pool(stack_data.endpt, "rtd%p",
                                                  PJSIP_POOL_RDATA_LEN,
@@ -925,7 +926,7 @@ TEST_F(CustomHeadersTest, ServiceRoute)
   EXPECT_STREQ("Service-Route: <sip:sprout.example.com:5054;transport=TCP;lr;orig>;x=2;y=3", buf);
 }
 
-TEST_F(CustomHeadersTest, Path)
+TEST_F(SipParserTest, Path)
 {
   pj_pool_t *main_pool = pjsip_endpt_create_pool(stack_data.endpt, "rtd%p",
                                                  PJSIP_POOL_RDATA_LEN,
@@ -980,7 +981,7 @@ TEST_F(CustomHeadersTest, Path)
   EXPECT_STREQ("Path: <sip:12345678@example.com:5054;transport=TCP;lr>;x=2;y=3", buf);
 }
 
-TEST_F(CustomHeadersTest, MinSE)
+TEST_F(SipParserTest, MinSE)
 {
   pj_pool_t *main_pool = pjsip_endpt_create_pool(stack_data.endpt, "rtd%p",
                                                  PJSIP_POOL_RDATA_LEN,
@@ -1027,4 +1028,36 @@ TEST_F(CustomHeadersTest, MinSE)
     i++;
   }
   EXPECT_STREQ("Min-SE: 300;other-param=other-param-value", buf);
+}
+
+TEST_F(SipParserTest, StarHashToHeader)
+{
+  pj_pool_t *main_pool = pjsip_endpt_create_pool(stack_data.endpt, "rtd%p",
+                                                 PJSIP_POOL_RDATA_LEN,
+                                                 PJSIP_POOL_RDATA_INC);
+
+  string str("INVITE sip:6505554321@homedomain SIP/2.0\n"
+             "Via: SIP/2.0/TCP 10.0.0.1:5060;rport;branch=z9hG4bKPjPtVFjqo;alias\n"
+             "Max-Forwards: 63\n"
+             "From: <sip:6505551234@homedomain>;tag=1234\n"
+             "To: <sip:*1234#@homedomain>\n"
+             "Contact: <sip:6505551234@10.0.0.1:5060;transport=TCP;ob>\n"
+             "Call-ID: 1-13919@10.151.20.48\n"
+             "CSeq: 1 INVITE\n"
+             "Content-Length: 0\n\n");
+
+  pjsip_rx_data* rdata = build_rxdata(str, _tp_default, main_pool);
+  parse_rxdata(rdata);
+
+  pj_str_t header_name = pj_str("To");
+  pjsip_to_hdr* hdr =
+      (pjsip_to_hdr*)pjsip_msg_find_hdr_by_name(rdata->msg_info.msg,
+                                                &header_name,
+                                                NULL);
+  EXPECT_NE(hdr, (pjsip_to_hdr*)NULL);
+  pjsip_name_addr* uri = (pjsip_name_addr*) hdr->uri;
+  pjsip_sip_uri* sip_uri = (pjsip_sip_uri*) uri->uri;
+  pj_str_t* user = &(sip_uri->user);
+  pj_str_t goal = pj_str("*1234#");
+  EXPECT_EQ(pj_strcmp(user, &goal), 0);
 }


### PR DESCRIPTION
Alex,

This validates that the I-CSCF can route messages with a * or a # in the To header. It requires in order to pass https://github.com/Metaswitch/pjsip-upstream/pull/66.