### PR TITLE
[Reviewer: Richard] Increase Sprout's default timeout for Homestead connections

### DIFF
--- a/sprout-base.root/etc/init.d/sprout
+++ b/sprout-base.root/etc/init.d/sprout
@@ -105,15 +105,15 @@ get_settings()
         # Calculate the correct homestead latency:
         #  - if we have sprout_homestead_timeout_ms set, use that
         #  - else:
-        #    - if we have diameter_timeout_ms set, use 550 + double that
-        #    - else use 750
+        #    - if we have diameter_timeout_ms set, use 1000 + double that
+        #    - else use 1200
         if [ -z "$sprout_homestead_timeout_ms" ];
         then
           if [ -z "$diameter_timeout_ms" ];
           then
-            sprout_homestead_timeout_ms=750
+            sprout_homestead_timeout_ms=1200
           else
-            sprout_homestead_timeout_ms=$((diameter_timeout_ms * 2 + 550))
+            sprout_homestead_timeout_ms=$((diameter_timeout_ms * 2 + 1000))
           fi
         fi
 


### PR DESCRIPTION
As discussed, this is a fix for https://github.com/Metaswitch/clearwater-issues/issues/2444

Homestead's latency on requests may be much higher that we had thought, because creating a new memcached connection will require an extra round trip. Across sites, the latency starts building massively.

We think this is the correct change for now