### PR TITLE
[Reviewer: Ellie] Remove port from the default Sproutlet URIs

### DIFF
--- a/include/sproutlet_options.h
+++ b/include/sproutlet_options.h
@@ -135,7 +135,6 @@
                            opt.prefix_##NAME_LOWER +                           \
                            "." +                                               \
                            opt.sprout_hostname +                               \
-                           ":" + std::to_string(opt.port_##NAME_LOWER) +       \
                            ";transport=TCP";                                   \
   }                                                                            \
                                                                                \


### PR DESCRIPTION
As discussed, we think this is the right change.