### PR TITLE
[Reviewer: Adam] Fix up handler UTs to use MockImpiStore

### DIFF
--- a/src/ut/chronoshandlers_test.cpp
+++ b/src/ut/chronoshandlers_test.cpp
@@ -421,12 +421,13 @@ class ChronosAuthTimeoutTest : public AuthTimeoutTest
 TEST_F(ChronosAuthTimeoutTest, NonceTimedOut)
 {
   fake_hss->set_impu_result("sip:6505550231@homedomain", "dereg-auth-timeout", RegDataXMLUtils::STATE_REGISTERED, "", "?private_id=6505550231%40homedomain");
-  ImpiStore::Impi* impi = new AstaireImpiStore::Impi("6505550231@homedomain");
+  ImpiStore::Impi* impi = new ImpiStore::Impi("6505550231@homedomain");
   ImpiStore::DigestAuthChallenge* auth_challenge = new ImpiStore::DigestAuthChallenge("abcdef", "example.com", "auth", "ha1", time(NULL) + 30);
   auth_challenge->_correlator = "abcde";
   auth_challenge->_scscf_uri = "sip:scscf.sprout.homedomain:5058;transport=TCP";
   impi->auth_challenges.push_back(auth_challenge);
-  store->set_impi(impi, 0);
+
+  EXPECT_CALL(*store, get_impi("6505550231@homedomain", _)).WillOnce(Return(impi));
 
   std::string body = "{\"impu\": \"sip:6505550231@homedomain\", \"impi\": \"6505550231@homedomain\", \"nonce\": \"abcdef\"}";
   build_timeout_request(body, htp_method_POST);
@@ -435,18 +436,17 @@ TEST_F(ChronosAuthTimeoutTest, NonceTimedOut)
   handler->run();
 
   ASSERT_TRUE(fake_hss->url_was_requested("/impu/sip%3A6505550231%40homedomain/reg-data?private_id=6505550231%40homedomain", "{\"reqtype\": \"dereg-auth-timeout\", \"server_name\": \"sip:scscf.sprout.homedomain:5058;transport=TCP\"}"));
-
-  delete impi; impi = NULL;
 }
 
 TEST_F(ChronosAuthTimeoutTest, NonceTimedOutWithEmptyCorrelator)
 {
   fake_hss->set_impu_result("sip:6505550231@homedomain", "dereg-auth-timeout", RegDataXMLUtils::STATE_REGISTERED, "", "?private_id=6505550231%40homedomain");
-  ImpiStore::Impi* impi = new AstaireImpiStore::Impi("6505550231@homedomain");
+  ImpiStore::Impi* impi = new ImpiStore::Impi("6505550231@homedomain");
   ImpiStore::DigestAuthChallenge* auth_challenge = new ImpiStore::DigestAuthChallenge("abcdef", "example.com", "auth", "ha1", time(NULL) + 30);
   auth_challenge->_scscf_uri = "sip:scscf.sprout.homedomain:5058;transport=TCP";
   impi->auth_challenges.push_back(auth_challenge);
-  store->set_impi(impi, 0);
+
+  EXPECT_CALL(*store, get_impi("6505550231@homedomain", _)).WillOnce(Return(impi));
 
   std::string body = "{\"impu\": \"sip:6505550231@homedomain\", \"impi\": \"6505550231@homedomain\", \"nonce\": \"abcdef\"}";
   build_timeout_request(body, htp_method_POST);
@@ -455,18 +455,17 @@ TEST_F(ChronosAuthTimeoutTest, NonceTimedOutWithEmptyCorrelator)
   handler->run();
 
   ASSERT_TRUE(fake_hss->url_was_requested("/impu/sip%3A6505550231%40homedomain/reg-data?private_id=6505550231%40homedomain", "{\"reqtype\": \"dereg-auth-timeout\", \"server_name\": \"sip:scscf.sprout.homedomain:5058;transport=TCP\"}"));
-
-  delete impi; impi = NULL;
 }
 
 TEST_F(ChronosAuthTimeoutTest, MainlineTest)
 {
-  ImpiStore::Impi* impi = new AstaireImpiStore::Impi("test@example.com");
+  ImpiStore::Impi* impi = new ImpiStore::Impi("test@example.com");
   ImpiStore::DigestAuthChallenge* auth_challenge = new ImpiStore::DigestAuthChallenge("abcdef", "example.com", "auth", "ha1", time(NULL) + 30);
   auth_challenge->_nonce_count++; // Indicates that one successful authentication has occurred
   auth_challenge->_correlator = "abcde";
   impi->auth_challenges.push_back(auth_challenge);
-  store->set_impi(impi, 0);
+
+  EXPECT_CALL(*store, get_impi("test@example.com", _)).WillOnce(Return(impi));
 
   std::string body = "{\"impu\": \"sip:test@example.com\", \"impi\": \"test@example.com\", \"nonce\": \"abcdef\"}";
   build_timeout_request(body, htp_method_POST);
@@ -475,8 +474,6 @@ TEST_F(ChronosAuthTimeoutTest, MainlineTest)
   handler->run();
 
   ASSERT_FALSE(fake_hss->url_was_requested("/impu/sip%3Atest%40example.com/reg-data?private_id=test%40example.com", "{\"reqtype\": \"dereg-auth-timeout\"}"));
-
-  delete impi; impi = NULL;
 }
 
 TEST_F(ChronosAuthTimeoutTest, BadMethod)

--- a/src/ut/handlers_test.cpp
+++ b/src/ut/handlers_test.cpp
@@ -187,11 +187,11 @@ TEST_F(DeregistrationTaskTest, MainlineTest)
   expect_sdm_updates(aor_ids, aors);
 
   // The IMPI is also deleted from the local and remote stores.
-  ImpiStore::Impi* impi = new AstaireImpiStore::Impi("6505550231");
+  ImpiStore::Impi* impi = new ImpiStore::Impi("6505550231");
   EXPECT_CALL(*_local_impi_store, get_impi("6505550231", _)).WillOnce(Return(impi));
   EXPECT_CALL(*_local_impi_store, delete_impi(impi, _)).WillOnce(Return(Store::OK));
 
-  impi = new AstaireImpiStore::Impi("6505550231");
+  impi = new ImpiStore::Impi("6505550231");
   EXPECT_CALL(*_remote_impi_store, get_impi("6505550231", _)).WillOnce(Return(impi));
   EXPECT_CALL(*_remote_impi_store, delete_impi(impi, _)).WillOnce(Return(Store::OK));
 
@@ -398,7 +398,7 @@ TEST_F(DeregistrationTaskTest, ImpiClearedWhenBindingUnconditionallyDeregistered
   expect_sdm_updates(aor_ids, aors);
 
   // The corresponding IMPI is also deleted.
-  ImpiStore::Impi* impi = new AstaireImpiStore::Impi("impi1");
+  ImpiStore::Impi* impi = new ImpiStore::Impi("impi1");
   EXPECT_CALL(*_local_impi_store, get_impi("impi1", _)).WillOnce(Return(impi));
   EXPECT_CALL(*_local_impi_store, delete_impi(impi, _)).WillOnce(Return(Store::OK));
 
@@ -472,9 +472,9 @@ TEST_F(DeregistrationTaskTest, ClearMultipleImpis)
   expect_sdm_updates(aor_ids, aors);
 
   // The corresponding IMPIs are also deleted.
-  ImpiStore::Impi* impi1 = new AstaireImpiStore::Impi("impi1");
-  ImpiStore::Impi* impi2 = new AstaireImpiStore::Impi("impi2");
-  ImpiStore::Impi* impi3 = new AstaireImpiStore::Impi("impi3");
+  ImpiStore::Impi* impi1 = new ImpiStore::Impi("impi1");
+  ImpiStore::Impi* impi2 = new ImpiStore::Impi("impi2");
+  ImpiStore::Impi* impi3 = new ImpiStore::Impi("impi3");
   EXPECT_CALL(*_local_impi_store, get_impi("impi1", _)).WillOnce(Return(impi1));
   EXPECT_CALL(*_local_impi_store, delete_impi(impi1, _)).WillOnce(Return(Store::OK));
   EXPECT_CALL(*_local_impi_store, get_impi("impi2", _)).WillOnce(Return(impi2));
@@ -554,7 +554,7 @@ TEST_F(DeregistrationTaskTest, ImpiStoreFailure)
 
   // Simulate the IMPI store failing when deleting the IMPI. The handler does
   // not retry the delete.
-  ImpiStore::Impi* impi1 = new AstaireImpiStore::Impi("impi1");
+  ImpiStore::Impi* impi1 = new ImpiStore::Impi("impi1");
   EXPECT_CALL(*_local_impi_store, get_impi("impi1", _)).WillOnce(Return(impi1));
   EXPECT_CALL(*_local_impi_store, delete_impi(impi1, _)).WillOnce(Return(Store::ERROR));
 
@@ -586,8 +586,8 @@ TEST_F(DeregistrationTaskTest, ImpiStoreDataContention)
 
   // We need to create two IMPIs when we return one on a call to get_impi we
   // lose ownership of it.
-  ImpiStore::Impi* impi1 = new AstaireImpiStore::Impi("impi1");
-  ImpiStore::Impi* impi1a = new AstaireImpiStore::Impi("impi1");
+  ImpiStore::Impi* impi1 = new ImpiStore::Impi("impi1");
+  ImpiStore::Impi* impi1a = new ImpiStore::Impi("impi1");
   {
     // Simulate the IMPI store returning data contention on the first delete.
     // The handler tries again.

--- a/src/ut/handlers_test.h
+++ b/src/ut/handlers_test.h
@@ -19,13 +19,11 @@
 #include "handlers.h"
 #include "basetest.hpp"
 #include "siptest.hpp"
-#include "localstore.h"
 #include "fakehssconnection.hpp"
 #include "fakechronosconnection.hpp"
 #include "mock_subscriber_data_manager.h"
 #include "mock_impi_store.h"
 #include "mock_hss_connection.h"
-#include "astaire_impistore.h"
 
 // Base class used for testing handlers with Mock SDMs.
 class TestWithMockSdms : public SipTest
@@ -111,15 +109,13 @@ class TestWithMockSdms : public SipTest
 
 class AuthTimeoutTest : public SipTest
 {
-  LocalStore* local_data_store;
-  ImpiStore* store;
+  MockImpiStore* store;
   FakeHSSConnection* fake_hss;
   MockHttpStack stack;
 
   void SetUp()
   {
-    local_data_store = new LocalStore();
-    store = new AstaireImpiStore(local_data_store);
+    store = new MockImpiStore();
     fake_hss = new FakeHSSConnection();
   }
 
@@ -127,7 +123,6 @@ class AuthTimeoutTest : public SipTest
   {
     delete fake_hss; fake_hss = NULL;
     delete store; store = NULL;
-    delete local_data_store; local_data_store = NULL;
   }
 };
 


### PR DESCRIPTION
This is a follow-on from my PR #1905 
Just tweaks the UTs to use a MockImpiStore where appropriate

`make full_test` passes