### PR TITLE
[Reviewer: HJS]  Change MMF URI's

### DIFF
--- a/src/scscfplugin.cpp
+++ b/src/scscfplugin.cpp
@@ -132,7 +132,7 @@ bool SCSCFPlugin::load(struct options& opt, std::list<Sproutlet*>& sproutlets)
     std::string mmf_cluster_uri = "sip:mmf." + opt.sprout_hostname;
 
     // As there is not currently a shared_config option for this, form the
-    // MMF node uri manually, specifying the port (currently the BGCF port)
+    // MMF node uri manually, directly specifying the mmf service
     std::string node_host(stack_data.local_host.ptr, stack_data.local_host.slen);
 
     if (Utils::parse_ip_address(node_host) == Utils::IPV6_ADDRESS)

--- a/src/scscfplugin.cpp
+++ b/src/scscfplugin.cpp
@@ -128,9 +128,8 @@ bool SCSCFPlugin::load(struct options& opt, std::list<Sproutlet*>& sproutlets)
       icscf_uri = opt.external_icscf_uri;
     }
 
-    // Create the MMF cluster uri.  As this is not a separate sproutlet, use
-    // the sprout hostname, and specify the port (currently the BGCF port)
-    std::string mmf_cluster_uri = "sip:" + opt.sprout_hostname + ":" + std::to_string(opt.port_bgcf);
+    // Create the MMF cluster uri
+    std::string mmf_cluster_uri = "sip:mmf." + opt.sprout_hostname;
 
     // As there is not currently a shared_config option for this, form the
     // MMF node uri manually, specifying the port (currently the BGCF port)
@@ -141,7 +140,7 @@ bool SCSCFPlugin::load(struct options& opt, std::list<Sproutlet*>& sproutlets)
       node_host = "[" + node_host + "]";
     }
 
-    std::string mmf_node_uri = "sip:" + node_host + ":" + std::to_string(opt.port_bgcf);
+    std::string mmf_node_uri = "sip:" + node_host + ";service=mmf";
 
     // Create Application Server communication trackers.
     _sess_term_as_alarm = new Alarm(alarm_manager,

--- a/src/scscfplugin.cpp
+++ b/src/scscfplugin.cpp
@@ -129,7 +129,7 @@ bool SCSCFPlugin::load(struct options& opt, std::list<Sproutlet*>& sproutlets)
     }
 
     // Create the MMF cluster uri
-    std::string mmf_cluster_uri = "sip:mmf." + opt.sprout_hostname;
+    std::string mmf_cluster_uri = "sip:" + opt.sprout_hostname + ";service=mmf";
 
     // As there is not currently a shared_config option for this, form the
     // MMF node uri manually, directly specifying the mmf service

--- a/src/scscfsproutlet.cpp
+++ b/src/scscfsproutlet.cpp
@@ -2507,12 +2507,6 @@ void SCSCFSproutletTsx::add_mmf_uri_parameters(pjsip_sip_uri* mmf_uri,
   // Use same transport as AS, in case it can only cope with one.
   mmf_uri->transport_param = as_transport_param;
 
-  TRC_DEBUG("Adding namespace parameter 'mmf'");
-  PJUtils::add_parameter_to_sip_uri(mmf_uri,
-                                    STR_NAMESPACE,
-                                    "mmf",
-                                    pool);
-
   TRC_DEBUG("Adding mmftarget parameter %s", mmftarget_param.c_str());
   PJUtils::add_parameter_to_sip_uri(mmf_uri,
                                     STR_MMFTARGET,

--- a/src/ut/scscf_test.cpp
+++ b/src/ut/scscf_test.cpp
@@ -10378,7 +10378,6 @@ TEST_F(SCSCFTest, MMFPreAs)
   pjsip_hdr* preas_hdr = (pjsip_hdr*)pjsip_msg_find_hdr_by_name(out, &STR_ROUTE, NULL);
   std::string preas_uri = PJUtils::get_header_value(preas_hdr);
   EXPECT_THAT(preas_uri, MatchesRegex(".*sip:11.22.33.44:5053.*"));
-  EXPECT_THAT(preas_uri, MatchesRegex(".*namespace=mmf.*"));
   EXPECT_THAT(preas_uri, MatchesRegex(".*mmfscope=pre-as.*"));
   EXPECT_THAT(preas_uri, MatchesRegex(".*mmftarget=PreASOnly.*"));
   pj_list_erase(preas_hdr);
@@ -10519,7 +10518,6 @@ TEST_F(SCSCFTest, MMFPostAs)
   pjsip_hdr* postas_hdr = (pjsip_hdr*)pjsip_msg_find_hdr_by_name(out, &STR_ROUTE, NULL);
   std::string postas_uri = PJUtils::get_header_value(postas_hdr);
   EXPECT_THAT(postas_uri, MatchesRegex(".*sip:44.33.22.11:5053.*"));
-  EXPECT_THAT(postas_uri, MatchesRegex(".*namespace=mmf.*"));
   EXPECT_THAT(postas_uri, MatchesRegex(".*mmfscope=post-as.*"));
   EXPECT_THAT(postas_uri, MatchesRegex(".*mmftarget=PostASOnly.*"));
   pj_list_erase(postas_hdr);
@@ -10649,7 +10647,6 @@ TEST_F(SCSCFTest, MMFPreAndPostAs)
   std::string preas_uri = PJUtils::get_header_value(preas_hdr);
   //
   EXPECT_THAT(preas_uri, MatchesRegex(".*sip:11.22.33.44:5053.*"));
-  EXPECT_THAT(preas_uri, MatchesRegex(".*namespace=mmf.*"));
   EXPECT_THAT(preas_uri, MatchesRegex(".*mmfscope=pre-as.*"));
   EXPECT_THAT(preas_uri, MatchesRegex(".*mmftarget=BothPreAndPost.*"));
   pj_list_erase(preas_hdr);
@@ -10664,7 +10661,6 @@ TEST_F(SCSCFTest, MMFPreAndPostAs)
   pjsip_hdr* postas_hdr = (pjsip_hdr*)pjsip_msg_find_hdr_by_name(out, &STR_ROUTE, NULL);
   std::string postas_uri = PJUtils::get_header_value(postas_hdr);
   EXPECT_THAT(postas_uri, MatchesRegex(".*sip:44.33.22.11:5053.*"));
-  EXPECT_THAT(postas_uri, MatchesRegex(".*namespace=mmf.*"));
   EXPECT_THAT(postas_uri, MatchesRegex(".*mmfscope=post-as.*"));
   EXPECT_THAT(postas_uri, MatchesRegex(".*mmftarget=BothPreAndPost.*"));
   pj_list_erase(postas_hdr);


### PR DESCRIPTION
Changes to the MMF URI's now that we no longer wish to route to MMF using the BGCF port

- For pre-as, use the mmf prefix
- For post-as, use the mmf service parameter (as we need to specify the exact node to route back to)

This also removes the now redundant `namespace` parameter.

NB:  This is likely a short-term fix, overridden by future changes following further high level thinking