### PR TITLE
[Reviewer: Ying] Improve the icscfsproutlet coverage to 100%

### DIFF
--- a/include/icscfsproutlet.h
+++ b/include/icscfsproutlet.h
@@ -184,7 +184,6 @@ public:
   virtual void on_tx_request(pjsip_msg* req, int fork_id) override;
   virtual void on_rx_response(pjsip_msg* rsp, int fork_id) override;
   virtual void on_tx_response(pjsip_msg* rsp) override;
-  virtual void on_rx_cancel(int status_code, pjsip_msg* req) override;
 
 private:
   ICSCFSproutlet* _icscf;

--- a/src/icscfsproutlet.cpp
+++ b/src/icscfsproutlet.cpp
@@ -76,11 +76,13 @@ bool ICSCFSproutlet::init()
   // not continually converting from a string.
   _bgcf_uri = PJUtils::uri_from_string(_bgcf_uri_str, stack_data.pool, false);
 
+  // LCOV_EXCL_START - Don't test pjsip URI failures in the I-CSCF UTs
   if (_bgcf_uri == NULL)
   {
-    TRC_ERROR("Invalid BGCF URI %s", _bgcf_uri_str.c_str()); //LCOV_EXCL_LINE
+    TRC_ERROR("Invalid BGCF URI %s", _bgcf_uri_str.c_str());
     init_success = false;
   }
+  // LCOV_EXCL_STOP
 
   return init_success;
 }
@@ -284,13 +286,15 @@ void ICSCFSproutletRegTsx::on_rx_initial_request(pjsip_msg* req)
 }
 
 
+// LCOV_EXCL_START - Excluding from UTs as this is a scenario that shouldn't
+// happen
 void ICSCFSproutletRegTsx::on_rx_in_dialog_request(pjsip_msg* req)
 {
   // I-CSCF shouldn't need to handle in-dialog requests, but it happens, so
   // handle as an initial request.
   on_rx_initial_request(req);
 }
-
+// LCOV_EXCL_STOP
 
 void ICSCFSproutletRegTsx::on_tx_request(pjsip_msg* req, int fork_id)
 {
@@ -396,23 +400,6 @@ void ICSCFSproutletRegTsx::on_tx_response(pjsip_msg* rsp)
     // Pass the transmitted response to the ACR to update the accounting
     // information.
     _acr->tx_response(rsp);
-  }
-}
-
-
-void ICSCFSproutletRegTsx::on_rx_cancel(int status_code, pjsip_msg* cancel_req)
-{
-  if ((status_code == PJSIP_SC_REQUEST_TERMINATED) &&
-      (cancel_req != NULL))
-  {
-    // Create and send an ACR for the CANCEL request.
-    ACR* acr = _icscf->get_acr(trail());
-
-    // @TODO - timestamp from request.
-    acr->rx_request(cancel_req);
-    acr->send();
-
-    delete acr;
   }
 }
 
@@ -710,14 +697,15 @@ void ICSCFSproutletTsx::on_rx_initial_request(pjsip_msg* req)
   }
 }
 
-
+// LCOV_EXCL_START - Excluding from UTs as this is a scenario that shouldn't
+// happen
 void ICSCFSproutletTsx::on_rx_in_dialog_request(pjsip_msg* req)
 {
   // I-CSCF shouldn't need to handle in-dialog requests, but it happens, so
   // handle as an initial request.
   on_rx_initial_request(req);
 }
-
+// LCOV_EXCL_STOP
 
 void ICSCFSproutletTsx::on_tx_request(pjsip_msg* req, int fork_id)
 {
@@ -943,6 +931,8 @@ void ICSCFSproutletTsx::add_p_profile_header(const std::string& wildcard,
   }
   else
   {
+    // LCOV_EXCL_START - Don't test pjsip URI failures in the I-CSCF UTs
     TRC_ERROR("Invalid wildcard returned on LIA: %s", wildcard.c_str());
+    // LCOV_EXCL_STOP
   }
 }

--- a/src/ut/coverage-not-yet
+++ b/src/ut/coverage-not-yet
@@ -24,6 +24,5 @@ src/sipresolver.cpp
 src/acr.cpp
 src/sproutletappserver.cpp
 src/mmtel.cpp
-src/icscfsproutlet.cpp
 src/scscfsproutlet.cpp
 src/pluginloader.cpp

--- a/src/ut/icscfsproutlet_test.cpp
+++ b/src/ut/icscfsproutlet_test.cpp
@@ -2028,6 +2028,136 @@ TEST_F(ICSCFSproutletTest, RouteOrigInviteHSSRetry)
   delete tp;
 }
 
+TEST_F(ICSCFSproutletTest, RouteOrigInviteHSSRetryWithWildcard)
+{
+  pjsip_tx_data* tdata;
+
+  // Create a TCP connection to the I-CSCF listening port.
+  TransportFlow* tp = new TransportFlow(TransportFlow::Protocol::TCP,
+                                        ICSCF_PORT,
+                                        "1.2.3.4",
+                                        49152);
+
+  // Set up the HSS responses for the originating location query.
+  _hss_connection->set_result("/impu/sip%3A6505551000%40homedomain/location?originating=true",
+                              "{\"result-code\": 2001,"
+                              " \"scscf\": \"sip:scscf1.homedomain:5058;transport=TCP\"}");
+  _hss_connection->set_result("/impu/sip%3A6505551000%40homedomain/location?originating=true&auth-type=CAPAB",
+                              "{\"result-code\": 2001,"
+                              " \"wildcard-identity\": \"sip:650![0-9].*!@homedomain\","
+                              " \"mandatory-capabilities\": [654],"
+                              " \"optional-capabilities\": [567]}");
+
+  // Inject a INVITE request with orig in the Route header and a P-Served-User
+  // header.
+  Message msg1;
+  msg1._method = "INVITE";
+  msg1._via = tp->to_string(false);
+  msg1._extra = "Contact: sip:6505551000@" +
+                tp->to_string(true) +
+                ";ob;expires=300;+sip.ice;reg-id=1;+sip.instance=\"<urn:uuid:00000000-0000-0000-0000-b665231f1213>\"\r\n";
+  msg1._extra += "P-Served-User: <sip:6505551000@homedomain>";
+  msg1._route = "Route: <sip:homedomain;orig>";
+  inject_msg(msg1.get_request(), tp);
+
+  // Expecting a 100 Trying and an INVITE. Free the 100 Trying, then kill the
+  // TCP connection to the S-CSCF to force a retry.
+  ASSERT_EQ(2, txdata_count());
+  free_txdata();
+  tdata = current_txdata();
+  terminate_tcp_transport(tdata->tp_info.transport);
+  free_txdata();
+  cwtest_advance_time_ms(6000);
+  poll();
+
+  // The HSS is queried a second time for capabilities. This time S-CSCF
+  // scscf4.homedomain is selected, and the subscriber has a wildcard
+  // identity.
+  ASSERT_EQ(1, txdata_count());
+  tdata = current_txdata();
+  expect_target("TCP", "10.10.10.4", 5058, tdata);
+
+  // Check that a P-Profile-Key has been added that uses the wildcard
+  string ppk = get_headers(tdata->msg, "P-Profile-Key");
+  ASSERT_EQ("P-Profile-Key: <sip:650![0-9].*!@homedomain>", PJUtils::unescape_string_for_uri(ppk, stack_data.pool));
+
+  // Send a 200 OK response.
+  inject_msg(respond_to_current_txdata(200));
+
+  // Check the response is forwarded back to the source.
+  ASSERT_EQ(1, txdata_count());
+  tdata = current_txdata();
+  tp->expect_target(tdata);
+  RespMatcher r1(200);
+  r1.matches(tdata->msg);
+  free_txdata();
+
+  test_session_establishment_stats(0, 0, 0, 0);
+
+  _hss_connection->delete_result("/impu/sip%3A6505551000%40homedomain/location?originating=true");
+  _hss_connection->delete_result("/impu/sip%3A6505551000%40homedomain/location?originating=true&auth-type=CAPAB");
+
+  delete tp;
+}
+
+TEST_F(ICSCFSproutletTest, RouteOrigInviteHSSRetryOnceNoMatchingSCSCF)
+{
+  pjsip_tx_data* tdata;
+
+  // Create a TCP connection to the I-CSCF listening port.
+  TransportFlow* tp = new TransportFlow(TransportFlow::Protocol::TCP,
+                                        ICSCF_PORT,
+                                        "1.2.3.4",
+                                        49152);
+
+  // Set up the HSS responses for the originating location query.
+  _hss_connection->set_result("/impu/sip%3A6505551000%40homedomain/location?originating=true",
+                              "{\"result-code\": 2001,"
+                              " \"scscf\": \"sip:scscf1.homedomain:5058;transport=TCP\"}");
+  _hss_connection->set_result("/impu/sip%3A6505551000%40homedomain/location?originating=true&auth-type=CAPAB",
+                              "{\"result-code\": 2001,"
+                              " \"mandatory-capabilities\": [765, 654],"
+                              " \"optional-capabilities\": [567]}");
+
+  // Inject a INVITE request with orig in the Route header and a P-Served-User
+  // header.
+  Message msg1;
+  msg1._method = "INVITE";
+  msg1._via = tp->to_string(false);
+  msg1._extra = "Contact: sip:6505551000@" +
+                tp->to_string(true) +
+                ";ob;expires=300;+sip.ice;reg-id=1;+sip.instance=\"<urn:uuid:00000000-0000-0000-0000-b665231f1213>\"\r\n";
+  msg1._extra += "P-Served-User: <sip:6505551000@homedomain>";
+  msg1._route = "Route: <sip:homedomain;orig>";
+  inject_msg(msg1.get_request(), tp);
+
+  // Expecting a 100 Trying and an INVITE. Free the 100 Trying, then kill the
+  // TCP connection to the S-CSCF to force a retry.
+  ASSERT_EQ(2, txdata_count());
+  free_txdata();
+  tdata = current_txdata();
+  terminate_tcp_transport(tdata->tp_info.transport);
+  free_txdata();
+  cwtest_advance_time_ms(6000);
+  poll();
+
+  // Looking up the next S-CSCF in the HSS fails though as there are no S-CSCFs
+  // that match all the mandatory capabilites. Check the response - it should
+  // be a 503 (as that's what we got from the first S-CSCF we tried).
+  ASSERT_EQ(1, txdata_count());
+  tdata = current_txdata();
+  tp->expect_target(tdata);
+  RespMatcher r2(503);
+  r2.matches(tdata->msg);
+  free_txdata();
+
+  test_session_establishment_stats(0, 0, 0, 0);
+
+  _hss_connection->delete_result("/impu/sip%3A6505551000%40homedomain/location?originating=true");
+  _hss_connection->delete_result("/impu/sip%3A6505551000%40homedomain/location?originating=true&auth-type=CAPAB");
+
+  delete tp;
+}
 
 TEST_F(ICSCFSproutletTest, RouteOrigInviteHSSFail)
 {


### PR DESCRIPTION
This PR takes the icscfsproutlet code to 100% code coverage, and removes it from the coverage exclusion list.

I've added tests for wildcards and S-CSCF selection failure when retrying a non-register request.
I've removed the on_cancel method when processing REGISTER requests, as this won't ever be hit.
I've excluded from coverage branches that are only hit when pjsip is unable to construct a URI, or methods to deal with in dialog requests.

Tested by running make full_test