### PR TITLE
[Reviewer: Adam] Scscf uri on as chain

### DIFF
--- a/include/aschain.h
+++ b/include/aschain.h
@@ -92,7 +92,8 @@ private:
           Ifcs& ifcs,
           ACR* acr,
           FIFCService* fifc_service,
-          IFCConfiguration ifc_configuration);
+          IFCConfiguration ifc_configuration,
+          std::string scscf_uri);
   ~AsChain();
 
   bool inc_ref()
@@ -166,6 +167,9 @@ private:
   IFCConfiguration _ifc_configuration;
   bool _using_standard_ifcs;
   rapidxml::xml_document<>* _root;
+
+  // The S-CSCF URI for which this AsChain was created
+  const std::string _scscf_uri;
 };
 
 
@@ -288,6 +292,11 @@ public:
     return _default_handling;
   }
 
+  std::string scscf_uri()
+  {
+    return (_as_chain != NULL) ? _as_chain->_scscf_uri : "";
+  }
+
   /// Called on receipt of each response from the AS.
   void on_response(int status_code);
 
@@ -320,7 +329,8 @@ public:
                                      Ifcs& ifcs,
                                      ACR* acr,
                                      FIFCService* fifc_service,
-                                     IFCConfiguration ifc_configuration);
+                                     IFCConfiguration ifc_configuration,
+                                     std::string scscf_uri);
 
   pjsip_status_code on_initial_request(pjsip_msg* msg,
                                        std::string& server_name,

--- a/src/aschain.cpp
+++ b/src/aschain.cpp
@@ -33,7 +33,8 @@ AsChain::AsChain(AsChainTable* as_chain_table,
                  Ifcs& ifcs,
                  ACR* acr,
                  FIFCService* fifc_service,
-                 IFCConfiguration ifc_configuration) :
+                 IFCConfiguration ifc_configuration,
+                 std::string scscf_uri) :
   _as_chain_table(as_chain_table),
   _refs(1),  // for the initial chain link being returned
   _as_info(ifcs.size() + 1),
@@ -48,7 +49,8 @@ AsChain::AsChain(AsChainTable* as_chain_table,
   _fallback_ifcs({}),
   _ifc_configuration(ifc_configuration),
   _using_standard_ifcs(true),
-  _root(NULL)
+  _root(NULL),
+  _scscf_uri(scscf_uri)
 {
   TRC_DEBUG("Creating AsChain %p with %d iFCs and adding to map", this, ifcs.size());
   _as_chain_table->register_(this, _odi_tokens);
@@ -151,7 +153,8 @@ AsChainLink AsChainLink::create_as_chain(AsChainTable* as_chain_table,
                                          Ifcs& ifcs,
                                          ACR* acr,
                                          FIFCService* fifc_service,
-                                         IFCConfiguration ifc_configuration)
+                                         IFCConfiguration ifc_configuration,
+                                         std::string scscf_uri)
 {
   AsChain* as_chain = new AsChain(as_chain_table,
                                   session_case,
@@ -161,7 +164,8 @@ AsChainLink AsChainLink::create_as_chain(AsChainTable* as_chain_table,
                                   ifcs,
                                   acr,
                                   fifc_service,
-                                  ifc_configuration);
+                                  ifc_configuration,
+                                  scscf_uri);
   return AsChainLink(as_chain, 0u);
 }
 

--- a/src/scscfsproutlet.cpp
+++ b/src/scscfsproutlet.cpp
@@ -586,7 +586,6 @@ void SCSCFSproutletTsx::on_rx_initial_request(pjsip_msg* req)
   // It will also set the S-CSCF URI
   status_code = determine_served_user(req);
 
-
   // Pass the received request to the ACR.
   // @TODO - request timestamp???
   ACR* acr = get_acr();

--- a/src/scscfsproutlet.cpp
+++ b/src/scscfsproutlet.cpp
@@ -580,20 +580,12 @@ void SCSCFSproutletTsx::on_rx_initial_request(pjsip_msg* req)
     }
   }
 
-  // Construct the S-CSCF URI for this transaction. Use the configured S-CSCF
-  // URI as a starting point.
-  pjsip_sip_uri* scscf_uri = (pjsip_sip_uri*)pjsip_uri_clone(get_pool(req), _scscf->_scscf_cluster_uri);
-  pjsip_sip_uri* routing_uri = get_routing_uri(req);
-  SCSCFUtils::get_scscf_uri(get_pool(req),
-                            get_local_hostname(routing_uri),
-                            get_local_hostname(scscf_uri),
-                            scscf_uri);
-  _scscf_uri = PJUtils::uri_to_string(PJSIP_URI_IN_ROUTING_HDR, (pjsip_uri*)scscf_uri);
-
   // Determine the session case and the served user.  This will link to
   // an AsChain object (creating it if necessary), if we need to provide
   // services.
+  // It will also set the S-CSCF URI
   status_code = determine_served_user(req);
+
 
   // Pass the received request to the ACR.
   // @TODO - request timestamp???
@@ -1115,6 +1107,9 @@ pjsip_status_code SCSCFSproutletTsx::determine_served_user(pjsip_msg* req)
 
   if (_as_chain_link.is_set())
   {
+    // Set the S-CSCF URI to the one we stored in the AsChain
+    _scscf_uri = _as_chain_link.scscf_uri();
+
     bool retargeted = false;
     std::string served_user = served_user_from_msg(req);
 
@@ -1283,6 +1278,16 @@ pjsip_status_code SCSCFSproutletTsx::determine_served_user(pjsip_msg* req)
         }
       }
 
+      // Before looking up the iFCs, calculate the S-CSCF URI to use for this
+      // transaction, using the configured S-CSCF URI as a starting point.
+      pjsip_sip_uri* scscf_uri = (pjsip_sip_uri*)pjsip_uri_clone(get_pool(req), _scscf->_scscf_cluster_uri);
+      pjsip_sip_uri* routing_uri = get_routing_uri(req);
+      SCSCFUtils::get_scscf_uri(get_pool(req),
+                                get_local_hostname(routing_uri),
+                                get_local_hostname(scscf_uri),
+                                scscf_uri);
+      _scscf_uri = PJUtils::uri_to_string(PJSIP_URI_IN_ROUTING_HDR, (pjsip_uri*)scscf_uri);
+
       TRC_DEBUG("Looking up iFCs for %s for new AS chain", served_user.c_str());
 
       Ifcs ifcs;
@@ -1381,8 +1386,8 @@ std::string SCSCFSproutletTsx::served_user_from_msg(pjsip_msg* msg)
         ((uri_class == NODE_LOCAL_SIP_URI) ||
          (uri_class == HOME_DOMAIN_SIP_URI) ||
          (uri_class == LOCAL_PHONE_NUMBER) ||
-         (uri_class == GLOBAL_PHONE_NUMBER) 
-         )) 
+         (uri_class == GLOBAL_PHONE_NUMBER)
+         ))
         || (PJSIP_URI_SCHEME_IS_TEL(uri)))
     {
       user = PJUtils::public_id_from_uri(uri);
@@ -1413,7 +1418,8 @@ AsChainLink SCSCFSproutletTsx::create_as_chain(Ifcs ifcs,
                                                  ifcs,
                                                  acr,
                                                  _scscf->fifcservice(),
-                                                 _scscf->ifc_configuration());
+                                                 _scscf->ifc_configuration(),
+                                                 _scscf_uri);
   acr = NULL;
   TRC_DEBUG("S-CSCF sproutlet transaction %p linked to AsChain %s",
             this, ret.to_string().c_str());
@@ -1917,7 +1923,7 @@ void SCSCFSproutletTsx::route_to_ue_bindings(pjsip_msg* req)
       event.add_var_param(public_id);
       SAS::report_event(event);
     }
-    
+
     delete aor_pair; aor_pair = NULL;
   }
   else
@@ -2019,7 +2025,7 @@ long SCSCFSproutletTsx::get_data_from_hss(std::string public_id)
 
 
 /// Look up the registration state for the given public ID, using the
-/// per-transaction cache, which will be present at this point 
+/// per-transaction cache, which will be present at this point
 bool SCSCFSproutletTsx::is_user_registered(std::string public_id)
 {
   return _registered;

--- a/src/ut/aschain_test.cpp
+++ b/src/ut/aschain_test.cpp
@@ -136,15 +136,15 @@ TEST_F(AsChainTest, Basics)
 {
   IFCConfiguration ifc_configuration(false, false, "", &SNMP::FAKE_COUNTER_TABLE, &SNMP::FAKE_COUNTER_TABLE);
   Ifcs ifcs1 = matching_ifcs(0);
-  AsChain as_chain(_as_chain_table, SessionCase::Originating, "sip:5755550011@homedomain", true, 0, ifcs1, NULL, NULL, ifc_configuration);
+  AsChain as_chain(_as_chain_table, SessionCase::Originating, "sip:5755550011@homedomain", true, 0, ifcs1, NULL, NULL, ifc_configuration, "sip:scscf.homedomain");
   AsChainLink as_chain_link(&as_chain, 0u);
 
   Ifcs ifcs2 = matching_ifcs(1, "sip:pancommunicon.cw-ngv.com");
-  AsChain as_chain2(_as_chain_table, SessionCase::Originating, "sip:5755550011@homedomain", true, 0, ifcs2, NULL, NULL, ifc_configuration);
+  AsChain as_chain2(_as_chain_table, SessionCase::Originating, "sip:5755550011@homedomain", true, 0, ifcs2, NULL, NULL, ifc_configuration, "sip:scscf.homedomain");
   AsChainLink as_chain_link2(&as_chain2, 0u);
 
   Ifcs ifcs3 = matching_ifcs(2, "sip:pancommunicon.cw-ngv.com", "sip:mmtel.homedomain");
-  AsChain as_chain3(_as_chain_table, SessionCase::Originating, "sip:5755550011@homedomain", true, 0, ifcs3, NULL, NULL, ifc_configuration);
+  AsChain as_chain3(_as_chain_table, SessionCase::Originating, "sip:5755550011@homedomain", true, 0, ifcs3, NULL, NULL, ifc_configuration, "sip:scscf.homedomain");
   AsChainLink as_chain_link3(&as_chain3, 0u);
 
   EXPECT_THAT(as_chain_link.to_string(), testing::MatchesRegex("AsChain-orig\\[0x[0-9a-f]+\\]:1/0"));
@@ -168,7 +168,7 @@ TEST_F(AsChainTest, MatchingStandardiFCs)
 {
   IFCConfiguration ifc_configuration(false, false, "", &SNMP::FAKE_COUNTER_TABLE, &SNMP::FAKE_COUNTER_TABLE);
   Ifcs ifcs = matching_ifcs(2, "sip:as1", "sip:as2");
-  AsChain as_chain(_as_chain_table, SessionCase::Originating, "sip:5755550011@homedomain", true, 0, ifcs, NULL, NULL, ifc_configuration);
+  AsChain as_chain(_as_chain_table, SessionCase::Originating, "sip:5755550011@homedomain", true, 0, ifcs, NULL, NULL, ifc_configuration, "sip:scscf.homedomain");
   AsChainLink as_chain_link(&as_chain, 0u);
 
   pjsip_tx_data* tdata = NULL;
@@ -199,7 +199,7 @@ TEST_F(AsChainTest, NoMatchingStandardiFCs)
 {
   IFCConfiguration ifc_configuration(false, false, "", &SNMP::FAKE_COUNTER_TABLE, &SNMP::FAKE_COUNTER_TABLE);
   Ifcs ifcs = non_matching_ifcs(2, "sip:as1", "sip:as2");
-  AsChain as_chain(_as_chain_table, SessionCase::Originating, "sip:5755550011@homedomain", true, 0, ifcs, NULL, NULL, ifc_configuration);
+  AsChain as_chain(_as_chain_table, SessionCase::Originating, "sip:5755550011@homedomain", true, 0, ifcs, NULL, NULL, ifc_configuration, "sip:scscf.homedomain");
   AsChainLink as_chain_link(&as_chain, 0u);
 
   pjsip_tx_data* tdata = NULL;
@@ -218,7 +218,7 @@ TEST_F(AsChainTest, MatchingStandardiFCsRejectIfNone)
 {
   IFCConfiguration ifc_configuration(false, true, "", &SNMP::FAKE_COUNTER_TABLE, &SNMP::FAKE_COUNTER_TABLE);
   Ifcs ifcs = matching_ifcs(1, "sip:as1");
-  AsChain as_chain(_as_chain_table, SessionCase::Originating, "sip:5755550011@homedomain", true, 0, ifcs, NULL, NULL, ifc_configuration);
+  AsChain as_chain(_as_chain_table, SessionCase::Originating, "sip:5755550011@homedomain", true, 0, ifcs, NULL, NULL, ifc_configuration, "sip:scscf.homedomain");
   AsChainLink as_chain_link(&as_chain, 0u);
 
   pjsip_tx_data* tdata = NULL;
@@ -237,7 +237,7 @@ TEST_F(AsChainTest, NoMatchingStandardiFCsRejectIfNone)
 {
   IFCConfiguration ifc_configuration(false, true, "", &SNMP::FAKE_COUNTER_TABLE, &SNMP::FAKE_COUNTER_TABLE);
   Ifcs ifcs = non_matching_ifcs(2, "sip:as1", "sip:as2");
-  AsChain as_chain(_as_chain_table, SessionCase::Originating, "sip:5755550011@homedomain", true, 0, ifcs, NULL, NULL, ifc_configuration);
+  AsChain as_chain(_as_chain_table, SessionCase::Originating, "sip:5755550011@homedomain", true, 0, ifcs, NULL, NULL, ifc_configuration, "sip:scscf.homedomain");
   AsChainLink as_chain_link(&as_chain, 0u);
 
   pjsip_tx_data* tdata = NULL;
@@ -256,7 +256,7 @@ TEST_F(AsChainTest, MatchingStandardiFCsWithMatchingFallbackiFCs)
   IFCConfiguration ifc_configuration(true, true, "", &SNMP::FAKE_COUNTER_TABLE, &SNMP::FAKE_COUNTER_TABLE);
   Ifcs ifcs = matching_ifcs(2, "sip:as1", "sip:as2");
   Ifcs fallback_ifcs = matching_ifcs(2, "sip:fallback_as2", "sip:fallback_as2");
-  AsChain as_chain(_as_chain_table, SessionCase::Originating, "sip:5755550011@homedomain", true, 0, ifcs, NULL, NULL, ifc_configuration);
+  AsChain as_chain(_as_chain_table, SessionCase::Originating, "sip:5755550011@homedomain", true, 0, ifcs, NULL, NULL, ifc_configuration, "sip:scscf.homedomain");
   as_chain._fallback_ifcs = fallback_ifcs.ifcs_list();
   AsChainLink as_chain_link(&as_chain, 0u);
 
@@ -286,7 +286,7 @@ TEST_F(AsChainTest, NoMatchingStandardiFCsWithFallbackiFCs)
   IFCConfiguration ifc_configuration(true, true, "", &SNMP::FAKE_COUNTER_TABLE, &SNMP::FAKE_COUNTER_TABLE);
   Ifcs ifcs = non_matching_ifcs(2, "sip:as1", "sip:as2");
   Ifcs fallback_ifcs = matching_ifcs(2, "sip:fallback_as1", "sip:fallback_as2");
-  AsChain as_chain(_as_chain_table, SessionCase::Originating, "sip:5755550011@homedomain", true, 0, ifcs, NULL, NULL, ifc_configuration);
+  AsChain as_chain(_as_chain_table, SessionCase::Originating, "sip:5755550011@homedomain", true, 0, ifcs, NULL, NULL, ifc_configuration, "sip:scscf.homedomain");
   as_chain._fallback_ifcs = fallback_ifcs.ifcs_list();
   AsChainLink as_chain_link(&as_chain, 0u);
 
@@ -316,7 +316,7 @@ TEST_F(AsChainTest, NoStandardIFCsWithFallbackIFCs)
   IFCConfiguration ifc_configuration(true, true, "", &SNMP::FAKE_COUNTER_TABLE, &SNMP::FAKE_COUNTER_TABLE);
   Ifcs ifcs = non_matching_ifcs(0);
   Ifcs fallback_ifcs = matching_ifcs(2, "sip:fallback_as1", "sip:fallback_as2");
-  AsChain as_chain(_as_chain_table, SessionCase::Originating, "sip:5755550011@homedomain", true, 0, ifcs, NULL, NULL, ifc_configuration);
+  AsChain as_chain(_as_chain_table, SessionCase::Originating, "sip:5755550011@homedomain", true, 0, ifcs, NULL, NULL, ifc_configuration, "sip:scscf.homedomain");
   as_chain._fallback_ifcs = fallback_ifcs.ifcs_list();
   AsChainLink as_chain_link(&as_chain, 0u);
 
@@ -346,7 +346,7 @@ TEST_F(AsChainTest, NoMatchingStandardOrFallbackiFCs)
   IFCConfiguration ifc_configuration(true, false, "", &SNMP::FAKE_COUNTER_TABLE, &SNMP::FAKE_COUNTER_TABLE);
   Ifcs ifcs = non_matching_ifcs(2, "sip:as1", "sip:as2");
   Ifcs fallback_ifcs = non_matching_ifcs(2, "sip:fallback_as2", "sip:fallback_as2");
-  AsChain as_chain(_as_chain_table, SessionCase::Originating, "sip:5755550011@homedomain", true, 0, ifcs, NULL, NULL, ifc_configuration);
+  AsChain as_chain(_as_chain_table, SessionCase::Originating, "sip:5755550011@homedomain", true, 0, ifcs, NULL, NULL, ifc_configuration, "sip:scscf.homedomain");
   as_chain._fallback_ifcs = fallback_ifcs.ifcs_list();
   AsChainLink as_chain_link(&as_chain, 0u);
 
@@ -366,7 +366,7 @@ TEST_F(AsChainTest, NoMatchingStandardOrFallbackiFCsWithReject)
   IFCConfiguration ifc_configuration(true, true, "", &SNMP::FAKE_COUNTER_TABLE, &SNMP::FAKE_COUNTER_TABLE);
   Ifcs ifcs = non_matching_ifcs(2, "sip:as1", "sip:as2");
   Ifcs fallback_ifcs = non_matching_ifcs(2, "sip:fallback_as2", "sip:fallback_as2");
-  AsChain as_chain(_as_chain_table, SessionCase::Originating, "sip:5755550011@homedomain", true, 0, ifcs, NULL, NULL, ifc_configuration);
+  AsChain as_chain(_as_chain_table, SessionCase::Originating, "sip:5755550011@homedomain", true, 0, ifcs, NULL, NULL, ifc_configuration, "sip:scscf.homedomain");
   as_chain._fallback_ifcs = fallback_ifcs.ifcs_list();
   AsChainLink as_chain_link(&as_chain, 0u);
 
@@ -387,7 +387,7 @@ TEST_F(AsChainTest, NoMatchingStandardMatchingDefaultiFCsWithReject)
   IFCConfiguration ifc_configuration(true, true, "", &SNMP::FAKE_COUNTER_TABLE, &SNMP::FAKE_COUNTER_TABLE);
   Ifcs ifcs = non_matching_ifcs(2, "sip:as1", "sip:as2");
   Ifcs fallback_ifcs = matching_ifcs(1, "sip:fallback_as");
-  AsChain as_chain(_as_chain_table, SessionCase::Originating, "sip:5755550011@homedomain", true, 0, ifcs, NULL, NULL, ifc_configuration);
+  AsChain as_chain(_as_chain_table, SessionCase::Originating, "sip:5755550011@homedomain", true, 0, ifcs, NULL, NULL, ifc_configuration, "sip:scscf.homedomain");
   as_chain._fallback_ifcs = fallback_ifcs.ifcs_list();
   AsChainLink as_chain_link(&as_chain, 0u);
 
@@ -410,7 +410,7 @@ TEST_F(AsChainTest, MatchingStandardiFCDummyAppServer)
   // the AS Chain with AS2 set up as a dummy application server.
   IFCConfiguration ifc_configuration(false, false, "sip:AS2", &SNMP::FAKE_COUNTER_TABLE, &SNMP::FAKE_COUNTER_TABLE);
   Ifcs ifcs = matching_ifcs(3, "sip:AS1", "sip:AS2", "sip:AS3");
-  AsChain as_chain(_as_chain_table, SessionCase::Originating, "sip:5755550011@homedomain", true, 0, ifcs, NULL, NULL, ifc_configuration);
+  AsChain as_chain(_as_chain_table, SessionCase::Originating, "sip:5755550011@homedomain", true, 0, ifcs, NULL, NULL, ifc_configuration, "sip:scscf.homedomain");
   AsChainLink as_chain_link(&as_chain, 0u);
 
   pjsip_tx_data* tdata = NULL;
@@ -444,7 +444,7 @@ TEST_F(AsChainTest, MatchingStandardiFCOnlyDummyAppServer)
   // the AS Chain with AS2 set up as a dummy application server.
   IFCConfiguration ifc_configuration(false, false, "sip:dummy_as", &SNMP::FAKE_COUNTER_TABLE, &SNMP::FAKE_COUNTER_TABLE);
   Ifcs ifcs = matching_ifcs(1, "sip:dummy_as");
-  AsChain as_chain(_as_chain_table, SessionCase::Originating, "sip:5755550011@homedomain", true, 0, ifcs, NULL, NULL, ifc_configuration);
+  AsChain as_chain(_as_chain_table, SessionCase::Originating, "sip:5755550011@homedomain", true, 0, ifcs, NULL, NULL, ifc_configuration, "sip:scscf.homedomain");
   AsChainLink as_chain_link(&as_chain, 0u);
 
   pjsip_tx_data* tdata = NULL;
@@ -465,7 +465,7 @@ TEST_F(AsChainTest, MatchingStandardiFCOnlyDummyAppServerWithReject)
   // the AS Chain with AS2 set up as a dummy application server.
   IFCConfiguration ifc_configuration(false, true, "sip:dummy_as", &SNMP::FAKE_COUNTER_TABLE, &SNMP::FAKE_COUNTER_TABLE);
   Ifcs ifcs = matching_ifcs(1, "sip:dummy_as");
-  AsChain as_chain(_as_chain_table, SessionCase::Originating, "sip:5755550011@homedomain", true, 0, ifcs, NULL, NULL, ifc_configuration);
+  AsChain as_chain(_as_chain_table, SessionCase::Originating, "sip:5755550011@homedomain", true, 0, ifcs, NULL, NULL, ifc_configuration, "sip:scscf.homedomain");
   AsChainLink as_chain_link(&as_chain, 0u);
 
   pjsip_tx_data* tdata = NULL;
@@ -487,7 +487,7 @@ TEST_F(AsChainTest, MatchingStandardiFCOnlyDummyAppServerWithFallbackiFCs)
   IFCConfiguration ifc_configuration(true, true, "sip:dummy_as", &SNMP::FAKE_COUNTER_TABLE, &SNMP::FAKE_COUNTER_TABLE);
   Ifcs ifcs = matching_ifcs(1, "sip:dummy_as");
   Ifcs fallback_ifcs = matching_ifcs(1, "sip:fallback_as1");
-  AsChain as_chain(_as_chain_table, SessionCase::Originating, "sip:5755550011@homedomain", true, 0, ifcs, NULL, NULL, ifc_configuration);
+  AsChain as_chain(_as_chain_table, SessionCase::Originating, "sip:5755550011@homedomain", true, 0, ifcs, NULL, NULL, ifc_configuration, "sip:scscf.homedomain");
   as_chain._fallback_ifcs = fallback_ifcs.ifcs_list();
   AsChainLink as_chain_link(&as_chain, 0u);
 

--- a/src/ut/scscf_test.cpp
+++ b/src/ut/scscf_test.cpp
@@ -6914,6 +6914,15 @@ TEST_F(SCSCFTest, OriginatingTerminatingAS)
 
   EXPECT_EQ(1, ((SNMP::FakeEventAccumulatorTable*)_scscf_sproutlet->_audio_session_setup_time_tbl)->_count);
   EXPECT_EQ(0, ((SNMP::FakeEventAccumulatorTable*)_scscf_sproutlet->_video_session_setup_time_tbl)->_count);
+
+  // Make sure that we haven't sent a request to homestead with 127.0.0.1 as the domain of the S-CSCF URI
+  bool found_wrong_uri = false;
+  for (FakeHSSConnection::UrlBody body : _hss_connection->_calls)
+  {
+    found_wrong_uri |= (!(body.second.find("127.0.0.1") == std::string::npos));
+  }
+
+  EXPECT_FALSE(found_wrong_uri);
 }
 
 

--- a/src/ut/scscf_test.cpp
+++ b/src/ut/scscf_test.cpp
@@ -2554,11 +2554,11 @@ TEST_F(SCSCFTest, TestSimpleMultipart)
   list<HeaderMatcher> hdrs;
   // Check that the Content-Type manipulation in PJSIP has not inserted multiple
   // Content-Types in the bodyparts
-  doSuccessfulFlow(msg, 
-                   testing::MatchesRegex(".*wuntootreefower.*"), 
-                   hdrs, 
-                   true, 
-                   list<HeaderMatcher>(), 
+  doSuccessfulFlow(msg,
+                   testing::MatchesRegex(".*wuntootreefower.*"),
+                   hdrs,
+                   true,
+                   list<HeaderMatcher>(),
                    ".*--\\S+\r\nContent-Length: 343\r\nContent-Type: application/sdp\r\n\r\n.*");
 }
 
@@ -3559,7 +3559,7 @@ TEST_F(SCSCFTest, DefaultHandlingTerminate)
 
 
 // Bug for both session terminated and session continue (see clearwater-issues)
-// When liveness timer pops before SIP response is received from AS, Sprout 
+// When liveness timer pops before SIP response is received from AS, Sprout
 // doesn't send immediate failure upstream but keeps retrying.
 // Currently the test is made to pass superficially to achieve full coverage
 TEST_F(SCSCFTest, DefaultHandlingTerminateTimeout)
@@ -3579,7 +3579,7 @@ TEST_F(SCSCFTest, DefaultHandlingTerminateTimeout)
                                    "UNREGISTERED",
                                    subscription.return_sub());
 
-  // The tracker should be called only once. Currently there is a code bug that 
+  // The tracker should be called only once. Currently there is a code bug that
   // Sprout keeps retrying if liveness timer pops before AS response is
   // received. So the tracker are being  called several times.
   EXPECT_CALL(*_sess_term_comm_tracker, on_failure(_, HasSubstr("timeout"))).Times(AtLeast(1));
@@ -6915,7 +6915,11 @@ TEST_F(SCSCFTest, OriginatingTerminatingAS)
   EXPECT_EQ(1, ((SNMP::FakeEventAccumulatorTable*)_scscf_sproutlet->_audio_session_setup_time_tbl)->_count);
   EXPECT_EQ(0, ((SNMP::FakeEventAccumulatorTable*)_scscf_sproutlet->_video_session_setup_time_tbl)->_count);
 
-  // Make sure that we haven't sent a request to homestead with 127.0.0.1 as the domain of the S-CSCF URI
+  // Make sure that we haven't sent a request to homestead with 127.0.0.1 as the
+  // domain of the S-CSCF URI.
+  // This used to happen when a request was routed to an App Server and back,
+  // and resulted in Homestead making a request to the HSS with the wrong S-CSCF
+  // URI
   bool found_wrong_uri = false;
   for (FakeHSSConnection::UrlBody body : _hss_connection->_calls)
   {
@@ -8625,7 +8629,7 @@ TEST_F(SCSCFTest, HSSTimeoutOnCdiv)
 
 
 // Test that a failure to get iFCs due to a 404 error from homestead during Call
-// Diversion result in AS sending a 404 error 
+// Diversion result in AS sending a 404 error
 TEST_F(SCSCFTest, HSSNotFoundOnCdiv)
 {
   ServiceProfileBuilder service_profile = ServiceProfileBuilder()
@@ -9738,14 +9742,14 @@ class SCSCFTestWithoutICSCF : public SCSCFTestBase
                                 additional_home_domains,
                                 sproutlets,
                                 std::set<std::string>());
-  }  
+  }
 
   ~SCSCFTestWithoutICSCF()
   {
   }
 };
 
-// Test routing directly to local SCSCF when ICSCF is disabled 
+// Test routing directly to local SCSCF when ICSCF is disabled
 TEST_F(SCSCFTestWithoutICSCF, TestRouteWithoutICSCF)
 {
   SCOPED_TRACE("");
@@ -9862,7 +9866,7 @@ LocalStore* SCSCFTestWithRemoteSDM::_remote_data_store;
 AstaireAoRStore* SCSCFTestWithRemoteSDM::_remote_aor_store;
 SubscriberDataManager* SCSCFTestWithRemoteSDM::_remote_sdm;
 
-//Get bindings from remote store if the AOR is not registered with local store 
+//Get bindings from remote store if the AOR is not registered with local store
 TEST_F(SCSCFTestWithRemoteSDM, TestGetBindingFromRemoteStore)
 {
   register_uri(_remote_sdm, _hss_connection, "6505551234", "homedomain", "sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob");


### PR DESCRIPTION
This PR is a fix for https://github.com/Metaswitch/clearwater-issues/issues/2418

There's lots of detail in the issue, but in summary:

A change was made recently to allow Sprout to calculate the S-CSCF URI based on the route header that routed the request to Sprout, as that's usually what we want to do. However, when Sprout routes a request via an AS, the route header that routes the request back to Sprout will have Sprout's IP address in it, so the ScscfSproutlet was setting the S-CSCF URI to its IP address. It then sends this to Homestead, which may send it to the HSS on an SAR, which is bad.

This fix is to store the S-CSCF URI on the AsChain when we first create it. Then, when we get the request back from the AS, we correlate that transaction to the AsChain and retrieve the S-CSCF URI from the AsChain. This ensures that the S-CSCF uri that we send to Homestead is the one that we decided on when Sprout received the initial request.

For ASs which retarget the request, we leave the S-CSCF URI as it was originally.

#### Testing:
* I've added a check to an existing UT that failed before I added this code, and now passes.
* `make full_test` passes
* I've live tested and verified that a deployment which hit the issue before now doesn't