### PR TITLE
[Reviewer: Adam] Impistore refactor

### DIFF
--- a/include/astaire_impistore.h
+++ b/include/astaire_impistore.h
@@ -1,0 +1,101 @@
+/**
+ * @file astaire_impistore.h  Definition of class for storing IMPIs in a
+ *                            Memcached-like store
+ *
+ * Copyright (C) Metaswitch Networks 2017
+ * If license terms are provided to you in a COPYING file in the root directory
+ * of the source code repository by which you are accessing this code, then
+ * the license outlined in that COPYING file applies to your use.
+ * Otherwise no rights are granted except for those provided to you by
+ * Metaswitch Networks in a separate written agreement.
+ */
+
+#ifndef ASTAIRE_IMPISTORE_H_
+#define ASTAIRE_IMPISTORE_H_
+
+#include "store.h"
+#include "impistore.h"
+#include <rapidjson/document.h>
+#include <rapidjson/writer.h>
+
+/// Class implementing store of IMPIs, including authentication challenges.
+/// This is a wrapper around an underlying Store class which implements a
+/// simple KV store API with atomic write and record expiry semantics.  The
+/// underlying store can be any implementation that implements the Store API.
+///
+/// We read and write a JSON object representing the full IMPI, including its
+/// authentication challenges, keyed solely off its private ID.
+class AstaireImpiStore : public ImpiStore
+{
+public:
+  /// @class AstaireImpiStore::Impi
+  ///
+  /// Represents an IMPI, below which AVs may exist
+  class Impi : public ImpiStore::Impi
+  {
+  public:
+    /// Constructor.
+    /// @param _impi         The private ID.
+    Impi(const std::string& _impi) : ImpiStore::Impi(_impi), _cas(0) {};
+
+    /// Destructor.
+    virtual ~Impi() {};
+
+  private:
+    /// Write to JSON writer.
+    virtual void write_json(rapidjson::Writer<rapidjson::StringBuffer>* writer) override;
+
+    /// Memcached CAS value.
+    uint64_t _cas;
+
+    // The IMPI store is a friend so it can read our CAS value.
+    friend class AstaireImpiStore;
+  };
+
+  /// Constructor.
+  /// @param data_store    A pointer to the underlying data store.
+  AstaireImpiStore(Store* data_store);
+
+  /// Destructor.
+  virtual ~AstaireImpiStore();
+
+  /// Store the specified IMPI in the store.
+  /// @returns Store::Status::OK on success, or an error code on failure.
+  /// @param impi      An Impi object representing the IMPI.  The caller
+  ///                  continues to own this object.
+  virtual Store::Status set_impi(ImpiStore::Impi* impi,
+                                 SAS::TrailId trail) override;
+
+  /// Retrieves the IMPI for the specified private user identity.
+  ///
+  /// @returns         A pointer to an Impi object describing the IMPI. The
+  ///                  caller owns the returned object. This method only returns
+  ///                  NULL if the underlying store failed - if no IMPI was
+  ///                  found it returns an empty object.
+  /// @param impi      The private user identity.
+  virtual ImpiStore::Impi* get_impi(const std::string& impi,
+                                    SAS::TrailId trail) override;
+
+  /// Delete all record of the IMPI.
+  ///
+  /// @param impi      An Impi object representing the IMPI.  The caller
+  ///                  continues to own this object.
+  /// @returns Store::Status::OK on success, or an error code on failure.
+  virtual Store::Status delete_impi(ImpiStore::Impi* impi,
+                                    SAS::TrailId trail) override;
+
+  /// Deserialization from JSON.
+  static AstaireImpiStore::Impi* from_json(const std::string& impi, const std::string& json);
+
+  /// Deserialization from JSON.
+  static AstaireImpiStore::Impi* from_json(const std::string& impi, rapidjson::Value* json);
+
+private:
+  /// Identifier for IMPI table.
+  static const std::string TABLE_IMPI;
+
+  /// The underlying data store.
+  Store* _data_store;
+};
+
+#endif

--- a/include/impistore.h
+++ b/include/impistore.h
@@ -135,6 +135,13 @@ public:
       _scscf_uri = uri;
     }
 
+    /// Returns whether this AuthChallenge has been updated since reading it
+    /// from the store.
+    bool is_updated()
+    {
+      return _updated;
+    }
+
   private:
     /// Constructor.
     /// @param _type         Type of authentication challenge.

--- a/include/impistore.h
+++ b/include/impistore.h
@@ -60,8 +60,7 @@ public:
       nonce_count(INITIAL_NONCE_COUNT),
       expires(_expires),
       correlator(),
-      scscf_uri(),
-      _cas(0) {};
+      scscf_uri() {};
 
     /// Destructor must be virtual as we're going to extend this class.
     virtual ~AuthChallenge() {};
@@ -96,17 +95,13 @@ public:
       nonce_count(0),
       expires(0),
       correlator(),
-      scscf_uri(),
-      _cas(0) {};
+      scscf_uri() {};
 
     /// Write to JSON writer (IMPI format).
     virtual void write_json(rapidjson::Writer<rapidjson::StringBuffer>* writer);
 
     /// Deserialization from JSON (IMPI format).
     static ImpiStore::AuthChallenge* from_json(rapidjson::Value* json);
-
-    /// Memcached CAS value.
-    uint64_t _cas;
 
     // The IMPI store is a friend so it can call our JSON serialization
     // functions and read our CAS value.

--- a/src/Makefile
+++ b/src/Makefile
@@ -139,7 +139,7 @@ sprout_test_SOURCES := ${SPROUT_COMMON_SOURCES} \
                        xdmconnection_test.cpp \
                        enumservice_test.cpp \
                        subscriber_data_manager_test.cpp \
-                       impistore_test.cpp \
+                       astaire_impistore_test.cpp \
                        registrar_test.cpp \
                        bono_test.cpp \
                        bgcfservice_test.cpp \

--- a/src/Makefile
+++ b/src/Makefile
@@ -29,6 +29,7 @@ SPROUT_COMMON_SOURCES := logger.cpp \
                          memcachedstoreview.cpp \
                          memcached_config.cpp \
                          impistore.cpp \
+                         astaire_impistore.cpp \
                          subscriber_data_manager.cpp \
                          xdmconnection.cpp \
                          simservs.cpp \

--- a/src/astaire_impistore.cpp
+++ b/src/astaire_impistore.cpp
@@ -54,7 +54,7 @@ void AstaireImpiStore::Impi::write_json(rapidjson::Writer<rapidjson::StringBuffe
          it != auth_challenges.end();
          it++)
     {
-      if ((*it)->expires > now)
+      if ((*it)->get_expires() > now)
       {
         writer->StartObject();
         {

--- a/src/astaire_impistore.cpp
+++ b/src/astaire_impistore.cpp
@@ -1,0 +1,228 @@
+/**
+ * @file astaire_impistore.cpp Implementation of class for storing IMPIs in a
+ *                             Memcached-like store
+ *
+ * Copyright (C) Metaswitch Networks 2017
+ * If license terms are provided to you in a COPYING file in the root directory
+ * of the source code repository by which you are accessing this code, then
+ * the license outlined in that COPYING file applies to your use.
+ * Otherwise no rights are granted except for those provided to you by
+ * Metaswitch Networks in a separate written agreement.
+ */
+
+#include <map>
+#include <pthread.h>
+
+#include "log.h"
+#include "store.h"
+#include "astaire_impistore.h"
+#include "sas.h"
+#include "sproutsasevent.h"
+#include <rapidjson/writer.h>
+#include <rapidjson/stringbuffer.h>
+#include "rapidjson/error/en.h"
+#include "json_parse_utils.h"
+#include <algorithm>
+
+// Constant table names.
+const std::string AstaireImpiStore::TABLE_IMPI = "impi";
+
+// JSON field names and values.
+static const char* const JSON_TYPE = "type";
+static const char* const JSON_TYPE_DIGEST = "digest";
+static const char* const JSON_TYPE_AKA = "aka";
+static const char* const JSON_TYPE_ENUM[] = {JSON_TYPE_DIGEST, JSON_TYPE_AKA};
+static const char* const JSON_NONCE = "nonce";
+static const char* const JSON_NONCE_COUNT = "nc";
+static const char* const JSON_EXPIRES = "expires";
+static const char* const JSON_CORRELATOR = "correlator";
+static const char* const JSON_REALM = "realm";
+static const char* const JSON_QOP = "qop";
+static const char* const JSON_HA1 = "ha1";
+static const char* const JSON_RESPONSE = "response";
+static const char* const JSON_AUTH_CHALLENGES = "authChallenges";
+static const char* const JSON_SCSCF_URI = "scscf-uri";
+
+void AstaireImpiStore::Impi::write_json(rapidjson::Writer<rapidjson::StringBuffer>* writer)
+{
+  // Write a JSON array, and then write each of the AuthChallenges into it.
+  int now = time(NULL);
+  writer->String(JSON_AUTH_CHALLENGES);
+  writer->StartArray();
+  {
+    for (std::vector<ImpiStore::AuthChallenge*>::iterator it = auth_challenges.begin();
+         it != auth_challenges.end();
+         it++)
+    {
+      if ((*it)->expires > now)
+      {
+        writer->StartObject();
+        {
+          (*it)->write_json(writer);
+        }
+        writer->EndObject();
+      }
+    }
+  }
+  writer->EndArray();
+  // The private ID itself is part of the key, so isn't stored in the JSON itself.
+}
+
+AstaireImpiStore::Impi* AstaireImpiStore::from_json(const std::string& impi, const std::string& json)
+{
+  // Simply parse the string to JSON, and then call through to the
+  // deserialization function.
+  AstaireImpiStore::Impi* impi_obj = NULL;
+  rapidjson::Document* json_obj = json_from_string(json);
+  if (json_obj != NULL)
+  {
+    impi_obj = AstaireImpiStore::from_json(impi, json_obj);
+  }
+  delete json_obj;
+  return impi_obj;
+}
+
+AstaireImpiStore::Impi* AstaireImpiStore::from_json(const std::string& impi, rapidjson::Value* json)
+{
+  AstaireImpiStore::Impi* impi_obj = NULL;
+  if (json->IsObject())
+  {
+    // Construct an Impi, and then look for an "authChallenges" array.
+    impi_obj = new AstaireImpiStore::Impi(impi);
+    if ((json->HasMember(JSON_AUTH_CHALLENGES)) &&
+        ((*json)[JSON_AUTH_CHALLENGES].IsArray()))
+    {
+      // Spin through the array, trying to parse as AuthChallenges.
+      rapidjson::Value* array = &((*json)[JSON_AUTH_CHALLENGES]);
+      for (unsigned int ii = 0; ii < array->Size(); ii++)
+      {
+        ImpiStore::AuthChallenge* auth_challenge = ImpiStore::AuthChallenge::from_json(&((*array)[ii]));
+        if (auth_challenge != NULL)
+        {
+          // Got an AuthChallenge, so add it to our array and also add its
+          // nonce to the array of nonces we retrieved from the server (so that
+          // we can spot when the user deletes AuthChallenges).
+          impi_obj->auth_challenges.push_back(auth_challenge);
+        }
+      }
+    }
+  }
+  else
+  {
+    TRC_WARNING("JSON IMPI is not an object - dropping");
+  }
+  return impi_obj;
+}
+
+AstaireImpiStore::AstaireImpiStore(Store* data_store) :
+  _data_store(data_store)
+{
+}
+
+AstaireImpiStore::~AstaireImpiStore()
+{
+}
+
+Store::Status AstaireImpiStore::set_impi(ImpiStore::Impi* impi,
+                                         SAS::TrailId trail)
+{
+  AstaireImpiStore::Impi* astaire_impi = (AstaireImpiStore::Impi*)impi;
+  int now = time(NULL);
+
+  // First serialize the IMPI and set it in the store.
+  std::string data = astaire_impi->to_json();
+  TRC_DEBUG("Storing IMPI for %s\n%s", impi->impi.c_str(), data.c_str());
+  Store::Status status = _data_store->set_data(TABLE_IMPI,
+                                               astaire_impi->impi,
+                                               data,
+                                               astaire_impi->_cas,
+                                               astaire_impi->get_expires() - now,
+                                               trail);
+  if (status == Store::Status::OK)
+  {
+    SAS::Event event(trail, SASEvent::IMPISTORE_IMPI_SET_SUCCESS, 0);
+    event.add_var_param(astaire_impi->impi);
+    SAS::report_event(event);
+  }
+  else
+  {
+    // LCOV_EXCL_START
+    if (status != Store::Status::DATA_CONTENTION)
+    {
+      TRC_ERROR("Failed to write IMPI for private_id %s", astaire_impi->impi.c_str());
+    }
+
+    SAS::Event event(trail, SASEvent::IMPISTORE_IMPI_SET_FAILURE, 0);
+    event.add_var_param(astaire_impi->impi);
+    SAS::report_event(event);
+    // LCOV_EXCL_STOP
+  }
+
+  return status;
+}
+
+ImpiStore::Impi* AstaireImpiStore::get_impi(const std::string& impi,
+                                     SAS::TrailId trail)
+{
+  // Get the IMPI data from the store and deserialize it.
+  AstaireImpiStore::Impi* impi_obj = NULL;
+  std::string data;
+  uint64_t cas;
+  Store::Status status = _data_store->get_data(TABLE_IMPI, impi, data, cas, trail);
+  if (status == Store::Status::OK)
+  {
+    TRC_DEBUG("Retrieved IMPI for %s\n%s", impi.c_str(), data.c_str());
+    SAS::Event event(trail, SASEvent::IMPISTORE_IMPI_GET_SUCCESS, 0);
+    event.add_var_param(impi);
+    SAS::report_event(event);
+
+    impi_obj = AstaireImpiStore::from_json(impi, data);
+    if (impi_obj == NULL)
+    {
+      // IMPI was corrupt. Create a new one.
+      impi_obj = new Impi(impi);
+    }
+
+    // By this point we've got an IMPI.  Fill in the CAS.
+    impi_obj->_cas = cas;
+  }
+  else if (status == Store::Status::NOT_FOUND)
+  {
+    impi_obj = new Impi(impi);
+  }
+  else
+  {
+    SAS::Event event(trail, SASEvent::IMPISTORE_IMPI_GET_FAILURE, 0);
+    event.add_var_param(impi);
+    SAS::report_event(event);
+  }
+  return impi_obj;
+}
+
+Store::Status AstaireImpiStore::delete_impi(ImpiStore::Impi* impi,
+                                     SAS::TrailId trail)
+{
+  // First, delete the IMPI data from the store.
+  TRC_DEBUG("Deleting IMPI for %s", impi->impi.c_str());
+  Store::Status status = _data_store->delete_data(TABLE_IMPI,
+                                                  impi->impi,
+                                                  trail);
+  if (status == Store::Status::OK)
+  {
+    SAS::Event event(trail, SASEvent::IMPISTORE_IMPI_DELETE_SUCCESS, 0);
+    event.add_var_param(impi->impi);
+    SAS::report_event(event);
+  }
+  else
+  {
+    // LCOV_EXCL_START
+    TRC_ERROR("Failed to delete IMPI for private_id %s", impi->impi.c_str());
+    SAS::Event event(trail, SASEvent::IMPISTORE_IMPI_DELETE_FAILURE, 0);
+    event.add_var_param(impi->impi);
+    event.add_static_param(status);
+    SAS::report_event(event);
+    // LCOV_EXCL_STOP
+  }
+
+  return status;
+}

--- a/src/astaire_impistore.cpp
+++ b/src/astaire_impistore.cpp
@@ -28,20 +28,7 @@
 const std::string AstaireImpiStore::TABLE_IMPI = "impi";
 
 // JSON field names and values.
-static const char* const JSON_TYPE = "type";
-static const char* const JSON_TYPE_DIGEST = "digest";
-static const char* const JSON_TYPE_AKA = "aka";
-static const char* const JSON_TYPE_ENUM[] = {JSON_TYPE_DIGEST, JSON_TYPE_AKA};
-static const char* const JSON_NONCE = "nonce";
-static const char* const JSON_NONCE_COUNT = "nc";
-static const char* const JSON_EXPIRES = "expires";
-static const char* const JSON_CORRELATOR = "correlator";
-static const char* const JSON_REALM = "realm";
-static const char* const JSON_QOP = "qop";
-static const char* const JSON_HA1 = "ha1";
-static const char* const JSON_RESPONSE = "response";
 static const char* const JSON_AUTH_CHALLENGES = "authChallenges";
-static const char* const JSON_SCSCF_URI = "scscf-uri";
 
 void AstaireImpiStore::Impi::write_json(rapidjson::Writer<rapidjson::StringBuffer>* writer)
 {

--- a/src/authenticationsproutlet.cpp
+++ b/src/authenticationsproutlet.cpp
@@ -444,7 +444,7 @@ pj_status_t AuthenticationSproutletTsx::user_lookup(pj_pool_t *pool,
   {
     pj_cstr(&cred_info->scheme, "digest");
     pj_strdup(pool, &cred_info->username, acc_name);
-    if (auth_challenge->type == ImpiStore::AuthChallenge::Type::AKA)
+    if (auth_challenge->get_type() == ImpiStore::AuthChallenge::Type::AKA)
     {
       ImpiStore::AKAAuthChallenge* aka_challenge = (ImpiStore::AKAAuthChallenge*)auth_challenge;
       pjsip_param* auts_param = pjsip_param_find(&credentials->other_param,
@@ -458,7 +458,7 @@ pj_status_t AuthenticationSproutletTsx::user_lookup(pj_pool_t *pool,
       std::string xres = "";
       if (auts_param == NULL)
       {
-        xres = unhex(aka_challenge->response);
+        xres = unhex(aka_challenge->get_response());
       }
 
       cred_info->data_type = PJSIP_CRED_DATA_PLAIN_PASSWD;
@@ -469,15 +469,15 @@ pj_status_t AuthenticationSproutletTsx::user_lookup(pj_pool_t *pool,
       pj_strdup(pool, &cred_info->realm, realm);
       status = PJ_SUCCESS;
     }
-    else if (auth_challenge->type == ImpiStore::AuthChallenge::Type::DIGEST)
+    else if (auth_challenge->get_type() == ImpiStore::AuthChallenge::Type::DIGEST)
     {
       ImpiStore::DigestAuthChallenge* digest_challenge = (ImpiStore::DigestAuthChallenge*)auth_challenge;
 
-      if (pj_strcmp2(realm, digest_challenge->realm.c_str()) == 0)
+      if (pj_strcmp2(realm, digest_challenge->get_realm().c_str()) == 0)
       {
         // Digest authentication, so ha1 field is hashed password.
         cred_info->data_type = PJSIP_CRED_DATA_DIGEST;
-        pj_strdup2(pool, &cred_info->data, digest_challenge->ha1.c_str());
+        pj_strdup2(pool, &cred_info->data, digest_challenge->get_ha1().c_str());
         cred_info->realm = *realm;
         TRC_DEBUG("Found Digest HA1 = %.*s", cred_info->data.slen, cred_info->data.ptr);
         status = PJ_SUCCESS;
@@ -518,15 +518,15 @@ AuthenticationVector* AuthenticationSproutletTsx::get_av_from_store(const std::s
     ImpiStore::AuthChallenge* auth_challenge = impi_obj->get_auth_challenge(nonce);
 
     if ((auth_challenge != nullptr) &&
-        (auth_challenge->type == ImpiStore::AuthChallenge::Type::DIGEST))
+        (auth_challenge->get_type() == ImpiStore::AuthChallenge::Type::DIGEST))
     {
       ImpiStore::DigestAuthChallenge* digest_challenge =
         dynamic_cast<ImpiStore::DigestAuthChallenge*>(auth_challenge);
 
       DigestAv* digest_av = new DigestAv();
-      digest_av->qop = digest_challenge->qop;
-      digest_av->realm = digest_challenge->realm;
-      digest_av->ha1 = digest_challenge->ha1;
+      digest_av->qop = digest_challenge->get_qop();
+      digest_av->realm = digest_challenge->get_realm();
+      digest_av->ha1 = digest_challenge->get_ha1();
 
       av = digest_av;
     }
@@ -784,8 +784,9 @@ void AuthenticationSproutletTsx::create_challenge(pjsip_digest_credential* crede
 
     // Store the branch parameter in memcached for correlation purposes
     pjsip_via_hdr* via_hdr = (pjsip_via_hdr*)pjsip_msg_find_hdr(req, PJSIP_H_VIA, NULL);
-    auth_challenge->correlator =
-      (via_hdr != NULL) ? PJUtils::pj_str_to_string(&via_hdr->branch_param) : "";
+    auth_challenge->set_correlator((via_hdr != NULL) ?
+                                   PJUtils::pj_str_to_string(&via_hdr->branch_param) :
+                                   "");
 
     // Write the new authentication challenge to the IMPI store
     TRC_DEBUG("Write authentication challenge to IMPI store");
@@ -793,12 +794,12 @@ void AuthenticationSproutletTsx::create_challenge(pjsip_digest_credential* crede
 
     // Save off the nonce. We will need it to reclaim the auth challenge from
     // the IMPI at the end of the loop.
-    std::string nonce = auth_challenge->nonce;
+    std::string nonce = auth_challenge->get_nonce();
 
     // Set the site-specific server name for the S-CSCF that issued this
     // challenge. This is so that if the authentication timer pops in a remote
     // site, we can use the same server name on the SAR.
-    auth_challenge->scscf_uri = _scscf_uri;
+    auth_challenge->set_scscf_uri(_scscf_uri);
 
     // Write the challenge back to the store.
     status = _authentication->write_challenge(impi, auth_challenge, impi_obj, trail());
@@ -922,7 +923,7 @@ void AuthenticationSproutletTsx::on_rx_initial_request(pjsip_msg* req)
       {
         // Authorization header did not specify an algorithm, so check the challenge for
         // this information instead.
-        if ((auth_challenge != NULL) && (auth_challenge->type == ImpiStore::AuthChallenge::Type::AKA))
+        if ((auth_challenge != NULL) && (auth_challenge->get_type() == ImpiStore::AuthChallenge::Type::AKA))
         {
           auth_stats_table = _authentication->_auth_stats_tables->ims_aka_auth_tbl;
         }
@@ -944,7 +945,7 @@ void AuthenticationSproutletTsx::on_rx_initial_request(pjsip_msg* req)
     unsigned long nonce_count = pj_strtoul2(&credentials->nc, NULL, 16);
     nonce_count = (nonce_count == 0) ? 1 : nonce_count;
 
-    if ((auth_challenge != NULL) && (auth_challenge->nonce_count > 1))
+    if ((auth_challenge != NULL) && (auth_challenge->get_nonce_count() > 1))
     {
       // A nonce count > 1 is supplied. Check that it is acceptable. If it is
       // not, pretend that we didn't find the challenge to check against as
@@ -960,14 +961,14 @@ void AuthenticationSproutletTsx::on_rx_initial_request(pjsip_msg* req)
         status = PJSIP_EAUTHACCNOTFOUND;
         auth_challenge = NULL;
       }
-      else if (nonce_count < auth_challenge->nonce_count)
+      else if (nonce_count < auth_challenge->get_nonce_count())
       {
         // The nonce count is too low - this might be a replay attack.
         TRC_INFO("Nonce count supplied (%d) is lower than expected (%d) - ignore it",
-                 nonce_count, auth_challenge->nonce_count);
+                 nonce_count, auth_challenge->get_nonce_count());
         SAS::Event event(trail(), SASEvent::AUTHENTICATION_NC_TOO_LOW, 0);
         event.add_static_param(nonce_count);
-        event.add_static_param(auth_challenge->nonce_count);
+        event.add_static_param(auth_challenge->get_nonce_count());
         SAS::report_event(event);
 
         status = PJSIP_EAUTHACCNOTFOUND;
@@ -1012,7 +1013,7 @@ void AuthenticationSproutletTsx::on_rx_initial_request(pjsip_msg* req)
         // Increment the nonce count and set it back to the AV store, handling
         // contention.  We don't check for overflow - it will take ~2^32
         // authentications before it happens.
-        auth_challenge->nonce_count = nonce_count + 1;
+        auth_challenge->set_nonce_count(nonce_count + 1);
 
         // Work out when the challenge should expire. We keep it around if we
         // might need it later which is the case if either:
@@ -1027,14 +1028,14 @@ void AuthenticationSproutletTsx::on_rx_initial_request(pjsip_msg* req)
           if (_authentication->_nonce_count_supported)
           {
             TRC_DEBUG("Storing challenge because nonce counts are supported");
-            auth_challenge->expires = calculate_challenge_expiration_time(req);
+            auth_challenge->set_expires(calculate_challenge_expiration_time(req));
           }
-          else if ((auth_challenge->type == ImpiStore::AuthChallenge::DIGEST) &&
+          else if ((auth_challenge->get_type() == ImpiStore::AuthChallenge::DIGEST) &&
                    (_authentication->_non_register_auth_mode &
                        NonRegisterAuthentication::INITIAL_REQ_FROM_REG_DIGEST_ENDPOINT))
           {
             TRC_DEBUG("Storing challenge in order to challenge non-REGISTER requests");
-            auth_challenge->expires = calculate_challenge_expiration_time(req);
+            auth_challenge->set_expires(calculate_challenge_expiration_time(req));
           }
         }
 
@@ -1296,7 +1297,7 @@ Store::Status AuthenticationSproutlet::
                            SAS::TrailId trail)
 {
   Store::Status status;
-  const std::string nonce = auth_challenge->nonce;
+  const std::string nonce = auth_challenge->get_nonce();
   ImpiStore::Impi* current_impi_obj = impi_obj;
 
   do
@@ -1329,10 +1330,10 @@ Store::Status AuthenticationSproutlet::
       //
       // Regardless, we want to be defensive and update the existing challenge
       // (making sure the nonce count and expiry don't move backwards).
-      challenge->nonce_count = std::max(auth_challenge->nonce_count,
-                                        challenge->nonce_count);
-      challenge->expires = std::max(auth_challenge->expires,
-                                    challenge->expires);
+      challenge->set_nonce_count(std::max(auth_challenge->get_nonce_count(),
+                                          challenge->get_nonce_count()));
+      challenge->set_expires(std::max(auth_challenge->get_expires(),
+                                      challenge->get_expires()));
     }
     else
     {

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -613,7 +613,7 @@ HTTPCode AuthTimeoutTask::timeout_auth_challenge(std::string impu,
 
     // If authentication completed, we'll have incremented the nonce count.
     // If not, authentication has timed out.
-    if (auth_challenge->nonce_count == ImpiStore::AuthChallenge::INITIAL_NONCE_COUNT)
+    if (auth_challenge->get_nonce_count() == ImpiStore::AuthChallenge::INITIAL_NONCE_COUNT)
     {
       TRC_DEBUG("AV for %s:%s has timed out", impi.c_str(), nonce.c_str());
 
@@ -624,7 +624,7 @@ HTTPCode AuthTimeoutTask::timeout_auth_challenge(std::string impu,
       // If either of these operations fail, we return a 500 Internal
       // Server Error - this will trigger the timer service to try a different
       // Sprout, which may have better connectivity to Homestead or Memcached.
-      HTTPCode hss_query = _cfg->_hss->update_registration_state(impu, impi, HSSConnection::AUTH_TIMEOUT, auth_challenge->scscf_uri, trail());
+      HTTPCode hss_query = _cfg->_hss->update_registration_state(impu, impi, HSSConnection::AUTH_TIMEOUT, auth_challenge->get_scscf_uri(), trail());
 
       if (hss_query == HTTP_OK)
       {

--- a/src/impistore.cpp
+++ b/src/impistore.cpp
@@ -26,7 +26,7 @@
 /// Parses a string to a JSON document.
 /// @returns a JSON document or NULL.
 /// @param string    the string to parse.
-static rapidjson::Document* json_from_string(const std::string& string)
+rapidjson::Document* ImpiStore::json_from_string(const std::string& string)
 {
   rapidjson::Document* json = new rapidjson::Document;
   json->Parse<0>(string.c_str());
@@ -256,77 +256,6 @@ std::string ImpiStore::Impi::to_json()
   return buffer.GetString();
 }
 
-void ImpiStore::Impi::write_json(rapidjson::Writer<rapidjson::StringBuffer>* writer)
-{
-  // Write a JSON array, and then write each of the AuthChallenges into it.
-  int now = time(NULL);
-  writer->String(JSON_AUTH_CHALLENGES);
-  writer->StartArray();
-  {
-    for (std::vector<ImpiStore::AuthChallenge*>::iterator it = auth_challenges.begin();
-         it != auth_challenges.end();
-         it++)
-    {
-      if ((*it)->expires > now)
-      {
-        writer->StartObject();
-        {
-          (*it)->write_json(writer);
-        }
-        writer->EndObject();
-      }
-    }
-  }
-  writer->EndArray();
-  // The private ID itself is part of the key, so isn't stored in the JSON itself.
-}
-
-ImpiStore::Impi* ImpiStore::Impi::from_json(const std::string& impi, const std::string& json)
-{
-  // Simply parse the string to JSON, and then call through to the
-  // deserialization function.
-  ImpiStore::Impi* impi_obj = NULL;
-  rapidjson::Document* json_obj = json_from_string(json);
-  if (json_obj != NULL)
-  {
-    impi_obj = ImpiStore::Impi::from_json(impi, json_obj);
-  }
-  delete json_obj;
-  return impi_obj;
-}
-
-ImpiStore::Impi* ImpiStore::Impi::from_json(const std::string& impi, rapidjson::Value* json)
-{
-  ImpiStore::Impi* impi_obj = NULL;
-  if (json->IsObject())
-  {
-    // Construct an Impi, and then look for an "authChallenges" array.
-    impi_obj = new ImpiStore::Impi(impi);
-    if ((json->HasMember(JSON_AUTH_CHALLENGES)) &&
-        ((*json)[JSON_AUTH_CHALLENGES].IsArray()))
-    {
-      // Spin through the array, trying to parse as AuthChallenges.
-      rapidjson::Value* array = &((*json)[JSON_AUTH_CHALLENGES]);
-      for (unsigned int ii = 0; ii < array->Size(); ii++)
-      {
-        ImpiStore::AuthChallenge* auth_challenge = ImpiStore::AuthChallenge::from_json(&((*array)[ii]));
-        if (auth_challenge != NULL)
-        {
-          // Got an AuthChallenge, so add it to our array and also add its
-          // nonce to the array of nonces we retrieved from the server (so that
-          // we can spot when the user deletes AuthChallenges).
-          impi_obj->auth_challenges.push_back(auth_challenge);
-        }
-      }
-    }
-  }
-  else
-  {
-    TRC_WARNING("JSON IMPI is not an object - dropping");
-  }
-  return impi_obj;
-}
-
 int ImpiStore::Impi::get_expires()
 {
   // Spin through the AuthChallenges, finding the latest expires time.
@@ -340,116 +269,8 @@ int ImpiStore::Impi::get_expires()
   return expires;
 }
 
-ImpiStore::ImpiStore(Store* data_store) :
-  _data_store(data_store)
-{
-}
-
 ImpiStore::~ImpiStore()
 {
-}
-
-Store::Status ImpiStore::set_impi(Impi* impi,
-                                  SAS::TrailId trail)
-{
-  int now = time(NULL);
-
-  // First serialize the IMPI and set it in the store.
-  std::string data = impi->to_json();
-  TRC_DEBUG("Storing IMPI for %s\n%s", impi->impi.c_str(), data.c_str());
-  Store::Status status = _data_store->set_data(TABLE_IMPI,
-                                               impi->impi,
-                                               data,
-                                               impi->_cas,
-                                               impi->get_expires() - now,
-                                               trail);
-  if (status == Store::Status::OK)
-  {
-    SAS::Event event(trail, SASEvent::IMPISTORE_IMPI_SET_SUCCESS, 0);
-    event.add_var_param(impi->impi);
-    SAS::report_event(event);
-  }
-  else
-  {
-    // LCOV_EXCL_START
-    if (status != Store::Status::DATA_CONTENTION)
-    {
-      TRC_ERROR("Failed to write IMPI for private_id %s", impi->impi.c_str());
-    }
-
-    SAS::Event event(trail, SASEvent::IMPISTORE_IMPI_SET_FAILURE, 0);
-    event.add_var_param(impi->impi);
-    SAS::report_event(event);
-    // LCOV_EXCL_STOP
-  }
-
-  return status;
-}
-
-ImpiStore::Impi* ImpiStore::get_impi(const std::string& impi,
-                                     SAS::TrailId trail)
-{
-  // Get the IMPI data from the store and deserialize it.
-  ImpiStore::Impi* impi_obj = NULL;
-  std::string data;
-  uint64_t cas;
-  Store::Status status = _data_store->get_data(TABLE_IMPI, impi, data, cas, trail);
-  if (status == Store::Status::OK)
-  {
-    TRC_DEBUG("Retrieved IMPI for %s\n%s", impi.c_str(), data.c_str());
-    SAS::Event event(trail, SASEvent::IMPISTORE_IMPI_GET_SUCCESS, 0);
-    event.add_var_param(impi);
-    SAS::report_event(event);
-
-    impi_obj = ImpiStore::Impi::from_json(impi, data);
-    if (impi_obj == NULL)
-    {
-      // IMPI was corrupt. Create a new one.
-      impi_obj = new Impi(impi);
-    }
-
-    // By this point we've got an IMPI.  Fill in the CAS.
-    impi_obj->_cas = cas;
-  }
-  else if (status == Store::Status::NOT_FOUND)
-  {
-    impi_obj = new Impi(impi);
-  }
-  else
-  {
-    SAS::Event event(trail, SASEvent::IMPISTORE_IMPI_GET_FAILURE, 0);
-    event.add_var_param(impi);
-    SAS::report_event(event);
-  }
-  return impi_obj;
-}
-
-Store::Status ImpiStore::delete_impi(Impi* impi,
-                                     SAS::TrailId trail)
-{
-  // First, delete the IMPI data from the store.
-  TRC_DEBUG("Deleting IMPI for %s", impi->impi.c_str());
-  Store::Status status = _data_store->delete_data(TABLE_IMPI,
-                                                  impi->impi,
-                                                  trail);
-  if (status == Store::Status::OK)
-  {
-    SAS::Event event(trail, SASEvent::IMPISTORE_IMPI_DELETE_SUCCESS, 0);
-    event.add_var_param(impi->impi);
-    SAS::report_event(event);
-  }
-  else
-  {
-    // LCOV_EXCL_START
-    TRC_ERROR("Failed to delete IMPI for private_id %s", impi->impi.c_str());
-    SAS::Event event(trail, SASEvent::IMPISTORE_IMPI_DELETE_FAILURE, 0);
-    event.add_var_param(impi->impi);
-    event.add_static_param(status);
-    SAS::report_event(event);
-    // LCOV_EXCL_STOP
-  }
-
-  return status;
 }
 
 void correlate_trail_to_challenge(ImpiStore::AuthChallenge* auth_challenge,

--- a/src/impistore.cpp
+++ b/src/impistore.cpp
@@ -13,7 +13,6 @@
 #include <pthread.h>
 
 #include "log.h"
-#include "store.h"
 #include "impistore.h"
 #include "sas.h"
 #include "sproutsasevent.h"
@@ -57,7 +56,6 @@ static const char* const JSON_REALM = "realm";
 static const char* const JSON_QOP = "qop";
 static const char* const JSON_HA1 = "ha1";
 static const char* const JSON_RESPONSE = "response";
-static const char* const JSON_AUTH_CHALLENGES = "authChallenges";
 static const char* const JSON_SCSCF_URI = "scscf-uri";
 
 ImpiStore::AuthChallenge* ImpiStore::Impi::get_auth_challenge(const std::string& nonce)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -86,6 +86,7 @@ extern "C" {
 #include "ralf_processor.h"
 #include "sprout_alarmdefinition.h"
 #include "sproutlet_options.h"
+#include "astaire_impistore.h"
 
 enum OptionTypes
 {
@@ -2161,7 +2162,7 @@ int main(int argc, char* argv[])
                                                                       astaire_resolver,
                                                                       false,
                                                                       astaire_comm_monitor);
-    local_impi_store = new ImpiStore(local_impi_data_store);
+    local_impi_store = new AstaireImpiStore(local_impi_data_store);
 
     // Only set up remote IMPI stores if some have been configured, and we need
     // the IMPI store to be GR.
@@ -2180,7 +2181,7 @@ int main(int argc, char* argv[])
                                                                              true,
                                                                              remote_astaire_comm_monitor);
         remote_impi_data_stores.push_back(remote_data_store);
-        remote_impi_stores.push_back(new ImpiStore(remote_data_store));
+        remote_impi_stores.push_back(new AstaireImpiStore(remote_data_store));
       }
     }
   }
@@ -2189,7 +2190,7 @@ int main(int argc, char* argv[])
     // Use local store.
     TRC_STATUS("Using local store");
     local_impi_data_store = (Store*)new LocalStore();
-    local_impi_store = new ImpiStore(local_data_store);
+    local_impi_store = new AstaireImpiStore(local_data_store);
   }
 
   // Load the sproutlet plugins.

--- a/src/ut/astaire_impistore_test.cpp
+++ b/src/ut/astaire_impistore_test.cpp
@@ -52,7 +52,7 @@ ImpiStore::Impi* example_impi_digest()
 {
   ImpiStore::Impi* impi = new AstaireImpiStore::Impi(IMPI);
   ImpiStore::AuthChallenge* auth_challenge = new ImpiStore::DigestAuthChallenge(NONCE1, "example.com", "auth", "ha1", time(NULL) + 30);
-  auth_challenge->correlator = "correlator";
+  auth_challenge->_correlator = "correlator";
   impi->auth_challenges.push_back(auth_challenge);
   return impi;
 };
@@ -62,7 +62,7 @@ ImpiStore::Impi* example_impi_aka()
 {
   ImpiStore::Impi* impi = new AstaireImpiStore::Impi(IMPI);
   ImpiStore::AuthChallenge* auth_challenge = new ImpiStore::AKAAuthChallenge(NONCE1, "response", time(NULL) + 30);
-  auth_challenge->correlator = "correlator";
+  auth_challenge->_correlator = "correlator";
   impi->auth_challenges.push_back(auth_challenge);
   return impi;
 };
@@ -72,10 +72,10 @@ ImpiStore::Impi* example_impi_digest_aka()
 {
   ImpiStore::Impi* impi = new AstaireImpiStore::Impi(IMPI);
   ImpiStore::AuthChallenge* auth_challenge = new ImpiStore::DigestAuthChallenge(NONCE1, "example.com", "auth", "ha1", time(NULL) + 30);
-  auth_challenge->correlator = "correlator";
+  auth_challenge->_correlator = "correlator";
   impi->auth_challenges.push_back(auth_challenge);
   auth_challenge = new ImpiStore::AKAAuthChallenge(NONCE2, "response", time(NULL) + 30);
-  auth_challenge->correlator = "correlator";
+  auth_challenge->_correlator = "correlator";
   impi->auth_challenges.push_back(auth_challenge);
   return impi;
 };
@@ -92,29 +92,29 @@ void expect_impis_equal(ImpiStore::Impi* impi1, ImpiStore::Impi* impi2)
        it++)
   {
     ImpiStore::AuthChallenge* auth_challenge1 = *it;
-    ImpiStore::AuthChallenge* auth_challenge2 = impi2->get_auth_challenge(auth_challenge1->nonce);
+    ImpiStore::AuthChallenge* auth_challenge2 = impi2->get_auth_challenge(auth_challenge1->_nonce);
     EXPECT_TRUE(auth_challenge2 != NULL);
     if (auth_challenge2 != NULL)
     {
-      EXPECT_EQ(auth_challenge1->type, auth_challenge2->type);
-      EXPECT_EQ(auth_challenge1->nonce, auth_challenge2->nonce);
-      EXPECT_EQ(auth_challenge1->nonce_count, auth_challenge2->nonce_count);
+      EXPECT_EQ(auth_challenge1->_type, auth_challenge2->_type);
+      EXPECT_EQ(auth_challenge1->_nonce, auth_challenge2->_nonce);
+      EXPECT_EQ(auth_challenge1->_nonce_count, auth_challenge2->_nonce_count);
       // Don't check expires.
-      EXPECT_EQ(auth_challenge1->correlator, auth_challenge2->correlator);
+      EXPECT_EQ(auth_challenge1->_correlator, auth_challenge2->_correlator);
       // Don't check CAS.
-      if (auth_challenge1->type == ImpiStore::AuthChallenge::Type::DIGEST)
+      if (auth_challenge1->_type == ImpiStore::AuthChallenge::Type::DIGEST)
       {
         ImpiStore::DigestAuthChallenge* digest_challenge1 = (ImpiStore::DigestAuthChallenge*)auth_challenge1;
         ImpiStore::DigestAuthChallenge* digest_challenge2 = (ImpiStore::DigestAuthChallenge*)auth_challenge2;
-        EXPECT_EQ(digest_challenge1->realm, digest_challenge2->realm);
-        EXPECT_EQ(digest_challenge1->qop, digest_challenge2->qop);
-        EXPECT_EQ(digest_challenge1->ha1, digest_challenge2->ha1);
+        EXPECT_EQ(digest_challenge1->_realm, digest_challenge2->_realm);
+        EXPECT_EQ(digest_challenge1->_qop, digest_challenge2->_qop);
+        EXPECT_EQ(digest_challenge1->_ha1, digest_challenge2->_ha1);
       }
-      else if (auth_challenge1->type == ImpiStore::AuthChallenge::Type::AKA)
+      else if (auth_challenge1->_type == ImpiStore::AuthChallenge::Type::AKA)
       {
         ImpiStore::AKAAuthChallenge* aka_challenge1 = (ImpiStore::AKAAuthChallenge*)auth_challenge1;
         ImpiStore::AKAAuthChallenge* aka_challenge2 = (ImpiStore::AKAAuthChallenge*)auth_challenge2;
-        EXPECT_EQ(aka_challenge1->response, aka_challenge2->response);
+        EXPECT_EQ(aka_challenge1->_response, aka_challenge2->_response);
       }
     }
   }
@@ -123,7 +123,7 @@ void expect_impis_equal(ImpiStore::Impi* impi1, ImpiStore::Impi* impi2)
        it++)
   {
     ImpiStore::AuthChallenge* auth_challenge2 = *it;
-    ImpiStore::AuthChallenge* auth_challenge1 = impi1->get_auth_challenge(auth_challenge2->nonce);
+    ImpiStore::AuthChallenge* auth_challenge1 = impi1->get_auth_challenge(auth_challenge2->_nonce);
     EXPECT_TRUE(auth_challenge1 != NULL);
   }
 };
@@ -194,7 +194,7 @@ TEST_F(AstaireImpiStoreTest, ChallengeDigest)
   ImpiStore::Impi* impi = impi_store->get_impi(IMPI, 0L);
   ASSERT_TRUE(impi != NULL);
   ASSERT_EQ(1, impi->auth_challenges.size());
-  ASSERT_EQ(ImpiStore::AuthChallenge::Type::DIGEST, impi->auth_challenges[0]->type);
+  ASSERT_EQ(ImpiStore::AuthChallenge::Type::DIGEST, impi->auth_challenges[0]->_type);
   delete impi;
 }
 

--- a/src/ut/authentication_test.cpp
+++ b/src/ut/authentication_test.cpp
@@ -23,7 +23,7 @@ extern "C" {
 #include "stack.h"
 #include "analyticslogger.h"
 #include "localstore.h"
-#include "impistore.h"
+#include "astaire_impistore.h"
 #include "sproutletproxy.h"
 #include "hssconnection.h"
 #include "authenticationsproutlet.h"
@@ -57,9 +57,9 @@ public:
     SipTest::SetUpTestCase();
 
     _local_data_store = new LocalStore();
-    _impi_store = new ImpiStore(_local_data_store);
+    _impi_store = new AstaireImpiStore(_local_data_store);
     _remote_data_stores.push_back(new LocalStore());
-    _remote_impi_stores.push_back(new ImpiStore(_remote_data_stores[0]));
+    _remote_impi_stores.push_back(new AstaireImpiStore(_remote_data_stores[0]));
     _hss_connection = new FakeHSSConnection();
     _chronos_connection = new FakeChronosConnection();
     _analytics = new AnalyticsLogger();

--- a/src/ut/chronoshandlers_test.cpp
+++ b/src/ut/chronoshandlers_test.cpp
@@ -421,7 +421,7 @@ class ChronosAuthTimeoutTest : public AuthTimeoutTest
 TEST_F(ChronosAuthTimeoutTest, NonceTimedOut)
 {
   fake_hss->set_impu_result("sip:6505550231@homedomain", "dereg-auth-timeout", RegDataXMLUtils::STATE_REGISTERED, "", "?private_id=6505550231%40homedomain");
-  ImpiStore::Impi* impi = new ImpiStore::Impi("6505550231@homedomain");
+  ImpiStore::Impi* impi = new AstaireImpiStore::Impi("6505550231@homedomain");
   ImpiStore::DigestAuthChallenge* auth_challenge = new ImpiStore::DigestAuthChallenge("abcdef", "example.com", "auth", "ha1", time(NULL) + 30);
   auth_challenge->correlator = "abcde";
   auth_challenge->scscf_uri = "sip:scscf.sprout.homedomain:5058;transport=TCP";
@@ -442,7 +442,7 @@ TEST_F(ChronosAuthTimeoutTest, NonceTimedOut)
 TEST_F(ChronosAuthTimeoutTest, NonceTimedOutWithEmptyCorrelator)
 {
   fake_hss->set_impu_result("sip:6505550231@homedomain", "dereg-auth-timeout", RegDataXMLUtils::STATE_REGISTERED, "", "?private_id=6505550231%40homedomain");
-  ImpiStore::Impi* impi = new ImpiStore::Impi("6505550231@homedomain");
+  ImpiStore::Impi* impi = new AstaireImpiStore::Impi("6505550231@homedomain");
   ImpiStore::DigestAuthChallenge* auth_challenge = new ImpiStore::DigestAuthChallenge("abcdef", "example.com", "auth", "ha1", time(NULL) + 30);
   auth_challenge->scscf_uri = "sip:scscf.sprout.homedomain:5058;transport=TCP";
   impi->auth_challenges.push_back(auth_challenge);
@@ -461,7 +461,7 @@ TEST_F(ChronosAuthTimeoutTest, NonceTimedOutWithEmptyCorrelator)
 
 TEST_F(ChronosAuthTimeoutTest, MainlineTest)
 {
-  ImpiStore::Impi* impi = new ImpiStore::Impi("test@example.com");
+  ImpiStore::Impi* impi = new AstaireImpiStore::Impi("test@example.com");
   ImpiStore::DigestAuthChallenge* auth_challenge = new ImpiStore::DigestAuthChallenge("abcdef", "example.com", "auth", "ha1", time(NULL) + 30);
   auth_challenge->nonce_count++; // Indicates that one successful authentication has occurred
   auth_challenge->correlator = "abcde";

--- a/src/ut/chronoshandlers_test.cpp
+++ b/src/ut/chronoshandlers_test.cpp
@@ -423,8 +423,8 @@ TEST_F(ChronosAuthTimeoutTest, NonceTimedOut)
   fake_hss->set_impu_result("sip:6505550231@homedomain", "dereg-auth-timeout", RegDataXMLUtils::STATE_REGISTERED, "", "?private_id=6505550231%40homedomain");
   ImpiStore::Impi* impi = new AstaireImpiStore::Impi("6505550231@homedomain");
   ImpiStore::DigestAuthChallenge* auth_challenge = new ImpiStore::DigestAuthChallenge("abcdef", "example.com", "auth", "ha1", time(NULL) + 30);
-  auth_challenge->correlator = "abcde";
-  auth_challenge->scscf_uri = "sip:scscf.sprout.homedomain:5058;transport=TCP";
+  auth_challenge->_correlator = "abcde";
+  auth_challenge->_scscf_uri = "sip:scscf.sprout.homedomain:5058;transport=TCP";
   impi->auth_challenges.push_back(auth_challenge);
   store->set_impi(impi, 0);
 
@@ -444,7 +444,7 @@ TEST_F(ChronosAuthTimeoutTest, NonceTimedOutWithEmptyCorrelator)
   fake_hss->set_impu_result("sip:6505550231@homedomain", "dereg-auth-timeout", RegDataXMLUtils::STATE_REGISTERED, "", "?private_id=6505550231%40homedomain");
   ImpiStore::Impi* impi = new AstaireImpiStore::Impi("6505550231@homedomain");
   ImpiStore::DigestAuthChallenge* auth_challenge = new ImpiStore::DigestAuthChallenge("abcdef", "example.com", "auth", "ha1", time(NULL) + 30);
-  auth_challenge->scscf_uri = "sip:scscf.sprout.homedomain:5058;transport=TCP";
+  auth_challenge->_scscf_uri = "sip:scscf.sprout.homedomain:5058;transport=TCP";
   impi->auth_challenges.push_back(auth_challenge);
   store->set_impi(impi, 0);
 
@@ -463,8 +463,8 @@ TEST_F(ChronosAuthTimeoutTest, MainlineTest)
 {
   ImpiStore::Impi* impi = new AstaireImpiStore::Impi("test@example.com");
   ImpiStore::DigestAuthChallenge* auth_challenge = new ImpiStore::DigestAuthChallenge("abcdef", "example.com", "auth", "ha1", time(NULL) + 30);
-  auth_challenge->nonce_count++; // Indicates that one successful authentication has occurred
-  auth_challenge->correlator = "abcde";
+  auth_challenge->_nonce_count++; // Indicates that one successful authentication has occurred
+  auth_challenge->_correlator = "abcde";
   impi->auth_challenges.push_back(auth_challenge);
   store->set_impi(impi, 0);
 

--- a/src/ut/handlers_test.cpp
+++ b/src/ut/handlers_test.cpp
@@ -187,11 +187,11 @@ TEST_F(DeregistrationTaskTest, MainlineTest)
   expect_sdm_updates(aor_ids, aors);
 
   // The IMPI is also deleted from the local and remote stores.
-  ImpiStore::Impi* impi = new ImpiStore::Impi("6505550231");
+  ImpiStore::Impi* impi = new AstaireImpiStore::Impi("6505550231");
   EXPECT_CALL(*_local_impi_store, get_impi("6505550231", _)).WillOnce(Return(impi));
   EXPECT_CALL(*_local_impi_store, delete_impi(impi, _)).WillOnce(Return(Store::OK));
 
-  impi = new ImpiStore::Impi("6505550231");
+  impi = new AstaireImpiStore::Impi("6505550231");
   EXPECT_CALL(*_remote_impi_store, get_impi("6505550231", _)).WillOnce(Return(impi));
   EXPECT_CALL(*_remote_impi_store, delete_impi(impi, _)).WillOnce(Return(Store::OK));
 
@@ -398,7 +398,7 @@ TEST_F(DeregistrationTaskTest, ImpiClearedWhenBindingUnconditionallyDeregistered
   expect_sdm_updates(aor_ids, aors);
 
   // The corresponding IMPI is also deleted.
-  ImpiStore::Impi* impi = new ImpiStore::Impi("impi1");
+  ImpiStore::Impi* impi = new AstaireImpiStore::Impi("impi1");
   EXPECT_CALL(*_local_impi_store, get_impi("impi1", _)).WillOnce(Return(impi));
   EXPECT_CALL(*_local_impi_store, delete_impi(impi, _)).WillOnce(Return(Store::OK));
 
@@ -472,9 +472,9 @@ TEST_F(DeregistrationTaskTest, ClearMultipleImpis)
   expect_sdm_updates(aor_ids, aors);
 
   // The corresponding IMPIs are also deleted.
-  ImpiStore::Impi* impi1 = new ImpiStore::Impi("impi1");
-  ImpiStore::Impi* impi2 = new ImpiStore::Impi("impi2");
-  ImpiStore::Impi* impi3 = new ImpiStore::Impi("impi3");
+  ImpiStore::Impi* impi1 = new AstaireImpiStore::Impi("impi1");
+  ImpiStore::Impi* impi2 = new AstaireImpiStore::Impi("impi2");
+  ImpiStore::Impi* impi3 = new AstaireImpiStore::Impi("impi3");
   EXPECT_CALL(*_local_impi_store, get_impi("impi1", _)).WillOnce(Return(impi1));
   EXPECT_CALL(*_local_impi_store, delete_impi(impi1, _)).WillOnce(Return(Store::OK));
   EXPECT_CALL(*_local_impi_store, get_impi("impi2", _)).WillOnce(Return(impi2));
@@ -554,7 +554,7 @@ TEST_F(DeregistrationTaskTest, ImpiStoreFailure)
 
   // Simulate the IMPI store failing when deleting the IMPI. The handler does
   // not retry the delete.
-  ImpiStore::Impi* impi1 = new ImpiStore::Impi("impi1");
+  ImpiStore::Impi* impi1 = new AstaireImpiStore::Impi("impi1");
   EXPECT_CALL(*_local_impi_store, get_impi("impi1", _)).WillOnce(Return(impi1));
   EXPECT_CALL(*_local_impi_store, delete_impi(impi1, _)).WillOnce(Return(Store::ERROR));
 
@@ -586,8 +586,8 @@ TEST_F(DeregistrationTaskTest, ImpiStoreDataContention)
 
   // We need to create two IMPIs when we return one on a call to get_impi we
   // lose ownership of it.
-  ImpiStore::Impi* impi1 = new ImpiStore::Impi("impi1");
-  ImpiStore::Impi* impi1a = new ImpiStore::Impi("impi1");
+  ImpiStore::Impi* impi1 = new AstaireImpiStore::Impi("impi1");
+  ImpiStore::Impi* impi1a = new AstaireImpiStore::Impi("impi1");
   {
     // Simulate the IMPI store returning data contention on the first delete.
     // The handler tries again.

--- a/src/ut/handlers_test.h
+++ b/src/ut/handlers_test.h
@@ -25,6 +25,7 @@
 #include "mock_subscriber_data_manager.h"
 #include "mock_impi_store.h"
 #include "mock_hss_connection.h"
+#include "astaire_impistore.h"
 
 // Base class used for testing handlers with Mock SDMs.
 class TestWithMockSdms : public SipTest
@@ -118,7 +119,7 @@ class AuthTimeoutTest : public SipTest
   void SetUp()
   {
     local_data_store = new LocalStore();
-    store = new ImpiStore(local_data_store);
+    store = new AstaireImpiStore(local_data_store);
     fake_hss = new FakeHSSConnection();
   }
 

--- a/src/ut/mock_impi_store.h
+++ b/src/ut/mock_impi_store.h
@@ -17,14 +17,11 @@
 class MockImpiStore : public ImpiStore
 {
 public:
-  MockImpiStore() : ImpiStore(NULL) {}
+  MockImpiStore() : ImpiStore() {}
   virtual ~MockImpiStore() {}
 
   MOCK_METHOD2(set_impi, Store::Status(Impi* impi, SAS::TrailId trail));
   MOCK_METHOD2(get_impi, Impi*(const std::string& impi, SAS::TrailId trail));
-  MOCK_METHOD3(get_impi_with_nonce, Impi*(const std::string& impi,
-                                          const std::string& nonce,
-                                          SAS::TrailId trail));
   MOCK_METHOD2(delete_impi, Store::Status(Impi* impi, SAS::TrailId trail));
 };
 


### PR DESCRIPTION
This PR refactors the ImpiStore slightly:

* the old `ImpiStore` implementation is now an `AstaireImpiStore`, as its implementation is specific to Astaire
* the `AuthChallenge` objects are common to all possible store implementations, so remain in the `ImpiStore` rather than the `AstaireImpiStore`
* the `Impi` objects are now store-specific, so there's an `AstaireImpiStore::Impi`
* the `AuthChallenge` member variables are now private, so that Sprout must use the getters/setters to access them

### Testing
`make full_test` passes, and the live tests pass
