### PR TITLE
[Reviewer: Seb] Depend correctly on the alarm definition file

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -338,9 +338,16 @@ include ../modules/cpp-common/makefiles/alarm-utils.mk
 ../usr/include/sprout_alarmdefinition.h : $(BUILD_DIR)/bin/alarm_header ../sprout-base.root/usr/share/clearwater/infrastructure/alarms/sprout_alarms.json
 	$< -j "../sprout-base.root/usr/share/clearwater/infrastructure/alarms/sprout_alarms.json" -n "sprout"
 	mv sprout_alarmdefinition.h $@
-${sprout_OBJECT_DIR}/main.o : ../usr/include/sprout_alarmdefinition.h
-${sprout_scscf.so_OBJECT_DIR}/scscfplugin.o : ../usr/include/sprout_alarmdefinition.h
+
 CLEANS += ../usr/include/sprout_alarmdefinition.h
+
+# The following files all include the alarm defintion
+ALARM_DEFINITION_FILES := ${sprout_test_OBJECT_DIR}/hssconnection_test.o \
+                          ${sprout_test_OBJECT_DIR}/enumservice_test.o \
+                          ${sprout_OBJECT_DIR}/main.o \
+                          ${sprout_scscf.so_OBJECT_DIR}/scscfplugin.o
+
+${ALARM_DEFINITION_FILES} : ../usr/include/sprout_alarmdefinition.h
 
 ../usr/include/memento_as_alarmdefinition.h : $(BUILD_DIR)/bin/alarm_header ../memento-as.root/usr/share/clearwater/infrastructure/alarms/memento_as_alarms.json
 	$< -j "../memento-as.root/usr/share/clearwater/infrastructure/alarms/memento_as_alarms.json" -n "memento_as"


### PR DESCRIPTION
Currently `make full_test` doesn't work on a clean checkout because it fails with:

```
g++   -MMD -MP -O0 -ggdb3 -std=c++11 -Wall -Werror -DUNIT_TEST -fprofile-arcs -ftest-coverage -fno-access-control -I../modules/gmock/gtest/include -I../modules/gmock/include -I../modules/cpp-common/test_utils -Wno-write-strings -I../include -I../modules/cpp-common/include -I../modules/app-servers/include -I../usr/include -I../modules/rapidjson/include `PKG_CONFIG_PATH=../usr/lib/pkgconfig pkg-config --cflags libpjproject` -I../modules/sipp -I../modules/app-servers/test -I../modules/memento-as/include -I../modules/memento-as/modules/memento-common/include -I../modules/gemini/include -I../include/mangelwurzel -Iut -DGTEST_USE_OWN_TR1_TUPLE=0  -c ut/hssconnection_test.cpp -o ../build/sprout_test/hssconnection_test.o
ut/hssconnection_test.cpp:26:36: fatal error: sprout_alarmdefinition.h: No such file or directory
 #include "sprout_alarmdefinition.h"
                                    ^
```

This fixes it by fixing the Makefile so that `hssconnection_test.o` depends on `sprout_alarmdefinition.h`.