### PR TITLE
[Reviewer: Sathiyan] Remove ENT log

### DIFF
--- a/include/sprout_pd_definitions.h
+++ b/include/sprout_pd_definitions.h
@@ -208,16 +208,6 @@ static const PDLog2<const char*, int> CL_SPROUT_HTTP_INTERFACE_STOP_FAIL
   "None."
 );
 
-static const PDLog2<const char*, const char*> CL_SPROUT_SIP_SEND_REQUEST_ERR
-(
-  PDLogBase::CL_SPROUT_ID + 23,
-  LOG_ERR,
-  "Failed to send SIP request to %s with error %s.",
-  "An attempt to send a SIP request failed.",
-  "This may cause a call to fail.",
-  "If the problem persists check the network connectivity."
-);
-
 static const PDLog CL_SPROUT_SIP_DEADLOCK
 (
   PDLogBase::CL_SPROUT_ID + 24,

--- a/src/pjutils.cpp
+++ b/src/pjutils.cpp
@@ -1276,10 +1276,6 @@ pj_status_t PJUtils::send_request(pjsip_tx_data* tdata,
   {
     // Failed to resolve the destination or failed to create a PJSIP UAC
     // transaction.
-    CL_SPROUT_SIP_SEND_REQUEST_ERR.log(PJUtils::uri_to_string(PJSIP_URI_IN_ROUTING_HDR,
-                                       PJUtils::next_hop(tdata->msg)).c_str(),
-                                       PJUtils::pj_status_to_string(status).c_str());
-
     TRC_ERROR("Failed to send request to %s",
               PJUtils::uri_to_string(PJSIP_URI_IN_ROUTING_HDR,
                                      PJUtils::next_hop(tdata->msg)).c_str());
@@ -1407,9 +1403,6 @@ pj_status_t PJUtils::send_request_stateless(pjsip_tx_data* tdata, int retries)
     // and the request here.  Also, this would be an unexpected error rather
     // than an indication that the selected destination server is down, so we
     // don't blacklist.
-    CL_SPROUT_SIP_SEND_REQUEST_ERR.log(PJUtils::uri_to_string(PJSIP_URI_IN_ROUTING_HDR,
-                                       PJUtils::next_hop(tdata->msg)).c_str(),
-                                       PJUtils::pj_status_to_string(status).c_str());
     TRC_ERROR("Failed to send request to %s",
               PJUtils::uri_to_string(PJSIP_URI_IN_ROUTING_HDR,
                                      PJUtils::next_hop(tdata->msg)).c_str());


### PR DESCRIPTION
ENT logs are meant to be for events that affect a node, not for things that affect a call.

This ENT log happens on a per-call basis, so I'm removing it (as the error can be debugged by SAS or by the engineering logs).