### PR TITLE
[Reviewer: Tom] Reject on queue

### DIFF
--- a/include/cfgoptions.h
+++ b/include/cfgoptions.h
@@ -147,6 +147,7 @@ struct options
   bool                                 reject_if_no_matching_ifcs;
   std::string                          dummy_app_server;
   bool                                 http_acr_logging;
+  int                                  request_on_queue_timeout;
 };
 
 // Objects that must be shared with dynamically linked sproutlets must be

--- a/include/sproutsasevent.h
+++ b/include/sproutsasevent.h
@@ -219,6 +219,7 @@ namespace SASEvent
   const int MMF_INVOKE_BEFORE_AS = SPROUT_BASE + 0x0160;
   const int MMF_INVOKE_AFTER_AS = SPROUT_BASE + 0x0161;
 
+  const int SIP_TOO_LONG_IN_QUEUE = SPROUT_BASE + 0x0170;
 } //namespace SASEvent
 
 #endif

--- a/include/thread_dispatcher.h
+++ b/include/thread_dispatcher.h
@@ -26,7 +26,8 @@ pj_status_t init_thread_dispatcher(int num_worker_threads_arg,
                                    SNMP::EventAccumulatorByScopeTable* latency_tbl_arg,
                                    SNMP::EventAccumulatorByScopeTable* queue_size_tbl_arg,
                                    LoadMonitor* load_monitor_arg,
-                                   ExceptionHandler* exception_handler_arg);
+                                   ExceptionHandler* exception_handler_arg,
+                                   unsigned long request_on_queue_timeout);
 
 void unregister_thread_dispatcher(void);
 

--- a/sprout-base.root/etc/init.d/sprout
+++ b/sprout-base.root/etc/init.d/sprout
@@ -157,6 +157,7 @@ get_daemon_args()
         [ -z "$chronos_hostname" ] || chronos_hostname_arg="--chronos-hostname=$chronos_hostname"
         [ -z "$sprout_chronos_callback_uri" ] || sprout_chronos_callback_uri_arg="--sprout-chronos-callback-uri=$sprout_chronos_callback_uri"
         [ -z "$dummy_app_server" ] || dummy_app_server_arg="--dummy-app-server=$dummy_app_server"
+        [ -z "$request_on_queue_timeout" ] || request_on_queue_timeout_arg="--request-on-queue-timeout=$request_on_queue_timeout"
 
         DAEMON_ARGS="
                      --domain=$home_domain
@@ -200,6 +201,7 @@ get_daemon_args()
                      $override_npdi_arg
                      $exception_max_ttl_arg
                      $force_3pr_body_arg
+                     $request_on_queue_timeout_arg
                      --http-address=$local_ip
                      --http-port=9888
                      --analytics=$log_directory

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -139,6 +139,7 @@ enum OptionTypes
   OPT_REJECT_IF_NO_MATCHING_IFCS,
   OPT_DUMMY_APP_SERVER,
   OPT_HTTP_ACR_LOGGING,
+  OPT_REQUEST_ON_QUEUE_TIMEOUT
 };
 
 
@@ -229,6 +230,7 @@ const static struct pj_getopt_option long_opt[] =
   { "reject-if-no-matching-ifcs",   no_argument,       0, OPT_REJECT_IF_NO_MATCHING_IFCS},
   { "dummy-app-server",             required_argument, 0, OPT_DUMMY_APP_SERVER},
   { "http-acr-logging",             no_argument,       0, OPT_HTTP_ACR_LOGGING},
+  { "request-on-queue-timeout",     required_argument, 0, OPT_REQUEST_ON_QUEUE_TIMEOUT},
   { NULL,                           0,                 0, 0}
 };
 
@@ -1309,6 +1311,14 @@ static pj_status_t init_options(int argc, char* argv[], struct options* options)
       }
       break;
 
+    case OPT_REQUEST_ON_QUEUE_TIMEOUT:
+      {
+        VALIDATE_INT_PARAM(options->request_on_queue_timeout,
+                           request_on_queue_timeout,
+                           Maximum time (in ms) a request can wait to be processed);
+      }
+      break;
+
     SPROUTLET_MACRO(SPROUTLET_OPTIONS)
 
     case 'h':
@@ -1588,6 +1598,7 @@ int main(int argc, char* argv[])
   opt.reject_if_no_matching_ifcs = false;
   opt.dummy_app_server = "";
   opt.http_acr_logging = false;
+  opt.request_on_queue_timeout = 4000; // TODO decide on actual default
 
   status = init_logging_options(argc, argv, &opt);
 
@@ -2370,7 +2381,8 @@ int main(int argc, char* argv[])
                          latency_table,
                          queue_size_table,
                          load_monitor,
-                         exception_handler);
+                         exception_handler,
+                         opt.request_on_queue_timeout);
 
   // Create worker threads first as they take work from the PJSIP threads so
   // need to be ready.


### PR DESCRIPTION
This PR ages out old requests if they've been on the queue for too long; rejecting them in the same way that we reject on overload.

It's not been tested, and I've not thought about what a sensible default would be.