### PR TITLE
[Reviewer: Adam] Further impistore changes

### DIFF
--- a/include/astaire_impistore.h
+++ b/include/astaire_impistore.h
@@ -43,7 +43,10 @@ public:
 
   private:
     /// Write to JSON writer.
-    virtual void write_json(rapidjson::Writer<rapidjson::StringBuffer>* writer) override;
+    void write_json(rapidjson::Writer<rapidjson::StringBuffer>* writer);
+
+    /// Serialization to JSON.
+    std::string to_json();
 
     /// Memcached CAS value.
     uint64_t _cas;

--- a/include/impistore.h
+++ b/include/impistore.h
@@ -387,10 +387,6 @@ public:
 
 protected:
   static rapidjson::Document* json_from_string(const std::string& string);
-
-private:
-  /// Identifier for IMPI table.
-  static const std::string TABLE_IMPI;
 };
 
 // Utility function - retrieves the "corrlator" field from the give challenge

--- a/include/impistore.h
+++ b/include/impistore.h
@@ -353,13 +353,6 @@ public:
     /// @returns the expiry time.
     int get_expires();
 
-  protected:
-    /// Serialization to JSON.
-    virtual std::string to_json();
-
-    /// Write to JSON writer.
-    virtual void write_json(rapidjson::Writer<rapidjson::StringBuffer>* writer) = 0;
-
     // The IMPI store is a friend so it can read our CAS value.
     friend class ImpiStore;
   };

--- a/src/astaire_impistore.cpp
+++ b/src/astaire_impistore.cpp
@@ -30,6 +30,19 @@ const std::string AstaireImpiStore::TABLE_IMPI = "impi";
 // JSON field names and values.
 static const char* const JSON_AUTH_CHALLENGES = "authChallenges";
 
+std::string AstaireImpiStore::Impi::to_json()
+{
+  // Build a writer, serialize the IMPI to it and return the result.
+  rapidjson::StringBuffer buffer;
+  rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
+  writer.StartObject();
+  {
+    write_json(&writer);
+  }
+  writer.EndObject();
+  return buffer.GetString();
+}
+
 void AstaireImpiStore::Impi::write_json(rapidjson::Writer<rapidjson::StringBuffer>* writer)
 {
   // Write a JSON array, and then write each of the AuthChallenges into it.

--- a/src/impistore.cpp
+++ b/src/impistore.cpp
@@ -40,9 +40,6 @@ rapidjson::Document* ImpiStore::json_from_string(const std::string& string)
   return json;
 }
 
-// Constant table names.
-const std::string ImpiStore::TABLE_IMPI = "impi";
-
 // JSON field names and values.
 static const char* const JSON_TYPE = "type";
 static const char* const JSON_TYPE_DIGEST = "digest";

--- a/src/impistore.cpp
+++ b/src/impistore.cpp
@@ -241,19 +241,6 @@ ImpiStore::Impi::~Impi()
   }
 }
 
-std::string ImpiStore::Impi::to_json()
-{
-  // Build a writer, serialize the IMPI to it and return the result.
-  rapidjson::StringBuffer buffer;
-  rapidjson::Writer<rapidjson::StringBuffer> writer(buffer);
-  writer.StartObject();
-  {
-    write_json(&writer);
-  }
-  writer.EndObject();
-  return buffer.GetString();
-}
-
 int ImpiStore::Impi::get_expires()
 {
   // Spin through the AuthChallenges, finding the latest expires time.


### PR DESCRIPTION
A couple of further changes to the ImpiStore interface here.

1) A general `Impi` object no longer necessarily needs to be able to write itself as a JSON object, so that is now moved down from the `ImpiStore::Impi` to the `AstaireImpiStore::Impi`

2) I had left a `TABLE_IMPI` variable in the `ImpiStore`, which is actually an Astaire thing (It's still present in the `AstaireImpiStore`)
