### PR TITLE
[Reviewer: Seb] Ignore libc double free during test exit

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -297,6 +297,9 @@ mangelwurzel-as.so_LDFLAGS := ${PLUGIN_COMMON_LDFLAGS}
 
 VPATH = ../modules/cpp-common/src ../modules/cpp-common/test_utils ../modules/app-servers/test ../modules/gemini/src ../modules/gemini/src/ut ../modules/memento-as/src ../modules/memento-as/src/ut ../modules/memento-as/modules/memento-common/src mangelwurzel mangelwurzel/ut ut
 
+# Use valgrind suppression file for UT
+sprout_test_VALGRIND_ARGS := --suppressions=ut/sprout_test.supp
+
 include ../build-infra/cpp.mk
 
 # Special extra objects for sprout_test

--- a/src/ut/sprout_test.supp
+++ b/src/ut/sprout_test.supp
@@ -1,0 +1,10 @@
+{
+   "Ignore libc double free during exit"
+   Memcheck:Free
+   fun:free
+   fun:__libc_freeres
+   fun:_vgnU_freeres
+   fun:__run_exit_handlers
+   fun:exit
+   fun:(below main)
+}


### PR DESCRIPTION
Seb,

This adds a valgrind suppression (in the same fashion as we have for Homestead) for a valgrind warning we've seen on certain machines.

We don't have the exact scenario for this, but I'm happy that it's fairly safe to suppress it because:

- We only see it during UT
- It always happens when the UTs are exiting rather than during execution

Short term plan is to suppress it and keep investigating.