### PR TITLE
[Reviewer: Seb] Move duplicated code to cpp-common

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1454,42 +1454,6 @@ SIFCService* sifc_service = NULL;
 FIFCService* fifc_service = NULL;
 MMFService* mmf_service = NULL;
 
-bool parse_multi_site_stores_arg(const std::vector<std::string>& stores_arg,
-                                 const std::string& local_site_name,
-                                 const char* store_name,
-                                 std::string& store_location,
-                                 std::vector<std::string>& remote_stores_locations)
-{
-  if (!stores_arg.empty())
-  {
-    if (!Utils::parse_stores_arg(stores_arg,
-                                 local_site_name,
-                                 store_location,
-                                 remote_stores_locations))
-    {
-      TRC_ERROR("Invalid format of %s program argument", store_name);
-      return false;
-    }
-
-    if (store_location == "")
-    {
-      // If we've failed to find a local site registration store then Sprout has
-      // been misconfigured.
-      TRC_ERROR("No local site %s specified", store_name);
-      return false;
-    }
-    else
-    {
-      TRC_INFO("Using memcached %s", store_name);
-      TRC_INFO("  Primary store: %s", store_location.c_str());
-      std::string remote_stores_str = boost::algorithm::join(remote_stores_locations, ", ");
-      TRC_INFO("  Backup store(s): %s", remote_stores_str.c_str());
-    }
-  }
-
-  return true;
-}
-
 /*
  * main()
  */
@@ -1746,11 +1710,11 @@ int main(int argc, char* argv[])
   std::string registration_store_location;
   std::vector<std::string> remote_registration_stores_locations;
 
-  if (!parse_multi_site_stores_arg(opt.registration_stores,
-                                   opt.local_site_name,
-                                   "registration-store",
-                                   registration_store_location,
-                                   remote_registration_stores_locations))
+  if (!Utils::parse_multi_site_stores_arg(opt.registration_stores,
+                                          opt.local_site_name,
+                                          "registration-store",
+                                          registration_store_location,
+                                          remote_registration_stores_locations))
   {
     return 1;
   }
@@ -1770,11 +1734,11 @@ int main(int argc, char* argv[])
   else
   {
     TRC_DEBUG("Parse IMPI store locations argument");
-    if (!parse_multi_site_stores_arg(opt.impi_stores,
-                                     opt.local_site_name,
-                                     "impi-store",
-                                     impi_store_location,
-                                     remote_impi_stores_locations))
+    if (!Utils::parse_multi_site_stores_arg(opt.impi_stores,
+                                            opt.local_site_name,
+                                            "impi-store",
+                                            impi_store_location,
+                                            remote_impi_stores_locations))
     {
       return 1;
     }


### PR DESCRIPTION
This removes the code from Sprout that's moved to cpp-common under Metaswitch/cpp-common#662