### PR TITLE
[Reviewer RJW2] Ensure content type appears once in bodyparts

### DIFF
--- a/src/registration_utils.cpp
+++ b/src/registration_utils.cpp
@@ -563,7 +563,7 @@ static void send_register_to_as(SubscriberDataManager* sdm,
   // Set the SAS trail on the request.
   set_trail(tdata, trail);
 
-  // Verbose trace
+  if (Log::enabled(Log::VERBOSE_LEVEL))
   {
     char buf[PJSIP_MAX_PKT_LEN];
     pj_ssize_t size;

--- a/src/registration_utils.cpp
+++ b/src/registration_utils.cpp
@@ -563,6 +563,33 @@ static void send_register_to_as(SubscriberDataManager* sdm,
   // Set the SAS trail on the request.
   set_trail(tdata, trail);
 
+  // Verbose trace
+  {
+    char buf[PJSIP_MAX_PKT_LEN];
+    pj_ssize_t size;
+
+    // Serialise the message in a separate buffer using the function
+    // exposed by PJSIP.  In principle we could use tdata's own
+    // serialisation buffer structure for this, but then we'd need to
+    // explicitly invalidate it afterwards to avoid accidentally sending
+    // the wrong data over SIP at some future point.  Safer to use a local
+    // buffer.
+    size = pjsip_msg_print(tdata->msg, buf, sizeof(buf));
+
+    // Defensively set size to zero if pjsip_msg_print failed
+    size = std::max(0L, size);
+
+    TRC_VERBOSE("Routing %s (%d bytes) to 3rd party AS %s:\n"
+                "--start msg--\n\n"
+                "%.*s\n"
+                "--end msg--",
+                pjsip_tx_data_get_info(tdata),
+                size,
+                as.server_name.c_str(),
+                (int)size,
+                buf);
+  }
+
   // Allocate a temporary structure to record the default handling for this
   // REGISTER, and send it statefully.
   ThirdPartyRegData* tsxdata = new ThirdPartyRegData;

--- a/src/ut/registrar_test.cpp
+++ b/src/ut/registrar_test.cpp
@@ -1220,8 +1220,10 @@ TEST_F(RegistrarTest, AppServersWithMultipartBodyWithTelURI)
   // INVITE passed on to AS
   SCOPED_TRACE("REGISTER (S)");
   pjsip_msg* out = current_txdata()->msg;
-  ReqMatcher r1("REGISTER");
+  // Verify that Content-Type headers are inserted into multipart message parts
+  ReqMatcher r1("REGISTER", "", ".*--\\S+\r\nContent-Type: message/sip\r\n\r\n.*");
   ASSERT_NO_FATAL_FAILURE(r1.matches(out));
+  r1.body_regex_matches(out);
   pj_str_t multipart = pj_str("multipart");
   pj_str_t mixed = pj_str("mixed");
   EXPECT_EQ(0, pj_strcmp(&multipart, &out->body->content_type.type));

--- a/src/ut/siptest.cpp
+++ b/src/ut/siptest.cpp
@@ -877,6 +877,17 @@ void MsgMatcher::matches(pjsip_msg* msg)
   }
 }
 
+void MsgMatcher::body_regex_matches(pjsip_msg* msg)
+{
+  if (_body_regex != "")
+  {    
+    char buf[16384];
+    int n = msg->body->print_body(msg->body, buf, sizeof(buf));
+    string body(buf, n);
+    EXPECT_THAT(body, testing::MatchesRegex(_body_regex));
+  }
+}
+
 void ReqMatcher::matches(pjsip_msg* msg)
 {
   ASSERT_EQ(PJSIP_REQUEST_MSG, msg->type) << PjMsg(msg);

--- a/src/ut/siptest.hpp
+++ b/src/ut/siptest.hpp
@@ -275,15 +275,19 @@ private:
 class MsgMatcher
 {
 public:
-  MsgMatcher(string expected_body="") :
-    _expected_body(expected_body)
+  MsgMatcher(string expected_body="",
+             string body_regex="") :
+    _expected_body(expected_body),
+    _body_regex(body_regex)
   {
   }
 
   void matches(pjsip_msg* msg);
+  void body_regex_matches(pjsip_msg* msg);
 
 private:
   string _expected_body;
+  string _body_regex;
 };
 
 /// Checker that asserts a PJSIP message is of the expected type,
@@ -299,8 +303,10 @@ public:
   }
 
   ReqMatcher(const string& method,
-             string expected_body) :
-    MsgMatcher(expected_body),
+             string expected_body,
+             string body_regex="") :
+    MsgMatcher(expected_body,
+               body_regex),
     _method(method)
   {
   }


### PR DESCRIPTION
Hi Richard

Here's the Sprout PR companion to https://github.com/Metaswitch/pjsip-upstream/pull/68. Note that in addition to extending the UTs to check that bodyparts are as expected, I've added a verbose log of the 3rd party REGISTER (much as we have for sproutet-sproutlet traffic) so that you can see what it is in UTs (when you don't have the benefit of SAS).

Cheers

Steve