### PR TITLE
Add route headers to sprout tests

### DIFF
--- a/src/basicproxy.cpp
+++ b/src/basicproxy.cpp
@@ -2056,7 +2056,7 @@ bool BasicProxy::UACTsx::retry_request()
     pjsip_transaction* retry_tsx;
 
     // In congestion cases, the old tdata might still be held by PjSIP's
-    // trasport layer waiting to be sent.  Therefore it's not safe to re-send
+    // transport layer waiting to be sent.  Therefore it's not safe to re-send
     // the same tdata, so we should clone it first.
     // LCOV_EXCL_START - No congestion in UTs
     if (_tdata->is_pending)

--- a/src/ut/bono_test.cpp
+++ b/src/ut/bono_test.cpp
@@ -797,8 +797,10 @@ Message StatefulEdgeProxyTest::doInviteEdge(string token)
   msg._method = "INVITE";
   msg._to = "6505551000";
   msg._from = "6505551234";
-  msg._extra = "Route: ";
-  msg._extra.append(token);
+//  msg._extra = "Route: ";
+//  msg._extra.append(token);
+  msg._route = "Route: ";
+  msg._route.append(token);
   msg._requri = "sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob";
   inject_msg(msg.get_request());
   return msg;

--- a/src/ut/bono_test.cpp
+++ b/src/ut/bono_test.cpp
@@ -797,8 +797,6 @@ Message StatefulEdgeProxyTest::doInviteEdge(string token)
   msg._method = "INVITE";
   msg._to = "6505551000";
   msg._from = "6505551234";
-//  msg._extra = "Route: ";
-//  msg._extra.append(token);
   msg._route = "Route: ";
   msg._route.append(token);
   msg._requri = "sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob";

--- a/src/ut/scscf_test.cpp
+++ b/src/ut/scscf_test.cpp
@@ -47,6 +47,21 @@ using testing::NiceMock;
 using testing::HasSubstr;
 using ::testing::Return;
 
+// TODO - make this class more consistent with the
+// TestingCommon::SubscriptionBuilder class (ie. have function "set_route",
+// instead of setting the route when initialising). This work should be done
+// when the parent class is reworked.
+//
+// Subclass which sets the correct Route header for the SCSCF tests.
+class SCSCFMessage : public TestingCommon::Message
+{
+public:
+  SCSCFMessage()
+  {
+    Message::_route = "Route: <sip:sprout.homedomain;service=scscf>";
+  };
+  ~SCSCFMessage() {};
+};
 
 /// ABC for fixtures for SCSCFTest and friends.
 class SCSCFTest : public SipTest
@@ -308,24 +323,24 @@ protected:
                      bool tpAset,
                      TransportFlow* tpB,
                      bool tpBset,
-                     TestingCommon::SCSCFMessage& msg,
+                     SCSCFMessage& msg,
                      string route,
                      bool expect_100,
                      bool expect_trusted_headers_on_requests,
                      bool expect_trusted_headers_on_responses,
                      bool expect_orig,
                      bool pcpi);
-  void doAsOriginated(TestingCommon::SCSCFMessage& msg, bool expect_orig);
+  void doAsOriginated(SCSCFMessage& msg, bool expect_orig);
   void doAsOriginated(const std::string& msg, bool expect_orig);
   void doFourAppServerFlow(std::string record_route_regex, bool app_servers_record_route=false);
-  void doSuccessfulFlow(TestingCommon::SCSCFMessage& msg,
+  void doSuccessfulFlow(SCSCFMessage& msg,
                         testing::Matcher<string> uri_matcher,
                         list<HeaderMatcher> headers,
                         bool include_ack_and_bye=true,
                         list<HeaderMatcher> rsp_hdrs = list<HeaderMatcher>());
-  void doFastFailureFlow(TestingCommon::SCSCFMessage& msg, int st_code);
-  void doSlowFailureFlow(TestingCommon::SCSCFMessage& msg, int st_code, std::string body = "", std::string reason = "");
-  void setupForkedFlow(TestingCommon::SCSCFMessage& msg);
+  void doFastFailureFlow(SCSCFMessage& msg, int st_code);
+  void doSlowFailureFlow(SCSCFMessage& msg, int st_code, std::string body = "", std::string reason = "");
+  void setupForkedFlow(SCSCFMessage& msg);
   list<string> doProxyCalculateTargets(int max_targets);
 };
 

--- a/src/ut/testingcommon.h
+++ b/src/ut/testingcommon.h
@@ -284,6 +284,16 @@ namespace TestingCommon
     std::string get_response();
   };
 
+  class SCSCFMessage : public Message
+  {
+  public:
+    SCSCFMessage()
+    {
+      Message::_route = "Route: <sip:sprout.homedomain;service=scscf>";
+    };
+    ~SCSCFMessage() {};
+  };
+
 }
 
 #endif

--- a/src/ut/testingcommon.h
+++ b/src/ut/testingcommon.h
@@ -175,7 +175,8 @@ namespace TestingCommon
   // TODO - Edit this class so that it is more consistent with the
   // SubscriptionBuilder class. (Instead of tests setting _method, etc.
   // directly, have functions setMethod(), etc. This means the interface will be
-  // more consistent.)
+  // more consistent.) When this work is done, the subclass SCSCFMessage (in
+  // scscf_test.cpp) should also be reworked.
   //
   // Class which can build request/response messages.
   //
@@ -282,17 +283,6 @@ namespace TestingCommon
     void convert_routeset(pjsip_msg*);
     std::string get_request();
     std::string get_response();
-  };
-
-  // Subclass which sets the correct Route header for the SCSCF tests.
-  class SCSCFMessage : public Message
-  {
-  public:
-    SCSCFMessage()
-    {
-      Message::_route = "Route: <sip:sprout.homedomain;service=scscf>";
-    };
-    ~SCSCFMessage() {};
   };
 
 }

--- a/src/ut/testingcommon.h
+++ b/src/ut/testingcommon.h
@@ -284,6 +284,7 @@ namespace TestingCommon
     std::string get_response();
   };
 
+  // Subclass which sets the correct Route header for the SCSCF tests.
   class SCSCFMessage : public Message
   {
   public:


### PR DESCRIPTION
I previously did some work reworking the sprout UTs - pull request #1890 

As part of this I accidentally cut out the code where the "Route" header was set in the scscf tests.
I've added this back in now.

I've also done minor tidying up around the codebase.

"make full_test" still passes.