### PR TITLE
[Reviewer: Richard] Allow ImpiStore to optionally return expired challenges

### DIFF
--- a/include/astaire_impistore.h
+++ b/include/astaire_impistore.h
@@ -77,7 +77,8 @@ public:
   ///                  found it returns an empty object.
   /// @param impi      The private user identity.
   virtual ImpiStore::Impi* get_impi(const std::string& impi,
-                                    SAS::TrailId trail) override;
+                                    SAS::TrailId trail,
+                                    bool include_expired = false) override;
 
   /// Delete all record of the IMPI.
   ///

--- a/include/impistore.h
+++ b/include/impistore.h
@@ -75,7 +75,8 @@ public:
 
     /// Deserialization from JSON (IMPI format).
     static ImpiStore::AuthChallenge* from_json(rapidjson::Value* json,
-                                               bool expiry_in_ms = false);
+                                               bool expiry_in_ms = false,
+                                               bool include_expired = false);
 
     /// Getters and setters
     Type get_type()
@@ -394,9 +395,11 @@ public:
   ///                  caller owns the returned object. This method only returns
   ///                  NULL if the underlying store failed - if no IMPI was
   ///                  found it returns an empty object.
-  /// @param impi      The private user identity.
+  /// @param impi                 The private user identity.
+  /// @param include_expired      Whether to include expired challenges.
   virtual Impi* get_impi(const std::string& impi,
-                         SAS::TrailId trail) = 0;
+                         SAS::TrailId trail,
+                         bool include_expired = false) = 0;
 
   /// Delete all record of the IMPI.
   ///

--- a/src/astaire_impistore.cpp
+++ b/src/astaire_impistore.cpp
@@ -161,8 +161,11 @@ Store::Status AstaireImpiStore::set_impi(ImpiStore::Impi* impi,
   return status;
 }
 
+// The AstaireImpiStore never includes expired challenges, so include_expired is
+// unused
 ImpiStore::Impi* AstaireImpiStore::get_impi(const std::string& impi,
-                                     SAS::TrailId trail)
+                                            SAS::TrailId trail,
+                                            bool include_expired)
 {
   // Get the IMPI data from the store and deserialize it.
   AstaireImpiStore::Impi* impi_obj = NULL;

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -595,7 +595,10 @@ HTTPCode AuthTimeoutTask::timeout_auth_challenge(std::string impu,
   report_sip_all_register_marker(trail(), impu);
 
   bool success = false;
-  ImpiStore::Impi* impi_obj = _cfg->_local_impi_store->get_impi(impi, trail());
+
+  // We ask the ImpiStore to return expired challenges here, so that we'll still
+  // get the challenge if the timer has popped after the challenge has expired
+  ImpiStore::Impi* impi_obj = _cfg->_local_impi_store->get_impi(impi, trail(), true);
   ImpiStore::AuthChallenge* auth_challenge = NULL;
   if (impi_obj != NULL)
   {

--- a/src/impistore.cpp
+++ b/src/impistore.cpp
@@ -103,7 +103,8 @@ void ImpiStore::AuthChallenge::write_json(rapidjson::Writer<rapidjson::StringBuf
 }
 
 ImpiStore::AuthChallenge* ImpiStore::AuthChallenge::from_json(rapidjson::Value* json,
-                                                              bool expiry_in_ms)
+                                                              bool expiry_in_ms,
+                                                              bool include_expired)
 {
   ImpiStore::AuthChallenge* auth_challenge = NULL;
   if (json->IsObject())
@@ -178,7 +179,7 @@ ImpiStore::AuthChallenge* ImpiStore::AuthChallenge::from_json(rapidjson::Value* 
                     JSON_NONCE);
         delete auth_challenge; auth_challenge = NULL;
       }
-      else if (auth_challenge->_expires < time(NULL))
+      else if ((auth_challenge->_expires < time(NULL)) && (!include_expired))
       {
         TRC_DEBUG("Expires in past - dropping");
         delete auth_challenge; auth_challenge = NULL;

--- a/src/ut/chronoshandlers_test.cpp
+++ b/src/ut/chronoshandlers_test.cpp
@@ -427,7 +427,7 @@ TEST_F(ChronosAuthTimeoutTest, NonceTimedOut)
   auth_challenge->_scscf_uri = "sip:scscf.sprout.homedomain:5058;transport=TCP";
   impi->auth_challenges.push_back(auth_challenge);
 
-  EXPECT_CALL(*store, get_impi("6505550231@homedomain", _)).WillOnce(Return(impi));
+  EXPECT_CALL(*store, get_impi("6505550231@homedomain", _, true)).WillOnce(Return(impi));
 
   std::string body = "{\"impu\": \"sip:6505550231@homedomain\", \"impi\": \"6505550231@homedomain\", \"nonce\": \"abcdef\"}";
   build_timeout_request(body, htp_method_POST);
@@ -446,7 +446,7 @@ TEST_F(ChronosAuthTimeoutTest, NonceTimedOutWithEmptyCorrelator)
   auth_challenge->_scscf_uri = "sip:scscf.sprout.homedomain:5058;transport=TCP";
   impi->auth_challenges.push_back(auth_challenge);
 
-  EXPECT_CALL(*store, get_impi("6505550231@homedomain", _)).WillOnce(Return(impi));
+  EXPECT_CALL(*store, get_impi("6505550231@homedomain", _, true)).WillOnce(Return(impi));
 
   std::string body = "{\"impu\": \"sip:6505550231@homedomain\", \"impi\": \"6505550231@homedomain\", \"nonce\": \"abcdef\"}";
   build_timeout_request(body, htp_method_POST);
@@ -465,7 +465,7 @@ TEST_F(ChronosAuthTimeoutTest, MainlineTest)
   auth_challenge->_correlator = "abcde";
   impi->auth_challenges.push_back(auth_challenge);
 
-  EXPECT_CALL(*store, get_impi("test@example.com", _)).WillOnce(Return(impi));
+  EXPECT_CALL(*store, get_impi("test@example.com", _, true)).WillOnce(Return(impi));
 
   std::string body = "{\"impu\": \"sip:test@example.com\", \"impi\": \"test@example.com\", \"nonce\": \"abcdef\"}";
   build_timeout_request(body, htp_method_POST);

--- a/src/ut/handlers_test.cpp
+++ b/src/ut/handlers_test.cpp
@@ -188,11 +188,11 @@ TEST_F(DeregistrationTaskTest, MainlineTest)
 
   // The IMPI is also deleted from the local and remote stores.
   ImpiStore::Impi* impi = new ImpiStore::Impi("6505550231");
-  EXPECT_CALL(*_local_impi_store, get_impi("6505550231", _)).WillOnce(Return(impi));
+  EXPECT_CALL(*_local_impi_store, get_impi("6505550231", _, false)).WillOnce(Return(impi));
   EXPECT_CALL(*_local_impi_store, delete_impi(impi, _)).WillOnce(Return(Store::OK));
 
   impi = new ImpiStore::Impi("6505550231");
-  EXPECT_CALL(*_remote_impi_store, get_impi("6505550231", _)).WillOnce(Return(impi));
+  EXPECT_CALL(*_remote_impi_store, get_impi("6505550231", _, false)).WillOnce(Return(impi));
   EXPECT_CALL(*_remote_impi_store, delete_impi(impi, _)).WillOnce(Return(Store::OK));
 
   // Run the task
@@ -399,7 +399,7 @@ TEST_F(DeregistrationTaskTest, ImpiClearedWhenBindingUnconditionallyDeregistered
 
   // The corresponding IMPI is also deleted.
   ImpiStore::Impi* impi = new ImpiStore::Impi("impi1");
-  EXPECT_CALL(*_local_impi_store, get_impi("impi1", _)).WillOnce(Return(impi));
+  EXPECT_CALL(*_local_impi_store, get_impi("impi1", _, false)).WillOnce(Return(impi));
   EXPECT_CALL(*_local_impi_store, delete_impi(impi, _)).WillOnce(Return(Store::OK));
 
   // Run the task
@@ -475,11 +475,11 @@ TEST_F(DeregistrationTaskTest, ClearMultipleImpis)
   ImpiStore::Impi* impi1 = new ImpiStore::Impi("impi1");
   ImpiStore::Impi* impi2 = new ImpiStore::Impi("impi2");
   ImpiStore::Impi* impi3 = new ImpiStore::Impi("impi3");
-  EXPECT_CALL(*_local_impi_store, get_impi("impi1", _)).WillOnce(Return(impi1));
+  EXPECT_CALL(*_local_impi_store, get_impi("impi1", _, false)).WillOnce(Return(impi1));
   EXPECT_CALL(*_local_impi_store, delete_impi(impi1, _)).WillOnce(Return(Store::OK));
-  EXPECT_CALL(*_local_impi_store, get_impi("impi2", _)).WillOnce(Return(impi2));
+  EXPECT_CALL(*_local_impi_store, get_impi("impi2", _, false)).WillOnce(Return(impi2));
   EXPECT_CALL(*_local_impi_store, delete_impi(impi2, _)).WillOnce(Return(Store::OK));
-  EXPECT_CALL(*_local_impi_store, get_impi("impi3", _)).WillOnce(Return(impi3));
+  EXPECT_CALL(*_local_impi_store, get_impi("impi3", _, false)).WillOnce(Return(impi3));
   EXPECT_CALL(*_local_impi_store, delete_impi(impi3, _)).WillOnce(Return(Store::OK));
 
   // Run the task
@@ -524,7 +524,7 @@ TEST_F(DeregistrationTaskTest, CannotFindImpiToDelete)
   // Simulate the IMPI not being found in the store. The handler does not go on
   // to try and delete the IMPI.
   ImpiStore::Impi* impi1 = NULL;
-  EXPECT_CALL(*_local_impi_store, get_impi("impi1", _)).WillOnce(Return(impi1));
+  EXPECT_CALL(*_local_impi_store, get_impi("impi1", _, false)).WillOnce(Return(impi1));
 
   // Run the task
   EXPECT_CALL(*_httpstack, send_reply(_, 200, _));
@@ -555,7 +555,7 @@ TEST_F(DeregistrationTaskTest, ImpiStoreFailure)
   // Simulate the IMPI store failing when deleting the IMPI. The handler does
   // not retry the delete.
   ImpiStore::Impi* impi1 = new ImpiStore::Impi("impi1");
-  EXPECT_CALL(*_local_impi_store, get_impi("impi1", _)).WillOnce(Return(impi1));
+  EXPECT_CALL(*_local_impi_store, get_impi("impi1", _, false)).WillOnce(Return(impi1));
   EXPECT_CALL(*_local_impi_store, delete_impi(impi1, _)).WillOnce(Return(Store::ERROR));
 
   // Run the task
@@ -592,9 +592,9 @@ TEST_F(DeregistrationTaskTest, ImpiStoreDataContention)
     // Simulate the IMPI store returning data contention on the first delete.
     // The handler tries again.
     InSequence s;
-    EXPECT_CALL(*_local_impi_store, get_impi("impi1", _)).WillOnce(Return(impi1));
+    EXPECT_CALL(*_local_impi_store, get_impi("impi1", _, false)).WillOnce(Return(impi1));
     EXPECT_CALL(*_local_impi_store, delete_impi(impi1, _)).WillOnce(Return(Store::DATA_CONTENTION));
-    EXPECT_CALL(*_local_impi_store, get_impi("impi1", _)).WillOnce(Return(impi1a));
+    EXPECT_CALL(*_local_impi_store, get_impi("impi1", _, false)).WillOnce(Return(impi1a));
     EXPECT_CALL(*_local_impi_store, delete_impi(impi1a, _)).WillOnce(Return(Store::OK));
   }
 

--- a/src/ut/mock_impi_store.h
+++ b/src/ut/mock_impi_store.h
@@ -21,7 +21,7 @@ public:
   virtual ~MockImpiStore() {}
 
   MOCK_METHOD2(set_impi, Store::Status(Impi* impi, SAS::TrailId trail));
-  MOCK_METHOD2(get_impi, Impi*(const std::string& impi, SAS::TrailId trail));
+  MOCK_METHOD3(get_impi, Impi*(const std::string& impi, SAS::TrailId trail, bool include_expired));
   MOCK_METHOD2(delete_impi, Store::Status(Impi* impi, SAS::TrailId trail));
 };
 


### PR DESCRIPTION
This commit adds a boolean to the ImpiStore's `get_impi` method which allows it to include expired challenges. This is passed through to the `from_json` method so that the AuthChallenge will be included even if it's expired when this is set to `true`.

The AstaireImpiStore doesn't use this, to keep the behaviour the same for that.

`make full_test` passes.