### PR TITLE
Better startup logging

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1512,7 +1512,7 @@ int create_astaire_stores(struct options opt,
 
   if (local_data_store == NULL)
   {
-    TRC_ERROR("Failed to connect to data store");
+    TRC_ERROR("Failed to connect to data store. Aborting startup");
     return 1;
   }
 
@@ -2175,7 +2175,7 @@ int main(int argc, char* argv[])
                                  opt.emerg_reg_accepted);
     if (status != PJ_SUCCESS)
     {
-      TRC_ERROR("Failed to enable P-CSCF edge proxy");
+      TRC_ERROR("Failed to enable P-CSCF edge proxy. Aborting startup");
       return 1;
     }
 
@@ -2269,7 +2269,7 @@ int main(int argc, char* argv[])
   if (!loader->load(sproutlets))
   {
     CL_SPROUT_PLUGIN_FAILURE.log();
-    TRC_ERROR("Failed to successfully load plug-ins");
+    TRC_ERROR("Failed to successfully load plug-ins. Aborting startup");
     return 1;
   }
 
@@ -2304,7 +2304,7 @@ int main(int argc, char* argv[])
                                          opt.max_sproutlet_depth);
     if (sproutlet_proxy == NULL)
     {
-      TRC_ERROR("Failed to create SproutletProxy");
+      TRC_ERROR("Failed to create SproutletProxy. Aborting startup");
       return 1;
     }
   }


### PR DESCRIPTION
Makes it clearer that we're aborting startup because of failures setting up plugins or stores. 
