### PR TITLE
[Reviewer: AJH] Move aliases into sproutlet class

### DIFF
--- a/include/authenticationsproutlet.h
+++ b/include/authenticationsproutlet.h
@@ -114,8 +114,6 @@ public:
                         pj_pool_t* pool,
                         SAS::TrailId trail) override;
 
-  const std::list<std::string> aliases() const override;
-
 private:
   bool needs_authentication(pjsip_msg* req,
                             SAS::TrailId trail);
@@ -209,9 +207,6 @@ private:
   // The next service to route requests onto if the sproutlet does not handle them
   // itself.
   std::string _next_hop_service;
-
-  // Aliases that this sproutlet registers for.
-  const std::list<std::string> _aliases;
 };
 
 

--- a/include/registrarsproutlet.h
+++ b/include/registrarsproutlet.h
@@ -60,8 +60,6 @@ public:
                         pj_pool_t* pool,
                         SAS::TrailId trail) override;
 
-  const std::list<std::string> aliases() const override;
-
   int expiry_for_binding(pjsip_contact_hdr* contact,
                          pjsip_expires_hdr* expires);
 
@@ -95,9 +93,6 @@ private:
   // The next service to route requests onto if the sproutlet does not handle
   // them itself.
   std::string _next_hop_service;
-
-  // Aliases that this sproutlet registers for.
-  const std::list<std::string> _aliases;
 };
 
 

--- a/include/sproutlet.h
+++ b/include/sproutlet.h
@@ -718,7 +718,7 @@ public:
 
   /// Returns the aliases of this service.
   virtual const std::list<std::string> aliases() const
-    { return std::list<std::string>(); }
+    { return _aliases; }
 
 protected:
   /// Constructor.
@@ -726,6 +726,7 @@ protected:
             int port,
             const std::string& uri,
             const std::string& service_host="",
+            const std::list<std::string> aliases={},
             SNMP::SuccessFailCountByRequestTypeTable* incoming_sip_transactions_tbl = NULL,
             SNMP::SuccessFailCountByRequestTypeTable* outgoing_sip_transactions_tbl = NULL) :
     _incoming_sip_transactions_tbl(incoming_sip_transactions_tbl),
@@ -733,7 +734,8 @@ protected:
     _service_name(service_name),
     _port(port),
     _uri(uri),
-    _service_host(service_host)
+    _service_host(service_host),
+    _aliases(aliases)
   {
   }
 
@@ -749,6 +751,9 @@ private:
 
   /// The host name of this service.
   const std::string _service_host;
+
+  /// The aliases for this service
+  const std::list<std::string> _aliases;
 };
 
 #endif

--- a/src/authenticationsproutlet.cpp
+++ b/src/authenticationsproutlet.cpp
@@ -59,7 +59,7 @@ AuthenticationSproutlet::AuthenticationSproutlet(const std::string& name,
                                                  SNMP::AuthenticationStatsTables* auth_stats_tbls,
                                                  bool nonce_count_supported_arg,
                                                  get_expiry_for_binding_fn get_expiry_for_binding_arg) :
-  Sproutlet(name, port, uri),
+  Sproutlet(name, port, uri, "", aliases),
   _aka_realm((realm_name != "") ?
     pj_strdup3(stack_data.pool, realm_name.c_str()) :
     stack_data.local_host),
@@ -73,8 +73,7 @@ AuthenticationSproutlet::AuthenticationSproutlet(const std::string& name,
   _nonce_count_supported(nonce_count_supported_arg),
   _get_expiry_for_binding(get_expiry_for_binding_arg),
   _non_register_auth_mode(non_register_auth_mode_param),
-  _next_hop_service(next_hop_service),
-  _aliases(aliases)
+  _next_hop_service(next_hop_service)
 {
 }
 
@@ -122,12 +121,6 @@ SproutletTsx* AuthenticationSproutlet::get_tsx(SproutletHelper* helper,
                                   base_uri,
                                   pool);
   return NULL;
-}
-
-
-const std::list<std::string> AuthenticationSproutlet::aliases() const
-{
-  return { _aliases };
 }
 
 // Determine whether this request should be challenged (and SAS log appropriately).

--- a/src/bgcfsproutlet.cpp
+++ b/src/bgcfsproutlet.cpp
@@ -26,7 +26,7 @@ BGCFSproutlet::BGCFSproutlet(const std::string& bgcf_name,
                              SNMP::SuccessFailCountByRequestTypeTable* incoming_sip_transactions_tbl,
                              SNMP::SuccessFailCountByRequestTypeTable* outgoing_sip_transactions_tbl,
                              bool override_npdi) :
-  Sproutlet(bgcf_name, port, uri, "", incoming_sip_transactions_tbl, outgoing_sip_transactions_tbl),
+  Sproutlet(bgcf_name, port, uri, "", {}, incoming_sip_transactions_tbl, outgoing_sip_transactions_tbl),
   _bgcf_service(bgcf_service),
   _enum_service(enum_service),
   _acr_factory(acr_factory),

--- a/src/icscfsproutlet.cpp
+++ b/src/icscfsproutlet.cpp
@@ -45,7 +45,7 @@ ICSCFSproutlet::ICSCFSproutlet(const std::string& icscf_name,
                                SNMP::SuccessFailCountByRequestTypeTable* incoming_sip_transactions_tbl,
                                SNMP::SuccessFailCountByRequestTypeTable* outgoing_sip_transactions_tbl,
                                bool override_npdi) :
-  Sproutlet(icscf_name, port, uri, "", incoming_sip_transactions_tbl, outgoing_sip_transactions_tbl),
+  Sproutlet(icscf_name, port, uri, "", {}, incoming_sip_transactions_tbl, outgoing_sip_transactions_tbl),
   _bgcf_uri(NULL),
   _hss(hss),
   _scscf_selector(scscf_selector),

--- a/src/registrarsproutlet.cpp
+++ b/src/registrarsproutlet.cpp
@@ -60,7 +60,7 @@ RegistrarSproutlet::RegistrarSproutlet(const std::string& name,
                                        SNMP::RegistrationStatsTables* third_party_reg_stats_tbls,
                                        FIFCService* fifc_service,
                                        IFCConfiguration ifc_configuration) :
-  Sproutlet(name, port, uri),
+  Sproutlet(name, port, uri, "", aliases),
   _sdm(reg_sdm),
   _remote_sdms(reg_remote_sdms),
   _hss(hss_connection),
@@ -71,8 +71,7 @@ RegistrarSproutlet::RegistrarSproutlet(const std::string& name,
   _third_party_reg_stats_tbls(third_party_reg_stats_tbls),
   _fifc_service(fifc_service),
   _ifc_configuration(ifc_configuration),
-  _next_hop_service(next_hop_service),
-  _aliases(aliases)
+  _next_hop_service(next_hop_service)
 {
 }
 
@@ -149,11 +148,6 @@ SproutletTsx* RegistrarSproutlet::get_tsx(SproutletHelper* helper,
                                   base_uri,
                                   pool);
   return NULL;
-}
-
-const std::list<std::string> RegistrarSproutlet::aliases() const
-{
-  return { _aliases };
 }
 
 RegistrarSproutletTsx::RegistrarSproutletTsx(RegistrarSproutlet* registrar,

--- a/src/scscfsproutlet.cpp
+++ b/src/scscfsproutlet.cpp
@@ -54,7 +54,7 @@ SCSCFSproutlet::SCSCFSproutlet(const std::string& name,
                                int session_terminated_timeout_ms,
                                AsCommunicationTracker* sess_term_as_tracker,
                                AsCommunicationTracker* sess_cont_as_tracker) :
-  Sproutlet(name, port, uri, "", incoming_sip_transactions_tbl, outgoing_sip_transactions_tbl),
+  Sproutlet(name, port, uri, "", {}, incoming_sip_transactions_tbl, outgoing_sip_transactions_tbl),
   _scscf_name(scscf_name),
   _scscf_cluster_uri(NULL),
   _scscf_node_uri(NULL),

--- a/src/ut/sproutletproxy_test.cpp
+++ b/src/ut/sproutletproxy_test.cpp
@@ -42,28 +42,14 @@ public:
                 std::string alias = "",
                 SNMP::FakeSuccessFailCountByRequestTypeTable* fake_inc_tbl = NULL,
                 SNMP::FakeSuccessFailCountByRequestTypeTable* fake_out_tbl = NULL) :
-    Sproutlet(service_name, port, uri, service_host, fake_inc_tbl, fake_out_tbl)
+    Sproutlet(service_name, port, uri, service_host, { alias }, fake_inc_tbl, fake_out_tbl)
   {
-    // Only one sproutlet loaded can own each alias.
-    if (alias != "")
-    {
-      _aliases.push_back(alias);
-    }
   }
 
   SproutletTsx* get_tsx(SproutletHelper* helper, const std::string& alias, pjsip_msg* req, pjsip_sip_uri*& next_hop, pj_pool_t* pool, SAS::TrailId trail)
   {
     return (SproutletTsx*)new T(this);
   }
-
-  const std::list<std::string> aliases() const
-  {
-    return _aliases;
-  }
-
-private:
-
-  std::list<std::string> _aliases;
 };
 
 template <int S>


### PR DESCRIPTION
Currently, the Sproutlet class has a method `aliases()` that just returns an empty list. This doesn't make any sense because every time a Sproutlet wants to use an alias it needs to override the `aliases()` method, and create its own `_aliases` member variable. It would be better to pass aliases into the Sproutlet constructor because it would remove duplicated code, and make it much easier to add an alias to an existing Sproutlet.