### PR TITLE
[Reviewer: Mat] Better logging for AS comm error alarms

### DIFF
--- a/src/as_communication_tracker.cpp
+++ b/src/as_communication_tracker.cpp
@@ -20,6 +20,11 @@ AsCommunicationTracker::AsCommunicationTracker(Alarm* alarm,
   _as_ok_log(as_ok_log)
 {
   pthread_mutex_init(&_lock, NULL);
+
+  // Clear the alarm on startup so we don't get alarms hanging over from a
+  // previous run. If an AS is actually in error, we'll alarm as soon as we
+  // detect a failure.
+  _alarm->clear();
 }
 
 

--- a/src/as_communication_tracker.cpp
+++ b/src/as_communication_tracker.cpp
@@ -101,6 +101,9 @@ void AsCommunicationTracker::check_for_healthy_app_servers()
       std::map<std::string, int>::iterator curr_as = _as_failures.begin();
       std::map<std::string, int>::iterator next_as;
 
+      // We build this string for logging which ASs are in failure.
+      std::string failed_as_string;
+
       while (curr_as != _as_failures.end())
       {
         next_as = std::next(curr_as);
@@ -113,6 +116,12 @@ void AsCommunicationTracker::check_for_healthy_app_servers()
         }
         else
         {
+          if (failed_as_string != "")
+          {
+            failed_as_string += ", ";
+          }
+
+          failed_as_string += curr_as->first;
           curr_as->second = 0;
         }
 
@@ -124,6 +133,12 @@ void AsCommunicationTracker::check_for_healthy_app_servers()
         TRC_DEBUG("All ASs OK - clear the alarm");
         // No ASs are currently failed. Clear the alarm.
         _alarm->clear();
+      }
+      else
+      {
+        TRC_WARNING("Not clearing the alarm as failures detected for the "
+                    "following ASs: %s. Next recheck will be in %ums.",
+                    failed_as_string.c_str(), NEXT_CHECK_INTERVAL_MS);
       }
     }
 

--- a/src/as_communication_tracker.cpp
+++ b/src/as_communication_tracker.cpp
@@ -24,7 +24,11 @@ AsCommunicationTracker::AsCommunicationTracker(Alarm* alarm,
   // Clear the alarm on startup so we don't get alarms hanging over from a
   // previous run. If an AS is actually in error, we'll alarm as soon as we
   // detect a failure.
-  _alarm->clear();
+  // Wrapped in if test as _alarm is NULL in UTs
+  if (_alarm)
+  {
+    _alarm->clear();
+  }
 }
 
 


### PR DESCRIPTION
This is a fix for https://github.com/Metaswitch/clearwater-issues/issues/2293

As per the issue, we think the behaviour here is sensible so we just want to make it more transparent. We already say that the alarm will take 5-10 minutes to clear (https://github.com/Metaswitch/sprout/blob/dev/sprout-base.root/usr/share/clearwater/infrastructure/alarms/sprout_alarms.json#L252), so this just adds a warning log whenever we check if the servers are healthy again and decide that they're not. We log the servers that aren't healthy, and when the next check will be.

We still don't clear the alarm on startup - we require at least 5 minutes to pass without errors. We could easily set the `_next_check_time` to 0 so that the very first successful communication with an AS triggers it to clear if you think we should be clearing it sooner.

Tested live and in UTs that the warning log generates the correct text:
```
14-07-2017 14:02:33.519 UTC Warning as_communication_tracker.cpp:135: Not clearing the alarm as failures detected for the  following ASs: sip:as.cwc.openstack.obu-enfield.test;transport=TCP. Next
recheck will be in 300000ms.
```