### PR TITLE
[Reviewer: Richard] Subscription sproutlet refactor

### DIFF
--- a/include/subscriptionsproutlet.h
+++ b/include/subscriptionsproutlet.h
@@ -101,7 +101,7 @@ protected:
   AoR::Subscription create_subscription(pjsip_msg* req, int expiry);
 
   Store::Status update_subscription_in_stores(SubscriptionSproutlet* _subscription,
-                                              AoR::Subscription new_subscription,
+                                              AoR::Subscription& new_subscription,
                                               std::string aor,
                                               AssociatedURIs* associated_uris,
                                               pjsip_msg* req,
@@ -115,7 +115,7 @@ protected:
                                      std::map<SubscriberDataManager*, AoRPair*>& _cached_aors);
 
   void update_subscription(SubscriptionSproutlet* _subscription,
-                           AoR::Subscription new_subscription,
+                           AoR::Subscription& new_subscription,
                            std::string aor,
                            AoRPair* aor_pair,
                            std::map<SubscriberDataManager*, AoRPair*>& _cached_aors);

--- a/include/subscriptionsproutlet.h
+++ b/include/subscriptionsproutlet.h
@@ -112,13 +112,13 @@ protected:
 
   AoRPair* read_and_cache_from_store(SubscriberDataManager* sdm,
                                      std::string aor,
-                                     std::map<SubscriberDataManager*, AoRPair*> _cached_aors);
+                                     std::map<SubscriberDataManager*, AoRPair*>& _cached_aors);
 
   void update_subscriptions(SubscriptionSproutlet* _subscription,
                             AoR::Subscription* new_subscription,
                             std::string aor,
                             AoRPair* aor_pair,
-                            std::map<SubscriberDataManager*, AoRPair*> _cached_aors);
+                            std::map<SubscriberDataManager*, AoRPair*>& _cached_aors);
 
   void log_subscriptions(const std::string& aor_name,
                          AoR* aor_data);

--- a/include/subscriptionsproutlet.h
+++ b/include/subscriptionsproutlet.h
@@ -98,27 +98,27 @@ protected:
   void on_rx_request(pjsip_msg* req);
   void process_subscription_request(pjsip_msg* req);
 
-  AoR::Subscription* create_subscription(pjsip_msg* req, int expiry);
+  AoR::Subscription create_subscription(pjsip_msg* req, int expiry);
 
-  Store::Status update_subscriptions_in_stores(SubscriptionSproutlet* _subscription,
-                                               AoR::Subscription* new_subscription,
-                                               std::string aor,
-                                               AssociatedURIs* associated_uris,
-                                               pjsip_msg* req,
-                                               std::string public_id,
-                                               ACR* acr,
-                                               std::deque<std::string> ccfs,
-                                               std::deque<std::string> ecfs);
+  Store::Status update_subscription_in_stores(SubscriptionSproutlet* _subscription,
+                                              AoR::Subscription new_subscription,
+                                              std::string aor,
+                                              AssociatedURIs* associated_uris,
+                                              pjsip_msg* req,
+                                              std::string public_id,
+                                              ACR* acr,
+                                              std::deque<std::string> ccfs,
+                                              std::deque<std::string> ecfs);
 
   AoRPair* read_and_cache_from_store(SubscriberDataManager* sdm,
                                      std::string aor,
                                      std::map<SubscriberDataManager*, AoRPair*>& _cached_aors);
 
-  void update_subscriptions(SubscriptionSproutlet* _subscription,
-                            AoR::Subscription* new_subscription,
-                            std::string aor,
-                            AoRPair* aor_pair,
-                            std::map<SubscriberDataManager*, AoRPair*>& _cached_aors);
+  void update_subscription(SubscriptionSproutlet* _subscription,
+                           AoR::Subscription new_subscription,
+                           std::string aor,
+                           AoRPair* aor_pair,
+                           std::map<SubscriberDataManager*, AoRPair*>& _cached_aors);
 
   void log_subscriptions(const std::string& aor_name,
                          AoR* aor_data);

--- a/include/subscriptionsproutlet.h
+++ b/include/subscriptionsproutlet.h
@@ -98,6 +98,15 @@ protected:
   void on_rx_request(pjsip_msg* req);
   void process_subscription_request(pjsip_msg* req);
 
+  Store::Status update_subscriptions_in_stores(SubscriptionSproutlet* _subscription,
+                                               std::string aor,
+                                               AssociatedURIs associated_uris,
+                                               pjsip_msg* req,
+                                               std::string public_id,
+                                               ACR* acr,
+                                               std::deque<std::string> ccfs,
+                                               std::deque<std::string> ecfs);
+
   AoRPair* write_subscriptions_to_store(
                      SubscriberDataManager* primary_sdm,        ///<store to write to
                      std::string aor,                           ///<address of record to write to

--- a/include/subscriptionsproutlet.h
+++ b/include/subscriptionsproutlet.h
@@ -98,30 +98,27 @@ protected:
   void on_rx_request(pjsip_msg* req);
   void process_subscription_request(pjsip_msg* req);
 
+  AoR::Subscription* create_subscription(pjsip_msg* req, int expiry);
+
   Store::Status update_subscriptions_in_stores(SubscriptionSproutlet* _subscription,
+                                               AoR::Subscription* new_subscription,
                                                std::string aor,
-                                               AssociatedURIs associated_uris,
+                                               AssociatedURIs* associated_uris,
                                                pjsip_msg* req,
                                                std::string public_id,
                                                ACR* acr,
                                                std::deque<std::string> ccfs,
                                                std::deque<std::string> ecfs);
 
-  AoRPair* write_subscriptions_to_store(
-                     SubscriberDataManager* primary_sdm,        ///<store to write to
-                     std::string aor,                           ///<address of record to write to
-                     AssociatedURIs* associated_uris,
-                                                                ///<IMPUs associated with this IRS
-                     pjsip_msg* req,                            ///<received request to read headers from
-                     int now,                                   ///<time now
-                     AoRPair* backup_aor,                       ///<backup data if no entry in store
-                     std::vector<SubscriberDataManager*> backup_sdms,
-                                                                ///<backup stores to read from if no entry in store and no backup data
-                     std::string public_id,                     ///
-                     bool send_ok,                              ///<Should we create an OK
-                     ACR* acr,                                  ///
-                     std::deque<std::string> ccfs,              ///
-                     std::deque<std::string> ecfs);             ///
+  AoRPair* read_and_cache_from_store(SubscriberDataManager* sdm,
+                                     std::string aor,
+                                     std::map<SubscriberDataManager*, AoRPair*> _cached_aors);
+
+  void update_subscriptions(SubscriptionSproutlet* _subscription,
+                            AoR::Subscription* new_subscription,
+                            std::string aor,
+                            AoRPair* aor_pair,
+                            std::map<SubscriberDataManager*, AoRPair*> _cached_aors);
 
   void log_subscriptions(const std::string& aor_name,
                          AoR* aor_data);

--- a/src/subscriptionsproutlet.cpp
+++ b/src/subscriptionsproutlet.cpp
@@ -606,7 +606,7 @@ Store::Status SubscriptionSproutletTsx::update_subscription_in_stores(
 
           // We've hit an error in reading from the remote store, but we don't
           // take any action on this. Bail out and try the next store.
-          TRC_ERROR("Failed to read AoR from remote store");
+          TRC_DEBUG("Failed to read AoR from remote store");
           break;
           // LCOV_EXCL_STOP
         }
@@ -640,8 +640,8 @@ AoRPair* SubscriptionSproutletTsx::read_and_cache_from_store(
       (aor_pair->get_current() == NULL))
   {
     // Failed to get data for the AoR because there is no connection
-    // to the store.
-    TRC_ERROR("Failed to get AoR subscriptions for %s from store", aor.c_str());
+    // to the store. SAS logging is left to the SDM
+    TRC_DEBUG("Failed to get AoR data for %s from store", aor.c_str());
     delete aor_pair;
     return NULL;
   }

--- a/src/subscriptionsproutlet.cpp
+++ b/src/subscriptionsproutlet.cpp
@@ -672,15 +672,13 @@ void SubscriptionSproutletTsx::update_subscription(
     // stores so that we can check them for any subscriptions. We only want to
     // perform the remote reads once, to avoid added latency.
     // The local AoR is added to the cache in the main function logic
-    for (std::vector<SubscriberDataManager*>::iterator sdm = _subscription->_remote_sdms.begin();
-         sdm != _subscription->_remote_sdms.end();
-         ++sdm)
+    for (SubscriberDataManager* sdm : _subscription->_remote_sdms)
     {
       // We want to read the remote AoR only once at this stage, so we check
       // if there's already an entry in the cache for it.
-      if ((_cached_aors.find(*sdm) == _cached_aors.end()) &&  ((*sdm)->has_servers()))
+      if ((_cached_aors.find(sdm) == _cached_aors.end()) &&  (sdm->has_servers()))
       {
-        read_and_cache_from_store(*sdm, aor, _cached_aors);
+        read_and_cache_from_store(sdm, aor, _cached_aors);
       }
     }
 

--- a/src/subscriptionsproutlet.cpp
+++ b/src/subscriptionsproutlet.cpp
@@ -304,6 +304,19 @@ void SubscriptionSproutletTsx::process_subscription_request(pjsip_msg* req)
   SAS::Marker start_marker(trail_id, MARKER_ID_START, 1u);
   SAS::report_marker(start_marker);
 
+  // Check if the contact header is present. If it isn't, we want to abort
+  // processing before going any further, to avoid unnecessary work.
+  pjsip_contact_hdr* contact = (pjsip_contact_hdr*)pjsip_msg_find_hdr(req, PJSIP_H_CONTACT, NULL);
+  if (contact == NULL)
+  {
+    TRC_ERROR("Unable to parse contact header from request. Aborting processing");
+    pjsip_msg* rsp = create_response(req, PJSIP_SC_BAD_REQUEST);
+    send_response(rsp);
+    free_msg(req);
+    delete acr;
+    return;
+  }
+
   // Query the HSS for the associated URIs.
   AssociatedURIs associated_uris = {};
   std::map<std::string, Ifcs> ifc_map;
@@ -346,20 +359,55 @@ void SubscriptionSproutletTsx::process_subscription_request(pjsip_msg* req)
   TRC_DEBUG("aor = %s", aor.c_str());
   TRC_DEBUG("SUBSCRIBE for public ID %s uses AOR %s", public_id.c_str(), aor.c_str());
 
+  // Create a subscription object from the request that we can pass down to
+  // be set into/updated in the different stores
+  AoR::Subscription* new_subscription = create_subscription(req, expiry);
 
   // Update the local and remote stores with the new subscription
   Store::Status status = update_subscriptions_in_stores(_subscription,
+                                                        new_subscription,
                                                         aor,
-                                                        associated_uris,
+                                                        &associated_uris,
                                                         req,
                                                         public_id,
                                                         acr,
                                                         ccfs,
                                                         ecfs);
 
+  if (_subscription->_analytics != NULL)
+  {
+    // Generate an analytics log for this subscription update.
+    _subscription->_analytics->subscription(aor,
+                                            new_subscription->_to_tag,
+                                            new_subscription->_req_uri,
+                                            expiry);
+  }
+
   if (status == Store::Status::OK)
   {
-  // send the 200 etc.
+    pjsip_msg* rsp = create_response(req, PJSIP_SC_OK);
+    // Add expires headers
+    pjsip_expires_hdr* expires_hdr = pjsip_expires_hdr_create(get_pool(rsp), expiry);
+    pjsip_msg_add_hdr(rsp, (pjsip_hdr*)expires_hdr);
+
+    // Add the to tag to the response
+    pjsip_to_hdr *to = (pjsip_to_hdr*) pjsip_msg_find_hdr(rsp,
+                                                          PJSIP_H_TO,
+                                                          NULL);
+    pj_strdup2(get_pool(rsp), &to->tag, new_subscription->_to_tag.c_str());
+
+    // Add a P-Charging-Function-Addresses header to the successful SUBSCRIBE
+    // response containing the charging addresses returned by the HSS.
+    PJUtils::add_pcfa_header(rsp,
+                             get_pool(rsp),
+                             ccfs,
+                             ecfs,
+                             false);
+
+    // Pass the response to the ACR.
+    acr->tx_response(rsp);
+
+    send_response(rsp);
   }
   else
   {
@@ -374,19 +422,8 @@ void SubscriptionSproutletTsx::process_subscription_request(pjsip_msg* req)
     pjsip_to_hdr *to = (pjsip_to_hdr*) pjsip_msg_find_hdr(rsp,
                                                           PJSIP_H_TO,
                                                           NULL);
-    std::string subscription_id = PJUtils::pj_str_to_string(&to->tag);
 
-    if (subscription_id == "")
-    {
-      // If there's no to tag, generate an unique one.
-      // TODO Should use unique deployment and instance IDs here.
-
-      // LCOV_EXCL_START
-      subscription_id = std::to_string(Utils::generate_unique_integer(0, 0));
-      // LCOV_EXCL_STOP
-    }
-
-    pj_strdup2(get_pool(rsp), &to->tag, subscription_id.c_str());
+    pj_strdup2(get_pool(rsp), &to->tag, new_subscription->_to_tag.c_str());
 
     // Pass the response to the ACR.
     acr->tx_response(req);
@@ -409,11 +446,75 @@ void SubscriptionSproutletTsx::process_subscription_request(pjsip_msg* req)
   free_msg(req);
 }
 
-// Handles all necessary logic for getting, updating, and setting AoRs from
-// local and remote sites, handling any data contention issues etc.
-Store::Status SubscriptionSproutletTsx::update_subscriptions_in_stores(SubscriptionSproutlet* _subscription,
+AoR::Subscription* SubscriptionSproutletTsx::create_subscription(pjsip_msg* req, int expiry)
+{
+  AoR::Subscription* subscription = NULL;
+  int now = time(NULL);
+  std::string cid = PJUtils::pj_str_to_string(&PJSIP_MSG_CID_HDR(req)->id);
+  pjsip_fromto_hdr* from = (pjsip_fromto_hdr*)pjsip_msg_find_hdr(req, PJSIP_H_FROM, NULL);
+  pjsip_fromto_hdr* to = (pjsip_fromto_hdr*)pjsip_msg_find_hdr(req, PJSIP_H_TO, NULL);
+  pjsip_contact_hdr* contact = (pjsip_contact_hdr*)pjsip_msg_find_hdr(req, PJSIP_H_CONTACT, NULL);
+  std::string subscription_id;
+
+  std::string contact_uri;
+  pjsip_uri* uri = (contact->uri != NULL) ?
+                   (pjsip_uri*)pjsip_uri_get_uri(contact->uri) :
+                   NULL;
+
+  if ((uri != NULL) &&
+      (PJSIP_URI_SCHEME_IS_SIP(uri)))
+  {
+    contact_uri = PJUtils::uri_to_string(PJSIP_URI_IN_CONTACT_HDR, uri);
+  }
+
+  subscription_id = PJUtils::pj_str_to_string(&to->tag);
+
+  if (subscription_id == "")
+  {
+    // If there's no to tag, generate an unique one
+    // TODO: Should use unique deployment and instance IDs here.
+    subscription_id = std::to_string(Utils::generate_unique_integer(0, 0));
+  }
+
+  // Create a subscription, and fill it with the new data
+  subscription = new AoR::Subscription;
+  TRC_DEBUG("Subscription identifier = %s", subscription_id.c_str());
+  subscription->_to_tag = subscription_id;
+
+  subscription->_req_uri = contact_uri;
+  pjsip_route_hdr* route_hdr = (pjsip_route_hdr*)pjsip_msg_find_hdr(req,
+                                                                    PJSIP_H_RECORD_ROUTE,
+                                                                    NULL);
+  while (route_hdr)
+  {
+    std::string route = PJUtils::uri_to_string(PJSIP_URI_IN_ROUTING_HDR,
+                                               route_hdr->name_addr.uri);
+    TRC_DEBUG("Route header %s", route.c_str());
+    // Add the route.
+    subscription->_route_uris.push_back(route);
+    // Look for the next header.
+    route_hdr = (pjsip_route_hdr*)pjsip_msg_find_hdr(req,
+                                                     PJSIP_H_RECORD_ROUTE,
+                                                     route_hdr->next);
+  }
+
+  subscription->_cid = cid;
+  subscription->_to_uri = PJUtils::uri_to_string(PJSIP_URI_IN_FROMTO_HDR, to->uri);
+  subscription->_from_uri = PJUtils::uri_to_string(PJSIP_URI_IN_FROMTO_HDR, from->uri);
+  subscription->_from_tag = PJUtils::pj_str_to_string(&from->tag);
+  subscription->_refreshed = true;
+  subscription->_expires = now + expiry;
+
+  return subscription;
+}
+
+// Handles the necessary logic for getting, updating, and setting AoRs from
+// local and remote sites with the new subscription data
+Store::Status SubscriptionSproutletTsx::update_subscriptions_in_stores(
+                                             SubscriptionSproutlet* _subscription,
+                                             AoR::Subscription* new_subscription,
                                              std::string aor,
-                                             AssociatedURIs associated_uris,
+                                             AssociatedURIs* associated_uris,
                                              pjsip_msg* req,
                                              std::string public_id,
                                              ACR* acr,
@@ -421,303 +522,177 @@ Store::Status SubscriptionSproutletTsx::update_subscriptions_in_stores(Subscript
                                              std::deque<std::string> ecfs)
 {
   Store::Status status;
-  // Get the system time in seconds for calculating absolute expiry times.
-  int now = time(NULL);
+  // We cache AoRPairs from the local and remote SDMs to avoid having
+  // to do repeated remote reads, saving thread time
+  std::map<SubscriberDataManager*, AoRPair*> _cached_aors;
 
-  // Write to the local store, checking the remote stores if there is no entry locally.
-  // If the write to the local store succeeds, then write to the remote stores.
-  AoRPair* aor_pair = write_subscriptions_to_store(_subscription->_sdm,
-                                                   aor,
-                                                   &associated_uris,
-                                                   req,
-                                                   now,
-                                                   NULL,
-                                                   _subscription->_remote_sdms,
-                                                   public_id,
-                                                   true,
-                                                   acr,
-                                                   ccfs,
-                                                   ecfs);
-
-  if (aor_pair != NULL)
-  {
-    // Log the subscriptions.
-    log_subscriptions(aor, aor_pair->get_current());
-
-    // If we have any remote stores, try to store this there too.  We don't worry
-    // about failures in this case.
-    for (std::vector<SubscriberDataManager*>::iterator it = _subscription->_remote_sdms.begin();
-         it != _subscription->_remote_sdms.end();
-         ++it)
-    {
-      if ((*it)->has_servers())
-      {
-        AoRPair* remote_aor_pair = write_subscriptions_to_store(*it,
-                                                                aor,
-                                                                &associated_uris,
-                                                                req,
-                                                                now,
-                                                                aor_pair,
-                                                                {},
-                                                                public_id,
-                                                                false,
-                                                                acr,
-                                                                ccfs,
-                                                                ecfs);
-        delete remote_aor_pair;
-      }
-    }
-    status = Store::Status::OK;
-  }
-  else
+  AoRPair* local_aor_pair = read_and_cache_from_store(_subscription->_sdm,
+                                                      aor,
+                                                      _cached_aors);
+  if (local_aor_pair == NULL)
   {
     status = Store::Status::ERROR;
+    return status;
   }
-  delete aor_pair;
-  return status;
-}
 
-/// Write to the registration store. If we can't find the AoR pair in the
-/// primary SDM, we will either use the backup_aor or we will try and look up
-/// the AoR pair in the backup SDMs. Therefore either the backup_aor should be
-/// NULL, or backup_sdms should be empty.
-AoRPair* SubscriptionSproutletTsx::write_subscriptions_to_store(
-                   SubscriberDataManager* primary_sdm,        ///<store to write to
-                   std::string aor,                           ///<address of record to write to
-                   AssociatedURIs* associated_uris,
-                                                              ///<IMPUs associated with this IRS
-                   pjsip_msg* req,                            ///<received request to read headers from
-                   int now,                                   ///<time now
-                   AoRPair* backup_aor,                       ///<backup data if no entry in store
-                   std::vector<SubscriberDataManager*> backup_sdms,
-                                                              ///<backup stores to read from if no entry in store and no backup data
-                   std::string public_id,                     ///
-                   bool is_primary,                           ///<Should we create an OK
-                   ACR* acr,                                  ///
-                   std::deque<std::string> ccfs,              ///
-                   std::deque<std::string> ecfs)              ///
-{
-  // Parse the headers
-  std::string cid = PJUtils::pj_str_to_string(&PJSIP_MSG_CID_HDR(req)->id);
-  pjsip_expires_hdr* expires = (pjsip_expires_hdr*)pjsip_msg_find_hdr(req, PJSIP_H_EXPIRES, NULL);
-  pjsip_fromto_hdr* from = (pjsip_fromto_hdr*)pjsip_msg_find_hdr(req, PJSIP_H_FROM, NULL);
-  pjsip_fromto_hdr* to = (pjsip_fromto_hdr*)pjsip_msg_find_hdr(req, PJSIP_H_TO, NULL);
-
-  // The registration store uses optimistic locking to avoid concurrent
-  // updates to the same AoR conflicting.  This means we have to loop
-  // reading, updating and writing the AoR until the write is successful.
-  bool backup_aor_alloced = false;
-  int expiry = 0;
-  Store::Status set_rc;
-  AoRPair* aor_pair = NULL;
-  std::string subscription_contact;
-  std::string subscription_id;
-
+  // Write to the local store, handling any CAS error
   do
   {
-    // delete NULL is safe, so we can do this on every iteration.
-    delete aor_pair;
+    update_subscriptions(_subscription, new_subscription, aor, local_aor_pair, _cached_aors);
+    local_aor_pair->get_current()->_associated_uris = *associated_uris;
 
-    // Find the current subscriptions for the AoR.
-    aor_pair = primary_sdm->get_aor_data(aor, trail());
-    TRC_DEBUG("Retrieved AoR data %p", aor_pair);
-
-    if ((aor_pair == NULL) ||
-        (aor_pair->get_current() == NULL))
+    status = _subscription->_sdm->set_aor_data(aor, local_aor_pair, trail());
+    if (status == Store::DATA_CONTENTION)
     {
-      // Failed to get data for the AoR because there is no connection
-      // to the store.
-      // LCOV_EXCL_START - local store (used in testing) never fails
-      TRC_ERROR("Failed to get AoR subscriptions for %s from store", aor.c_str());
-      break;
-      // LCOV_EXCL_STOP
-    }
-
-    // If we don't have any subscriptions, try the backup AoR and/or stores.
-    if (aor_pair->get_current()->subscriptions().empty())
-    {
-      bool found_subscription = false;
-
-      if ((backup_aor != NULL) &&
-          (backup_aor->current_contains_subscriptions()))
+      delete local_aor_pair;
+      local_aor_pair = read_and_cache_from_store(_subscription->_sdm, aor, _cached_aors);
+      if (local_aor_pair == NULL)
       {
-        found_subscription = true;
-      }
-      else
-      {
-        std::vector<SubscriberDataManager*>::iterator it = backup_sdms.begin();
-        AoRPair* local_backup_aor = NULL;
-
-        while ((it != backup_sdms.end()) && (!found_subscription))
-        {
-          if ((*it)->has_servers())
-          {
-            local_backup_aor = (*it)->get_aor_data(aor, trail());
-
-            if ((local_backup_aor != NULL) &&
-                (local_backup_aor->current_contains_subscriptions()))
-            {
-              // LCOV_EXCL_START - this code is very similar to code in handlers.cpp and is unit tested there.
-              found_subscription = true;
-              backup_aor = local_backup_aor;
-
-              // Flag that we have allocated the memory for the backup pair so
-              // that we can tidy it up later.
-              backup_aor_alloced = true;
-              // LCOV_EXCL_STOP
-            }
-          }
-
-          if (!found_subscription)
-          {
-            ++it;
-
-            if (local_backup_aor != NULL)
-            {
-              delete local_backup_aor;
-              local_backup_aor = NULL;
-            }
-          }
-        }
-      }
-
-      if (found_subscription)
-      {
-        aor_pair->get_current()->copy_aor(backup_aor->get_current());
+        status = Store::Status::ERROR;
+        return status;
       }
     }
+  }
+  while (status == Store::DATA_CONTENTION);
 
-    pjsip_contact_hdr* contact = (pjsip_contact_hdr*)pjsip_msg_find_hdr(req, PJSIP_H_CONTACT, NULL);
+  log_subscriptions(aor, local_aor_pair->get_current());
 
-    if (contact != NULL)
+  // Using a different rc for the remote stores, as their success/failure does
+  // not impact whether we determine the overall process a success
+  Store::Status rc;
+  AoRPair* remote_aor_pair = NULL;
+
+  for (std::vector<SubscriberDataManager*>::iterator sdm = _subscription->_remote_sdms.begin();
+       sdm != _subscription->_remote_sdms.end();
+       ++sdm)
+  {
+    // Check if we have done the remote read for this SDM yet, and do it if not
+    // Saves us from doing a re-read if we had to get the AoRs previously
+    if ((_cached_aors.find(*sdm) == _cached_aors.end()) &&  ((*sdm)->has_servers()))
     {
-      std::string contact_uri;
-      pjsip_uri* uri = (contact->uri != NULL) ?
-                       (pjsip_uri*)pjsip_uri_get_uri(contact->uri) :
-                       NULL;
-
-      if ((uri != NULL) &&
-          (PJSIP_URI_SCHEME_IS_SIP(uri)))
-      {
-        contact_uri = PJUtils::uri_to_string(PJSIP_URI_IN_CONTACT_HDR, uri);
-      }
-
-      subscription_id = PJUtils::pj_str_to_string(&to->tag);
-
-      if (subscription_id == "")
-      {
-        // If there's no to tag, generate an unique one
-        // TODO: Should use unique deployment and instance IDs here.
-        subscription_id = std::to_string(Utils::generate_unique_integer(0, 0));
-      }
-
-      TRC_DEBUG("Subscription identifier = %s", subscription_id.c_str());
-
-      // Find the appropriate subscription in the subscription list for this AoR. If it can't
-      // be found a new empty subscription is created.
-      AoR::Subscription* subscription =
-                    aor_pair->get_current()->get_subscription(subscription_id);
-
-      // Update/create the subscription.
-      subscription->_req_uri = contact_uri;
-
-      subscription->_route_uris.clear();
-      pjsip_route_hdr* route_hdr = (pjsip_route_hdr*)pjsip_msg_find_hdr(req,
-                                                                        PJSIP_H_RECORD_ROUTE,
-                                                                        NULL);
-
-      while (route_hdr)
-      {
-        std::string route = PJUtils::uri_to_string(PJSIP_URI_IN_ROUTING_HDR,
-                                                   route_hdr->name_addr.uri);
-        TRC_DEBUG("Route header %s", route.c_str());
-        // Add the route.
-        subscription->_route_uris.push_back(route);
-        // Look for the next header.
-        route_hdr = (pjsip_route_hdr*)pjsip_msg_find_hdr(req,
-                                                         PJSIP_H_RECORD_ROUTE,
-                                                         route_hdr->next);
-      }
-
-      subscription->_cid = cid;
-      subscription->_to_uri = PJUtils::uri_to_string(PJSIP_URI_IN_FROMTO_HDR, to->uri);
-      subscription->_to_tag = subscription_id;
-      subscription->_from_uri = PJUtils::uri_to_string(PJSIP_URI_IN_FROMTO_HDR, from->uri);
-      subscription->_from_tag = PJUtils::pj_str_to_string(&from->tag);
-      subscription->_refreshed = true;
-
-      // Calculate the expiry period for the subscription.
-      expiry = (expires != NULL) ?
-        expires->ivalue : SubscriptionSproutlet::DEFAULT_SUBSCRIPTION_EXPIRES;
-
-      if (expiry > _subscription->_max_expires)
-      {
-        // Expiry is too long, set it to the maximum.
-        expiry = _subscription->_max_expires;
-      }
-
-      subscription->_expires = now + expiry;
-      subscription_contact = subscription->_req_uri;
-    }
-
-    // Try to write the AoR back to the store.
-    bool unused;
-    aor_pair->get_current()->_associated_uris = *associated_uris;
-    set_rc = primary_sdm->set_aor_data(aor, aor_pair, trail(), unused);
-
-    if (set_rc == Store::OK)
-    {
-      if (is_primary)
-      {
-        pjsip_msg* rsp = create_response(req, PJSIP_SC_OK);
-
-        // Add expires headers
-        pjsip_expires_hdr* expires_hdr = pjsip_expires_hdr_create(get_pool(rsp), expiry);
-        pjsip_msg_add_hdr(rsp, (pjsip_hdr*)expires_hdr);
-
-        // Add the to tag to the response
-        pjsip_to_hdr *to = (pjsip_to_hdr*) pjsip_msg_find_hdr(rsp,
-                                                              PJSIP_H_TO,
-                                                              NULL);
-        pj_strdup2(get_pool(rsp), &to->tag, subscription_id.c_str());
-
-        // Add a P-Charging-Function-Addresses header to the successful SUBSCRIBE
-        // response containing the charging addresses returned by the HSS.
-        PJUtils::add_pcfa_header(rsp,
-                                 get_pool(rsp),
-                                 ccfs,
-                                 ecfs,
-                                 false);
-
-        // Pass the response to the ACR.
-        acr->tx_response(rsp);
-
-        send_response(rsp);
-      }
+      TRC_DEBUG("No cached AoR data found for remote site");
+      remote_aor_pair = read_and_cache_from_store(*sdm, aor, _cached_aors);
     }
     else
     {
-      delete aor_pair; aor_pair = NULL;
+      TRC_DEBUG("Reading cached AoR data for remote site");
+      remote_aor_pair = _cached_aors[*sdm];
+    }
+
+    do
+    {
+      update_subscriptions(_subscription, new_subscription, aor, remote_aor_pair, _cached_aors);
+      remote_aor_pair->get_current()->_associated_uris = *associated_uris;
+
+      rc = (*sdm)->set_aor_data(aor, remote_aor_pair, trail());
+      if (rc == Store::DATA_CONTENTION)
+      {
+        delete remote_aor_pair;
+        remote_aor_pair = read_and_cache_from_store(*sdm, aor, _cached_aors);
+        if (remote_aor_pair == NULL)
+        {
+          // We've hit an error in reading from the remote store, but we don't
+          // take any action on this. Bail out and try the next store.
+          TRC_ERROR("Failed to read AoR from remote store");
+          break;
+        }
+      }
+    }
+    while (rc == Store::DATA_CONTENTION);
+  }
+
+  delete local_aor_pair;
+  delete remote_aor_pair;
+  return status;
+}
+
+AoRPair* SubscriptionSproutletTsx::read_and_cache_from_store(
+                       SubscriberDataManager* sdm,
+                       std::string aor,
+                       std::map<SubscriberDataManager*, AoRPair*> _cached_aors)
+{
+  // Returns NULL if the SDM hits an error reading from the store
+  // Adds the AoRPair to the _cached_aors if we succeed, and returns it
+
+  AoRPair* aor_pair = sdm->get_aor_data(aor, trail());
+
+  if ((aor_pair == NULL) ||
+      (aor_pair->get_current() == NULL))
+  {
+    // Failed to get data for the AoR because there is no connection
+    // to the store.
+    // LCOV_EXCL_START - local store (used in testing) never fails
+    TRC_ERROR("Failed to get AoR subscriptions for %s from store", aor.c_str());
+    delete aor_pair;
+    return NULL;
+    // LCOV_EXCL_STOP
+  }
+
+  TRC_DEBUG("Retrieved AoR data %p. Storing in local cache for SDM %p", aor_pair, sdm);
+  _cached_aors[sdm] = aor_pair;
+  return aor_pair;
+}
+
+void SubscriptionSproutletTsx::update_subscriptions(
+                  SubscriptionSproutlet* _subscription,
+                  AoR::Subscription* new_subscription,
+                  std::string aor,
+                  AoRPair* aor_pair,
+                  std::map<SubscriberDataManager*, AoRPair*> _cached_aors)
+{
+  if (aor_pair->get_current()->subscriptions().empty())
+  {
+    // If we don't have any subscriptions in the local AoR, read from remote
+    // stores so that we can check them for any subscriptions. We only want to
+    // perform the remote reads once, to avoid added latency.
+    // The local AoR is added to the cache in the main function logic
+    for (std::vector<SubscriberDataManager*>::iterator sdm = _subscription->_remote_sdms.begin();
+         sdm != _subscription->_remote_sdms.end();
+         ++sdm)
+    {
+      // We want to read the remote AoR only once at this stage, so we check
+      // if there's already an entry in the cache for it.
+      if ((_cached_aors.find(*sdm) == _cached_aors.end()) &&  ((*sdm)->has_servers()))
+      {
+        read_and_cache_from_store(*sdm, aor, _cached_aors);
+      }
+    }
+
+    // Now copy over any details from the first cached aor we have with any subscriptions
+    for (std::map<SubscriberDataManager*, AoRPair*>::const_iterator it = _cached_aors.begin();
+        it != _cached_aors.end();
+        ++it)
+    {
+      if (it->second != aor_pair)
+      {
+        if (! it->second->get_current()->subscriptions().empty())
+        {
+          TRC_DEBUG("AoR contained no subscriptions, but a remote copy did; copying data across");
+          aor_pair->get_current()->copy_aor(it->second->get_current());
+          break;
+        }
+      }
     }
   }
-  while (set_rc == Store::DATA_CONTENTION);
 
-  if ((_subscription->_analytics != NULL) && (is_primary))
-  {
-    // Generate an analytics log for this subscription update.
-    _subscription->_analytics->subscription(aor,
-                                         subscription_id,
-                                         subscription_contact,
-                                         expiry);
-  }
+  // Find the appropriate subscription in the subscription list for this AoR. If it can't
+  // be found a new empty subscription is created.
+  AoR::Subscription* subscription =
+                aor_pair->get_current()->get_subscription(new_subscription->_to_tag);
 
-  // If we allocated the backup AoR, tidy up.
-  if (backup_aor_alloced)
-  {
-    delete backup_aor; backup_aor = NULL; // LCOV_EXCL_LINE
-  }
+  // Update/create the subscription with the new details.
+  subscription->_req_uri = new_subscription->_req_uri;
 
-  return aor_pair;
+  subscription->_route_uris.clear();
+  subscription->_route_uris = new_subscription->_route_uris;
+
+  subscription->_cid = new_subscription->_cid;
+  subscription->_to_uri = new_subscription->_to_uri;
+  subscription->_to_tag = new_subscription->_to_tag;
+  subscription->_from_uri = new_subscription->_from_uri;
+  subscription->_from_tag = new_subscription->_from_tag;
+  subscription->_refreshed = true;
+  subscription->_expires = new_subscription->_expires;
 }
 
 void SubscriptionSproutletTsx::log_subscriptions(const std::string& aor_name,

--- a/src/subscriptionsproutlet.cpp
+++ b/src/subscriptionsproutlet.cpp
@@ -512,7 +512,7 @@ AoR::Subscription SubscriptionSproutletTsx::create_subscription(pjsip_msg* req, 
 // local and remote sites with the new subscription data
 Store::Status SubscriptionSproutletTsx::update_subscription_in_stores(
                                              SubscriptionSproutlet* _subscription,
-                                             AoR::Subscription new_subscription,
+                                             AoR::Subscription& new_subscription,
                                              std::string aor,
                                              AssociatedURIs* associated_uris,
                                              pjsip_msg* req,
@@ -661,7 +661,7 @@ AoRPair* SubscriptionSproutletTsx::read_and_cache_from_store(
 // AoRs have subscription information we want to copy over
 void SubscriptionSproutletTsx::update_subscription(
                   SubscriptionSproutlet* _subscription,
-                  AoR::Subscription new_subscription,
+                  AoR::Subscription& new_subscription,
                   std::string aor,
                   AoRPair* aor_pair,
                   std::map<SubscriberDataManager*, AoRPair*>& _cached_aors)

--- a/src/subscriptionsproutlet.cpp
+++ b/src/subscriptionsproutlet.cpp
@@ -532,10 +532,8 @@ Store::Status SubscriptionSproutletTsx::update_subscriptions_in_stores(
                                                       _cached_aors);
   if (local_aor_pair == NULL)
   {
-    // LCOV_EXCL_START - local store (used in testing) never fails
     status = Store::Status::ERROR;
     return status;
-    // LCOV_EXCL_STOP
   }
 
   // Write to the local store, handling any CAS error
@@ -551,7 +549,8 @@ Store::Status SubscriptionSproutletTsx::update_subscriptions_in_stores(
       local_aor_pair = read_and_cache_from_store(_subscription->_sdm, aor, _cached_aors);
       if (local_aor_pair == NULL)
       {
-        // LCOV_EXCL_START - local store (used in testing) never fails
+        // LCOV_EXCL_START We test behaviour on store error elsewhere,
+        // and UT-ing this case is more effort than it's worth
         status = Store::Status::ERROR;
         return status;
         // LCOV_EXCL_STOP
@@ -596,7 +595,8 @@ Store::Status SubscriptionSproutletTsx::update_subscriptions_in_stores(
         remote_aor_pair = read_and_cache_from_store(*sdm, aor, _cached_aors);
         if (remote_aor_pair == NULL)
         {
-          // LCOV_EXCL_START - local store (used in testing) never fails
+          // LCOV_EXCL_START We test behaviour on store error elsewhere,
+          // and UT-ing this case is more effort than it's worth
 
           // We've hit an error in reading from the remote store, but we don't
           // take any action on this. Bail out and try the next store.
@@ -635,11 +635,9 @@ AoRPair* SubscriptionSproutletTsx::read_and_cache_from_store(
   {
     // Failed to get data for the AoR because there is no connection
     // to the store.
-    // LCOV_EXCL_START - local store (used in testing) never fails
     TRC_ERROR("Failed to get AoR subscriptions for %s from store", aor.c_str());
     delete aor_pair;
     return NULL;
-    // LCOV_EXCL_STOP
   }
 
   TRC_DEBUG("Retrieved AoR data %p. Storing in local cache for SDM %p", aor_pair, sdm);

--- a/src/ut/subscription_test.cpp
+++ b/src/ut/subscription_test.cpp
@@ -435,8 +435,7 @@ TEST_F(SubscriptionTest, BadScheme)
   msg._scheme = "sips";
   inject_msg(msg.get());
   ASSERT_EQ(1, txdata_count());
-  pjsip_msg* out = current_txdata()->msg;
-  out = pop_txdata()->msg;
+  pjsip_msg* out = pop_txdata()->msg;
   EXPECT_EQ(404, out->line.status.code);
   EXPECT_EQ("Not Found", str_pj(out->line.status.reason));
 }
@@ -447,8 +446,7 @@ TEST_F(SubscriptionTest, NoContact)
   msg._contact = "";
   inject_msg(msg.get());
   ASSERT_EQ(1, txdata_count());
-  pjsip_msg* out = current_txdata()->msg;
-  out = pop_txdata()->msg;
+  pjsip_msg* out = pop_txdata()->msg;
   EXPECT_EQ(400, out->line.status.code);
   EXPECT_EQ("Bad Request", str_pj(out->line.status.reason));
 }
@@ -483,8 +481,7 @@ TEST_F(SubscriptionTest, LocalStoreGetError)
   SubscribeMessage msg;
   inject_msg(msg.get());
   ASSERT_EQ(1, txdata_count());
-  pjsip_msg* out = current_txdata()->msg;
-  out = pop_txdata()->msg;
+  pjsip_msg* out = pop_txdata()->msg;
   EXPECT_EQ(500, out->line.status.code);
   EXPECT_EQ("Internal Server Error", str_pj(out->line.status.reason));
 }
@@ -562,8 +559,7 @@ TEST_F(SubscriptionTest, LocalStoreSetError)
   SubscribeMessage msg;
   inject_msg(msg.get());
   ASSERT_EQ(1, txdata_count());
-  pjsip_msg* out = current_txdata()->msg;
-  out = pop_txdata()->msg;
+  pjsip_msg* out = pop_txdata()->msg;
   EXPECT_EQ(500, out->line.status.code);
   EXPECT_EQ("Internal Server Error", str_pj(out->line.status.reason));
 }
@@ -850,7 +846,6 @@ TEST_F(SubscriptionTest, LocalStoreNoSubscriptions)
   check_subscriptions("sip:6505550231@homedomain", 2u);
 }
 
-
 /// Check that a subscription where there is data contention doesn't
 /// generate any duplicate NOTIFYs
 TEST_F(SubscriptionTest, SubscriptionWithDataContention)
@@ -879,12 +874,9 @@ TEST_F(SubscriptionTest, SubscriptionWithDataContention)
 // Check data contention in a remote store 
 TEST_F(SubscriptionTest, SubscriptionWitihRemoteDataContention)
 {
-  TRC_DEBUG("SETTING REMOTE STORE CONTENTION FLAG ON %p", _remote_sdm);
-  _remote_data_store->force_contention();
   // Add the base AoR to the remote store
   std::string aor = "sip:6505550231@homedomain";
   int now = time(NULL);
-  TRC_DEBUG("ADDING AOR TO REMOTE STORE");
   AoRPair* aor_pair = _remote_sdm->get_aor_data(aor, 0);
   AoR::Binding* b1 = aor_pair->get_current()->get_binding(std::string("urn:uuid:00000000-0000-0000-0000-b4dd32817622:1"));
   b1->_uri = std::string("<sip:6505550231@192.91.191.29:59934;transport=tcp;ob>");
@@ -902,10 +894,8 @@ TEST_F(SubscriptionTest, SubscriptionWitihRemoteDataContention)
   // Add the AoR record to the store.
   AssociatedURIs associated_uris = {};
   associated_uris.add_uri(aor, false);
-  TRC_DEBUG("SETTING AOR TO REMOTE STORE %p", _remote_sdm);
   _remote_sdm->set_aor_data(aor, aor_pair, 0);
 
-  TRC_DEBUG("SETTING REMOTE STORE CONTENTION FLAG ON %p", _remote_sdm);
   _remote_data_store->force_contention();
 
   // Set up a single subscription - this should generate a 200 OK then
@@ -923,11 +913,10 @@ TEST_F(SubscriptionTest, SubscriptionWitihRemoteDataContention)
 
   check_OK_and_NOTIFY("active", std::make_pair("active", "registered"), irs_impus);
 
-  delete aor_pair; aor_pair = NULL;
+  delete aor_pair;
   // Check there's one subscription stored
   check_subscriptions("sip:6505550231@homedomain", 1u);
 }
-
 
 // Test the Event Header
 // Missing Event header should be rejected


### PR DESCRIPTION
There were a couple of issues present in the old code for creating/updating subscriptions:

* We would perform multiple remote reads on a new subscription 
* If we were unable to create a subscription (because we couldn't read a contact header), we would still update associated IMPUs in the respective AoR, and respond with a 200 OK if the store was updated.

These changes do the following:

* Perform an early check on the contact header, before even reading to the HSS to check registration state, and reject the subscription with a 400 Bad Request if we fail to parse it. This is unlikely to happen, but will save us a bunch of time if we do hit that condition.

* Refactors the old `write_subscriptions_to_store` into a number of new, clearer functions. The flow is now as follows:

    * We create a new Subscription object from the request, parsing all necessary information out.
    * This new subscription is passed into the `update_subscriptions_in_stores` function, whose overall responsibility is handling the full set of flows necessary to add the subscription to local and remote stores
        * Within this function, we read and cache AoRs from local and Remote stores when necessary, using the `read_and_cache_from_stores` function to store the AoRPair data in the `cached_aors` map of SDM* to AoRPair*
        * Within CAS loops, we add/update the subscription in the AoR, using `update_subscriptions`, attempt to set data to the store, and then re-read/cache the AoR if we hit data contention.
        * The remote store loops do not set the return code to an error status if the store fails, as we only really care about local store failure here.
    * Once the stores have been updated, we check the return code, and send an appropriate response of 200 OK or 500 Internal Server Error.

* Adds some new UTs, covering:
    * Subscriptions with no contact header get a 400 Bad Request
    * Get/set errors in local store causes 500 response  (These previously  had LCOV_EXCL in the code, so woo more coverage!)
    * Get/Set errors remote stores do not impact the overall return code.
    * Data contention in remote stores (This highlighted that the contention tests weren't working correctly before, as the localstore wasn't clearing the contention database along with the main database when calling flush_all. Fixed in https://github.com/Metaswitch/cpp-common/pull/696 )


UTs and full_test pass, so that's good. Looking to live test this on our set up test rig later today.
