### PR TITLE
[No reviewer] Only use chronos connection if it exists

### DIFF
--- a/src/authenticationsproutlet.cpp
+++ b/src/authenticationsproutlet.cpp
@@ -813,7 +813,7 @@ void AuthenticationSproutletTsx::create_challenge(pjsip_digest_credential* crede
 
     if (status == Store::OK)
     {
-      if (!impu_for_hss.empty())
+      if ((!impu_for_hss.empty()) && (_authentication->_chronos))
       {
         TRC_DEBUG("Set chronos timer for AUTHENTICATION_TIMEOUT SAR");
 

--- a/src/subscriber_data_manager.cpp
+++ b/src/subscriber_data_manager.cpp
@@ -174,7 +174,10 @@ Store::Status SubscriberDataManager::set_aor_data(
     }
 
     // 3. Send any Chronos timer requests
-    _chronos_timer_request_sender->send_timers(aor_id, aor_pair, now, trail);
+    if (_chronos_timer_request_sender->_chronos_conn)
+    {
+      _chronos_timer_request_sender->send_timers(aor_id, aor_pair, now, trail);
+    }
   }
 
   // 4. Write the data to memcached. If this fails, bail out here


### PR DESCRIPTION
Avoid crashes when we haven't got a valid chronos_connection.
`make full_test` still passes fine 