### PR TITLE
[Reviewer: Adam] Add sprout_{http/worker}_threads to override num_*

### DIFF
--- a/sprout-base.root/etc/init.d/sprout
+++ b/sprout-base.root/etc/init.d/sprout
@@ -102,6 +102,16 @@ get_settings()
         authentication=Y
         . /etc/clearwater/config
 
+        if [ -n "$sprout_worker_threads" ];
+        then
+          num_worker_threads="$sprout_worker_threads"
+        fi
+
+        if [ -n "$sprout_http_threads" ];
+        then
+          num_http_threads="$sprout_http_threads"
+        fi
+
         # Calculate the correct homestead latency:
         #  - if we have sprout_homestead_timeout_ms set, use that
         #  - else:


### PR DESCRIPTION
Adam,

Hopefully an uncontroversial change to add a couple of configuration options for the thread counts to Sprout.

I've tested setting `sprout_worker_threads` and `sprout_http_threads` on a Chef deployment and checking that they get picked up.