### PR TITLE
[No reviewer] Check doc is actually a JSON object before parsing

### DIFF
--- a/src/astaire_aor_store.cpp
+++ b/src/astaire_aor_store.cpp
@@ -189,6 +189,7 @@ AoR* AstaireAoRStore::JsonSerializerDeserializer::
 
   try
   {
+    JSON_ASSERT_OBJECT(doc);
     JSON_ASSERT_CONTAINS(doc, JSON_BINDINGS);
     JSON_ASSERT_OBJECT(doc[JSON_BINDINGS]);
     const rapidjson::Value& bindings_obj = doc[JSON_BINDINGS];


### PR DESCRIPTION
Stops the code crashing out if we receive an invalid non-object back from the store. We should definitely have been assuring that the doc was an object before attempting to perform an object specific action on it.