### PR TITLE
Have the transport thread log out the thread ID assigned by the kernel

### DIFF
--- a/src/stack.cpp
+++ b/src/stack.cpp
@@ -26,6 +26,9 @@ extern "C" {
 #include <list>
 #include <queue>
 #include <string>
+#include <unistd.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
 
 #include "constants.h"
 #include "eventq.h"
@@ -140,7 +143,11 @@ static int pjsip_thread_func(void *p)
 
   PJ_UNUSED_ARG(p);
 
-  TRC_STATUS("PJSIP thread started");
+  // Get the Kernel's ID for this thread so we can log it out.
+  pid_t tid;
+  tid = syscall(SYS_gettid);
+
+  TRC_STATUS("PJSIP transport thread started with kernel thread ID %d", tid);
 
   pj_bool_t curr_quiescing = PJ_FALSE;
   pj_bool_t new_quiescing = quiescing;


### PR DESCRIPTION
Krista, please could you review this change to sprout to make it log the thread ID of the transport thread. This allows you to monitor the thread's CPU usage using tools like [htop](http://hisham.hm/htop/). 

With this change, `/var/log/sprout/*` contains the following log:

```
05-10-2017 10:01:16.629 UTC Status stack.cpp:150: PJSIP transport thread started with kernel thread ID 24384
```