### PR TITLE
[Reviewer: Adam] Use target-specific exclusions

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -317,6 +317,9 @@ VPATH = ../modules/cpp-common/src ../modules/cpp-common/test_utils ../modules/ap
 # Use valgrind suppression file for UT
 sprout_test_VALGRIND_ARGS := --suppressions=ut/sprout_test.supp
 
+# Exclude the Bono tests from valgrind unless SLOW is set
+sprout_test_VALGRIND_EXCL = $(if ${SLOW},,Stateful*Proxy*Test.*)
+
 include ../build-infra/cpp.mk
 
 # Special extra objects for sprout_test


### PR DESCRIPTION
Use the new feature of the makefile in https://github.com/Metaswitch/clearwater-build-infra/pull/70 to exlcude all the Bono tests unless the variable `SLOW` is set. This allows us to speed up the valgrind check for most use-cases. I'm expecting that most developers will want to run without SLOW set, but that our automated builds will run with it set.

So, to run valgrind over everything, you now run

`SLOW=T make valgrind_check`

like we have in etcd.

An example of the speed-up I saw (on the repo server, so not one where we have to drastic slowdown that we've seen in some cases):

```
time make valgrind_check
...
real    4m2.077s
user    3m53.094s
sys     0m1.847s
```
vs
```
time SLOW=T make valgrind_check
...
real    5m50.543s
user    5m41.626s
sys     0m1.866s
```

That's a 2-minute saving on a 5-minute build, which is pretty decent.