### PR TITLE
Log Call-IDs from In-Reply-To headers as markers to SAS

### DIFF
--- a/include/constants.h
+++ b/include/constants.h
@@ -43,6 +43,7 @@ const pj_str_t STR_P_PREFERRED_IDENTITY = pj_str((char*)"P-Preferred-Identity");
 const pj_str_t STR_P_ASSOCIATED_URI = pj_str((char*)"P-Associated-URI");
 const pj_str_t STR_REQUEST_DISPOSITION = pj_str((char*)"Request-Disposition");
 const pj_str_t STR_SERVICE_ROUTE = pj_str((char*)"Service-Route");
+const pj_str_t STR_IN_REPLY_TO = pj_str((char*)"In-Reply-To");
 const pj_str_t STR_ORIG = pj_str((char*)"orig");
 const pj_str_t STR_ORIG_CDIV = pj_str((char*)"orig-cdiv");
 const pj_str_t STR_NO_FORK = pj_str((char*)"no-fork");

--- a/include/pjutils.h
+++ b/include/pjutils.h
@@ -226,7 +226,9 @@ void create_random_token(size_t length, std::string& token);
 
 std::string get_header_value(pjsip_hdr*);
 
-void mark_sas_call_branch_ids(const SAS::TrailId trail, pjsip_cid_hdr* cid_hdr, pjsip_msg* msg);
+void mark_sas_call_branch_ids(const SAS::TrailId trail,
+                              pjsip_msg* msg,
+                              const std::vector<std::string>& cids = std::vector<std::string>());
 
 bool is_emergency_registration(pjsip_contact_hdr* contact_hdr);
 

--- a/src/pjutils.cpp
+++ b/src/pjutils.cpp
@@ -1242,7 +1242,7 @@ pj_status_t PJUtils::send_request(pjsip_tx_data* tdata,
     set_trail(tsx, get_trail(tdata));
     if (log_sas_branch)
     {
-      PJUtils::mark_sas_call_branch_ids(get_trail(tdata), NULL, tdata->msg);
+      PJUtils::mark_sas_call_branch_ids(get_trail(tdata), tdata->msg);
     }
 
     // Set up the module data for the new transaction to reference
@@ -1671,8 +1671,9 @@ std::string PJUtils::get_header_value(pjsip_hdr* header)
   return std::string(buf2, len);
 }
 
-/// Add SAS markers for the specified call ID and branch IDs on the message (call ID may be omitted, but not message).
-void PJUtils::mark_sas_call_branch_ids(const SAS::TrailId trail, pjsip_cid_hdr* cid_hdr, pjsip_msg* msg)
+/// Add SAS markers for the specified call IDs and branch IDs on the message
+// (msg must not be NULL).
+void PJUtils::mark_sas_call_branch_ids(const SAS::TrailId trail, pjsip_msg* msg, const std::vector<std::string>& cids)
 {
   // Decide whether this is a message where we want to correlate on Call-ID or branch ID
   //
@@ -1693,11 +1694,11 @@ void PJUtils::mark_sas_call_branch_ids(const SAS::TrailId trail, pjsip_cid_hdr* 
                                  (pjsip_method_cmp(&msg->line.req.method, pjsip_get_subscribe_method()) == 0) ||
                                  (pjsip_method_cmp(&msg->line.req.method, pjsip_get_notify_method()) == 0)));
 
-  if (cid_hdr != NULL)
+  for (std::string cid : cids)
   {
-    TRC_DEBUG("Logging SAS Call-ID marker, Call-ID %.*s", cid_hdr->id.slen, cid_hdr->id.ptr);
+    TRC_DEBUG("Logging SAS Call-ID marker, Call-ID %s", cid.c_str());
     SAS::Marker cid_marker(trail, MARKER_ID_SIP_CALL_ID, 1u);
-    cid_marker.add_var_param(cid_hdr->id.slen, cid_hdr->id.ptr);
+    cid_marker.add_var_param(cid.size(), (char*)cid.c_str());
     SAS::report_marker(cid_marker, branch_id_correlation ? SAS::Marker::Scope::None : SAS::Marker::Scope::Trace);
   }
 


### PR DESCRIPTION
Idea is to correlate related SIP MESSAGE flows together so they show in SAS as a single trail group (search result). (Fix is limited in scope to SIP MESSAGEs.)

Alex - feel free to assign to someone else, just picked you because of your timely help on the RTR/PPR issue. :-)