### PR TITLE
[Reviewer: Mat] Tweak AS comm failure text

### DIFF
--- a/include/sprout_pd_definitions.h
+++ b/include/sprout_pd_definitions.h
@@ -420,7 +420,7 @@ static const PDLog2<const char *, const char*> CL_SPROUT_SESS_CONT_AS_COMM_FAILU
   LOG_ERR,
   "Sprout is currently unable to successfully communicate with an Application Server that uses session continued default handling. The server's URI is %s. Failure reason: %s",
   "Communication is failing to an Application server",
-  "Probable minor degradation of service, or loss of a supplemental service. The precise impact will vary depending on the role of the Application Server in the deployment.",
+  "Probable minor degradation of service, loss of a supplemental service or increased call setup time. The precise impact will vary depending on the role of the Application Server in the deployment.",
   "Investigate why communication to this Application Server is failing. It might be due to failure of the AS, misconfiguration of Initial Filter Criteria, or network / DNS problems"
 );
 

--- a/include/sprout_pd_definitions.h
+++ b/include/sprout_pd_definitions.h
@@ -420,7 +420,7 @@ static const PDLog2<const char *, const char*> CL_SPROUT_SESS_CONT_AS_COMM_FAILU
   LOG_ERR,
   "Sprout is currently unable to successfully communicate with an Application Server that uses session continued default handling. The server's URI is %s. Failure reason: %s",
   "Communication is failing to an Application server",
-  "Probable minor degradation of service, loss of a supplemental service or increased call setup time. The precise impact will vary depending on the role of the Application Server in the deployment.",
+  "The service(s) provided by this Application Server will be unavailable until communication is restored. In addition, call setup time will likely be increased for all subscribers configured to use this Application Server.",
   "Investigate why communication to this Application Server is failing. It might be due to failure of the AS, misconfiguration of Initial Filter Criteria, or network / DNS problems"
 );
 

--- a/sprout-base.root/usr/share/clearwater/infrastructure/alarms/sprout_alarms.json
+++ b/sprout-base.root/usr/share/clearwater/infrastructure/alarms/sprout_alarms.json
@@ -248,7 +248,7 @@
                     "details": "Sprout cannot successfully communicate with one or more Application Servers that use session continued default handling. Check that all ASs are operational, they have network connectivity to Sprout, and iFCs are properly configured.",
                     "description": "Sprout: Communication error to session continued Application Server.",
                     "cause": "Sprout is unable to successfully communicate with at least one active Application Server that uses session continued iFC default handling.",
-                    "effect": "Probable minor degradation of service, loss of a supplemental service or increased call setup time. The precise impact will vary depending on the role of Application Servers in the deployment.",
+                    "effect": "The service(s) provided by this Application Server will be unavailable until communication is restored. In addition, call setup time will likely be increased for all subscribers configured to use this Application Server.",
                     "action": "Use ENT logs to identify which Application Servers cannot be successfully communicated with and investigate the cause. It might be due to failure of an AS, misconfiguration of Initial Filter Criteria, or network / DNS problems. Once the issue has been resolved this alarm will clear after approximately 5-10 minutes."
                 }
             ]

--- a/sprout-base.root/usr/share/clearwater/infrastructure/alarms/sprout_alarms.json
+++ b/sprout-base.root/usr/share/clearwater/infrastructure/alarms/sprout_alarms.json
@@ -248,7 +248,7 @@
                     "details": "Sprout cannot successfully communicate with one or more Application Servers that use session continued default handling. Check that all ASs are operational, they have network connectivity to Sprout, and iFCs are properly configured.",
                     "description": "Sprout: Communication error to session continued Application Server.",
                     "cause": "Sprout is unable to successfully communicate with at least one active Application Server that uses session continued iFC default handling.",
-                    "effect": "Probable minor degradation of service, or loss of a supplemental service. The precise impact will vary depending on the role of Application Servers in the deployment.",
+                    "effect": "Probable minor degradation of service, loss of a supplemental service or increased call setup time. The precise impact will vary depending on the role of Application Servers in the deployment.",
                     "action": "Use ENT logs to identify which Application Servers cannot be successfully communicated with and investigate the cause. It might be due to failure of an AS, misconfiguration of Initial Filter Criteria, or network / DNS problems. Once the issue has been resolved this alarm will clear after approximately 5-10 minutes."
                 }
             ]


### PR DESCRIPTION
The alarm and PD log now warn that call setup time may also be increased if an
AS with session continued default handling is uncontactable.

Tested live, and verified that the correct text is seen