### PR TITLE
Include contact parameters on NOTIFY bodies

### DIFF
--- a/include/constants.h
+++ b/include/constants.h
@@ -132,11 +132,13 @@ const pj_str_t STR_REGISTRATION = pj_str((char*)"registration");
 const pj_str_t STR_CONTACT = pj_str((char*)"contact");
 const pj_str_t STR_URI = pj_str((char*)"uri");
 const pj_str_t STR_WILDCARD = pj_str((char*)"ere:wildcardedIdentity");
+const pj_str_t STR_UNKNOWN_PARAM = pj_str((char*)"unknown-param");
 
 /* XML node attribute constants */
 const pj_str_t STR_STATE = pj_str((char*)"state");
 const pj_str_t STR_AOR = pj_str((char*)"aor");
 const pj_str_t STR_ID = pj_str((char*)"id");
+const pj_str_t STR_NAME = pj_str((char*)"name");
 
 /* XML node registration STATE attribute enum constants. */
 const pj_str_t STR_INIT = pj_str((char*)"init");

--- a/src/notify_utils.cpp
+++ b/src/notify_utils.cpp
@@ -240,8 +240,19 @@ pj_xml_node* notify_create_reg_state_xml(
                  &gruu,
                  Utils::xml_escape((*bni)->_b->pub_gruu_str(pool)).c_str());
 
-      // Add all 'unknown parameters' from the contact header into the element
-      // as <unknown-param> elements.
+      // Add all 'unknown parameters' from the contact header into the contact
+      // element as <unknown-param> elements. For example, a contact header that
+      // looks like this:
+      //
+      //     Contact: <sip:alice@example.com;p1=v1>;expires=3600;p2;p3=v3
+      //
+      // Would result in the following unknown param elements being added.
+      //
+      //     <unknown-param name="p2" />
+      //     <unknown-param name="p3">v3<unknown-param>
+      //
+      // Note that p1 is not included (as it's a URI parameter) and expires is
+      // not included (as it is defined in RFC 3261 so is a 'known' parameter).
       for (const std::pair<std::string, std::string>& param: (*bni)->_b->_params)
       {
         // RFC 3680 defines unknown parameters as any parameter not defined in

--- a/src/notify_utils.cpp
+++ b/src/notify_utils.cpp
@@ -240,6 +240,29 @@ pj_xml_node* notify_create_reg_state_xml(
                  &gruu,
                  Utils::xml_escape((*bni)->_b->pub_gruu_str(pool)).c_str());
 
+      // Add all 'unknown parameters' from the contact header into the element
+      // as <unknown-param> elements.
+      for (const std::pair<std::string, std::string>& param: (*bni)->_b->_params)
+      {
+        // RFC 3680 defines unknown parameters as any parameter not defined in
+        // RFC 3261. RFC 3261 defines 'q' and 'expires' so don't add these.
+        if ((param.first != "q") && (param.first != "expires"))
+        {
+          // Add the parameter value as the element content, and the parameter
+          // name as the 'name' attribute.
+          pj_xml_node* unknown_param_node = pj_xml_node_new(pool, &STR_UNKNOWN_PARAM);
+          std::string escaped_value = Utils::xml_check_escape(param.second);
+          pj_strdup2(pool, &unknown_param_node->content, escaped_value.c_str());
+
+          pj_str_t param_name;
+          pj_strdup2(pool, &param_name, param.first.c_str());
+          pj_xml_attr* name_attr = pj_xml_attr_new(pool, &STR_NAME, &param_name);
+          pj_xml_add_attr(unknown_param_node, name_attr);
+
+          pj_xml_add_node(contact_node, unknown_param_node);
+        }
+      }
+
       if (gruu.slen != 0)
       {
         TRC_DEBUG("Create pub-gruu node");


### PR DESCRIPTION
(Section 5.1 of RFC3680)[https://tools.ietf.org/html/rfc3680#section-5.1] states that parameters from the contact header of a binding should be included in the `unknown-param` elements in the reg state NOTIFY. This PR makes that the case. 

Tested in UT, and also live (by @johadalin).