### PR TITLE
rename mmf_context to mmf_target

### DIFF
--- a/include/constants.h
+++ b/include/constants.h
@@ -112,7 +112,7 @@ const pj_str_t STR_SERVICE = pj_str((char*)"service");
 const pj_str_t STR_USERNAME = pj_str((char*)"username");
 const pj_str_t STR_NONCE = pj_str((char*)"nonce");
 const pj_str_t STR_NAMESPACE = pj_str((char*)"namespace");
-const pj_str_t STR_MMFCONTEXT = pj_str((char*)"mmfcontext");
+const pj_str_t STR_MMFTARGET = pj_str((char*)"mmftarget");
 const pj_str_t STR_MMFSCOPE = pj_str((char*)"mmfscope");
 
 /// Prefix of ODI tokens we generate.

--- a/include/mmftargets.h
+++ b/include/mmftargets.h
@@ -23,7 +23,7 @@ class MMFTarget
 public:
   MMFTarget(const rapidjson::Value& config);
 
-  inline const std::string get_mmfcontext() const {return _name;};
+  inline const std::string get_target_name() const {return _name;};
   inline const std::vector<std::string>& get_addresses() const {return _addresses;};
 
   /// Return whether we should invoke MMF prior to routing a message to any

--- a/include/scscfsproutlet.h
+++ b/include/scscfsproutlet.h
@@ -297,7 +297,7 @@ private:
   void add_mmf_uri_parameters(pjsip_sip_uri* mmf_uri,
                               pj_str_t as_transport_param,
                               std::string mmfscope_param,
-                              std::string mmfcontext_param,
+                              std::string mmftarget_param,
                               pj_pool_t* pool);
 
   /// Route the request to an application server.

--- a/src/scscfsproutlet.cpp
+++ b/src/scscfsproutlet.cpp
@@ -1632,15 +1632,15 @@ void SCSCFSproutletTsx::route_to_as(pjsip_msg* req, const std::string& server_na
 
       add_mmf_uri_parameters(post_as_uri,
                              as_uri->transport_param,
-                             server_mmf_config->get_mmfcontext(),
                              "post-as",
+                             server_mmf_config->get_target_name(),
                              get_pool(req));
 
       TRC_DEBUG("Adding top route header for post-AS MMF");
 
       SAS::Event invoke_mmf(trail(), SASEvent::MMF_INVOKE_AFTER_AS, 0);
       invoke_mmf.add_var_param(server_domain_str);
-      invoke_mmf.add_var_param(server_mmf_config->get_mmfcontext());
+      invoke_mmf.add_var_param(server_mmf_config->get_target_name());
       SAS::report_event(invoke_mmf);
 
       PJUtils::add_top_route_header(req, post_as_uri, get_pool(req));
@@ -1659,13 +1659,13 @@ void SCSCFSproutletTsx::route_to_as(pjsip_msg* req, const std::string& server_na
 
       add_mmf_uri_parameters(pre_as_uri,
                              as_uri->transport_param,
-                             server_mmf_config->get_mmfcontext(),
                              "pre-as",
+                             server_mmf_config->get_target_name(),
                              get_pool(req));
 
       SAS::Event invoke_mmf(trail(), SASEvent::MMF_INVOKE_BEFORE_AS, 0);
       invoke_mmf.add_var_param(server_domain_str);
-      invoke_mmf.add_var_param(server_mmf_config->get_mmfcontext());
+      invoke_mmf.add_var_param(server_mmf_config->get_target_name());
       SAS::report_event(invoke_mmf);
 
       TRC_DEBUG("Adding top route header for pre-as MMF");
@@ -2485,7 +2485,7 @@ pjsip_msg* SCSCFSproutletTsx::get_base_request()
 void SCSCFSproutletTsx::add_mmf_uri_parameters(pjsip_sip_uri* mmf_uri,
                                                pj_str_t as_transport_param,
                                                std::string mmfscope_param,
-                                               std::string mmfcontext_param,
+                                               std::string mmftarget_param,
                                                pj_pool_t* pool)
 {
   // Use same transport as AS, in case it can only cope with one.
@@ -2497,10 +2497,10 @@ void SCSCFSproutletTsx::add_mmf_uri_parameters(pjsip_sip_uri* mmf_uri,
                                     "mmf",
                                     pool);
 
-  TRC_DEBUG("Adding mmfcontext parameter %s", mmfcontext_param.c_str());
+  TRC_DEBUG("Adding mmftarget parameter %s", mmftarget_param.c_str());
   PJUtils::add_parameter_to_sip_uri(mmf_uri,
-                                    STR_MMFCONTEXT,
-                                    mmfcontext_param.c_str(),
+                                    STR_MMFTARGET,
+                                    mmftarget_param.c_str(),
                                     pool);
 
   TRC_DEBUG("Adding mmfscope parameter %s", mmfscope_param.c_str());

--- a/src/ut/scscf_test.cpp
+++ b/src/ut/scscf_test.cpp
@@ -10232,8 +10232,8 @@ TEST_F(SCSCFTest, MMFPreAs)
   std::string preas_uri = PJUtils::get_header_value(preas_hdr);
   EXPECT_THAT(preas_uri, MatchesRegex(".*sip:11.22.33.44:5053.*"));
   EXPECT_THAT(preas_uri, MatchesRegex(".*namespace=mmf.*"));
-  EXPECT_THAT(preas_uri, MatchesRegex(".*mmfcontext=pre-as.*"));
-  EXPECT_THAT(preas_uri, MatchesRegex(".*mmfscope=PreASOnly.*"));
+  EXPECT_THAT(preas_uri, MatchesRegex(".*mmfscope=pre-as.*"));
+  EXPECT_THAT(preas_uri, MatchesRegex(".*mmftarget=PreASOnly.*"));
   pj_list_erase(preas_hdr);
 
   // Ensure the AS header was added as expected, and remove it
@@ -10373,8 +10373,8 @@ TEST_F(SCSCFTest, MMFPostAs)
   std::string postas_uri = PJUtils::get_header_value(postas_hdr);
   EXPECT_THAT(postas_uri, MatchesRegex(".*sip:44.33.22.11:5053.*"));
   EXPECT_THAT(postas_uri, MatchesRegex(".*namespace=mmf.*"));
-  EXPECT_THAT(postas_uri, MatchesRegex(".*mmfcontext=post-as.*"));
-  EXPECT_THAT(postas_uri, MatchesRegex(".*mmfscope=PostASOnly.*"));
+  EXPECT_THAT(postas_uri, MatchesRegex(".*mmfscope=post-as.*"));
+  EXPECT_THAT(postas_uri, MatchesRegex(".*mmftarget=PostASOnly.*"));
   pj_list_erase(postas_hdr);
 
   // We have removed route headers to simulate the request being routed to the
@@ -10503,8 +10503,8 @@ TEST_F(SCSCFTest, MMFPreAndPostAs)
   //
   EXPECT_THAT(preas_uri, MatchesRegex(".*sip:11.22.33.44:5053.*"));
   EXPECT_THAT(preas_uri, MatchesRegex(".*namespace=mmf.*"));
-  EXPECT_THAT(preas_uri, MatchesRegex(".*mmfcontext=pre-as.*"));
-  EXPECT_THAT(preas_uri, MatchesRegex(".*mmfscope=BothPreAndPost.*"));
+  EXPECT_THAT(preas_uri, MatchesRegex(".*mmfscope=pre-as.*"));
+  EXPECT_THAT(preas_uri, MatchesRegex(".*mmftarget=BothPreAndPost.*"));
   pj_list_erase(preas_hdr);
 
   // Ensure the AS header was added as expected, and remove it
@@ -10518,8 +10518,8 @@ TEST_F(SCSCFTest, MMFPreAndPostAs)
   std::string postas_uri = PJUtils::get_header_value(postas_hdr);
   EXPECT_THAT(postas_uri, MatchesRegex(".*sip:44.33.22.11:5053.*"));
   EXPECT_THAT(postas_uri, MatchesRegex(".*namespace=mmf.*"));
-  EXPECT_THAT(postas_uri, MatchesRegex(".*mmfcontext=post-as.*"));
-  EXPECT_THAT(postas_uri, MatchesRegex(".*mmfscope=BothPreAndPost.*"));
+  EXPECT_THAT(postas_uri, MatchesRegex(".*mmfscope=post-as.*"));
+  EXPECT_THAT(postas_uri, MatchesRegex(".*mmftarget=BothPreAndPost.*"));
   pj_list_erase(postas_hdr);
 
   // We have removed route headers to simulate the request being routed from


### PR DESCRIPTION
Update mmf_context to be called mmf_target, to reduce confusion between config files.
Also fixing up the calls to add_mmf_uri_parameters, to pass the correct parameters in in the correct order (previously context and scope were mixed up) see https://github.com/Metaswitch/houdini/issues/812