### PR TITLE
[Reviewer: Richard] Increase Sprout's timeout to Homestead to 750ms

### DIFF
--- a/include/cfgoptions.h
+++ b/include/cfgoptions.h
@@ -140,6 +140,7 @@ struct options
   bool                                 reject_if_no_matching_ifcs;
   std::string                          dummy_app_server;
   bool                                 http_acr_logging;
+  int                                  homestead_timeout;
 };
 
 // Objects that must be shared with dynamically linked sproutlets must be

--- a/include/hssconnection.h
+++ b/include/hssconnection.h
@@ -42,7 +42,8 @@ public:
                 SNMP::EventAccumulatorTable* homestead_uar_latency_tbl,
                 SNMP::EventAccumulatorTable* homestead_lir_latency_tbl,
                 CommunicationMonitor* comm_monitor,
-                SIFCService* sifc_service);
+                SIFCService* sifc_service,
+                long homestead_timeout_ms);
   virtual ~HSSConnection();
 
   HTTPCode get_auth_vector(const std::string& private_user_id,

--- a/sprout-base.root/etc/init.d/sprout
+++ b/sprout-base.root/etc/init.d/sprout
@@ -105,7 +105,7 @@ get_settings()
         # Calculate the correct homestead latency:
         #  - if we have sprout_homestead_timeout_ms set, use that
         #  - else:
-        #    - if we have diameter_timeout_ms set, use 550 + that
+        #    - if we have diameter_timeout_ms set, use 550 + double that
         #    - else use 750
         if [ -z "$sprout_homestead_timeout_ms" ];
         then
@@ -113,7 +113,7 @@ get_settings()
           then
             sprout_homestead_timeout_ms=750
           else
-            sprout_homestead_timeout_ms=$((diameter_timeout_ms + 550))
+            sprout_homestead_timeout_ms=$((diameter_timeout_ms * 2 + 550))
           fi
         fi
 

--- a/sprout-base.root/etc/init.d/sprout
+++ b/sprout-base.root/etc/init.d/sprout
@@ -102,6 +102,21 @@ get_settings()
         authentication=Y
         . /etc/clearwater/config
 
+        # Calculate the correct homestead latency:
+        #  - if we have sprout_homestead_timeout_ms set, use that
+        #  - else:
+        #    - if we have diameter_timeout_ms set, use 550 + that
+        #    - else use 750
+        if [ -z "$sprout_homestead_timeout_ms" ];
+        then
+          if [ -z "$diameter_timeout_ms" ];
+          then
+            sprout_homestead_timeout_ms=750
+          else
+            sprout_homestead_timeout_ms=$((diameter_timeout_ms + 550))
+          fi
+        fi
+
         # Work out which features are enabled.
         MMTEL_SERVICES_ENABLED=Y
         if [ -d /etc/clearwater/features.d ]
@@ -205,7 +220,8 @@ get_daemon_args()
                      --analytics=$log_directory
                      --log-file=$log_directory
                      --log-level=$log_level
-                     --alias=$public_ip,$public_hostname,$alias_list"
+                     --alias=$public_ip,$public_hostname,$alias_list
+                     --homestead-timeout=$sprout_homestead_timeout_ms"
 
         if [ -n "$reg_max_expires" ]
         then

--- a/src/hssconnection.cpp
+++ b/src/hssconnection.cpp
@@ -26,6 +26,8 @@
 #include "xml_utils.h"
 #include "sprout_xml_utils.h"
 
+const long HOMESTEAD_TIMEOUT_MS = 750;
+
 const std::string HSSConnection::REG = "reg";
 const std::string HSSConnection::CALL = "call";
 const std::string HSSConnection::DEREG_USER = "dereg-user";
@@ -51,7 +53,11 @@ HSSConnection::HSSConnection(const std::string& server,
                            homestead_count_tbl,
                            load_monitor,
                            SASEvent::HttpLogLevel::PROTOCOL,
-                           comm_monitor)),
+                           comm_monitor,
+                           "http",
+                           false,
+                           false,
+                           HOMESTEAD_TIMEOUT_MS)),
   _latency_tbl(homestead_overall_latency_tbl),
   _mar_latency_tbl(homestead_mar_latency_tbl),
   _sar_latency_tbl(homestead_sar_latency_tbl),

--- a/src/hssconnection.cpp
+++ b/src/hssconnection.cpp
@@ -26,8 +26,6 @@
 #include "xml_utils.h"
 #include "sprout_xml_utils.h"
 
-const long HOMESTEAD_TIMEOUT_MS = 750;
-
 const std::string HSSConnection::REG = "reg";
 const std::string HSSConnection::CALL = "call";
 const std::string HSSConnection::DEREG_USER = "dereg-user";
@@ -46,7 +44,8 @@ HSSConnection::HSSConnection(const std::string& server,
                              SNMP::EventAccumulatorTable* homestead_uar_latency_tbl,
                              SNMP::EventAccumulatorTable* homestead_lir_latency_tbl,
                              CommunicationMonitor* comm_monitor,
-                             SIFCService* sifc_service) :
+                             SIFCService* sifc_service,
+                             long homestead_timeout_ms) :
   _http(new HttpConnection(server,
                            false,
                            resolver,
@@ -57,7 +56,7 @@ HSSConnection::HSSConnection(const std::string& server,
                            "http",
                            false,
                            false,
-                           HOMESTEAD_TIMEOUT_MS)),
+                           homestead_timeout_ms)),
   _latency_tbl(homestead_overall_latency_tbl),
   _mar_latency_tbl(homestead_mar_latency_tbl),
   _sar_latency_tbl(homestead_sar_latency_tbl),

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -444,7 +444,7 @@ static void usage(void)
        "                            then the iFC is skipped over.\n"
        "     --http-acr-logging     Whether to include the bodies of ACR HTTP requests when they are logged \n"
        "                            to SAS\n"
-       "     --homestead-timeout    The timeout to use on HTTP requests to Homestead\n"
+       "     --homestead-timeout    The timeout in ms to use on HTTP requests to Homestead\n"
        " -N, --plugin-option <plugin>,<name>,<value>\n"
        "                            Provide an option value to a plugin.\n"
        " -F, --log-file <directory>\n"

--- a/src/ut/fakehssconnection.cpp
+++ b/src/ut/fakehssconnection.cpp
@@ -33,7 +33,8 @@ FakeHSSConnection::FakeHSSConnection(MockHSSConnection* hss_connection_observer)
                 &SNMP::FAKE_EVENT_ACCUMULATOR_TABLE,
                 &SNMP::FAKE_EVENT_ACCUMULATOR_TABLE,
                 NULL,
-                NULL)
+                NULL,
+                0)
 {
   _hss_connection_observer = hss_connection_observer;
 }

--- a/src/ut/hssconnection_test.cpp
+++ b/src/ut/hssconnection_test.cpp
@@ -52,7 +52,8 @@ class HssConnectionTest : public BaseTest
          &SNMP::FAKE_EVENT_ACCUMULATOR_TABLE,
          &SNMP::FAKE_EVENT_ACCUMULATOR_TABLE,
          &_cm,
-         NULL)
+         NULL,
+         500)
     {
     fakecurl_responses.clear();
     fakecurl_responses_with_body[std::make_pair("http://10.42.42.42:80/impu/pubid42/reg-data", "{\"reqtype\": \"reg\", \"server_name\": \"server_name\"}")] =
@@ -726,7 +727,8 @@ class HssWithSifcTest : public BaseTest
               &SNMP::FAKE_EVENT_ACCUMULATOR_TABLE,
               &SNMP::FAKE_EVENT_ACCUMULATOR_TABLE,
               NULL,
-              &_sifc_service)
+              &_sifc_service,
+              500)
   {
     fakecurl_responses.clear();
     fakecurl_responses_with_body[std::make_pair("http://10.42.42.42:80/impu/onesifc/reg-data", "{\"reqtype\": \"reg\", \"server_name\": \"server_name\"}")] =

--- a/src/ut/mock_hss_connection.h
+++ b/src/ut/mock_hss_connection.h
@@ -30,7 +30,8 @@ public:
                                       &SNMP::FAKE_EVENT_ACCUMULATOR_TABLE,
                                       &SNMP::FAKE_EVENT_ACCUMULATOR_TABLE,
                                       NULL,
-                                      NULL) {};
+                                      NULL,
+                                      0) {};
   virtual ~MockHSSConnection() {};
 
   MOCK_METHOD5(update_registration_state,


### PR DESCRIPTION
This change is to accompany https://github.com/Metaswitch/homestead/pull/475

We expect that initial registers will take over 500ms in a GR deployment, so we need to increase the timeout Sprout specifies on its requests to Homestead. It defaulted to 500ms before, but this increases it to 750ms.

(All the other options in the constructor are the defaults from https://github.com/Metaswitch/cpp-common/blob/master/include/httpconnection.h#L31)

`make full_test` and the live tests pass.