### PR TITLE
[No reviewer] make_test ignores privacy, so i checked in a bad fix

### DIFF
--- a/include/aor.h
+++ b/include/aor.h
@@ -261,7 +261,6 @@ public:
   /// registration has been created.
   std::string _scscf_uri;
 
-private:
   /// Map holding the bindings for a particular AoR indexed by binding ID.
   Bindings _bindings;
 


### PR DESCRIPTION
In https://github.com/Metaswitch/sprout/pull/1907 i un-commented something i'd missed, making the `_bindings` and `_subscriptions` private again. I ran make test, and all was good, so commited and merged. 
`make_test` doesn't respect privacy (rude), so they ran fine, but an actual `make` fails miserably, so i'm reverting the reversion here.