### PR TITLE
Fix graylisting ACK bug.

### DIFF
--- a/include/basicproxy.h
+++ b/include/basicproxy.h
@@ -290,9 +290,11 @@ protected:
 
       /// Tell the Target about an address and whether it represents a stateless
       /// proxy.
-      /// @param addr            - The address in question.
-      /// @param stateless_proxy - Whether the address is for a stateless proxy.
-      void set(AddrInfo& addr, bool stateless_proxy);
+      /// @param addr - The address in question.
+      /// @param blacklist_by_default
+      ///             - Whether to blacklist the address when we have finished
+      ///               with it (if the state of the address is not known).
+      void set(AddrInfo& addr, bool blacklist_by_default);
 
       /// Helper method to check if the Target had been initialized with an
       /// address.
@@ -313,7 +315,7 @@ protected:
       AddrInfo _addr;
       bool _is_set;
       bool _health_known;
-      bool _stateless_proxy;
+      bool _blacklist_by_default;
 
       // This class is not copyable or moveable. If it were, the semantics of
       Target(const Target& rhs) = delete;

--- a/src/basicproxy.cpp
+++ b/src/basicproxy.cpp
@@ -2274,7 +2274,31 @@ bool BasicProxy::UACTsx::get_next_server()
     AddrInfo addr;
     if (_servers_iter->next(addr))
     {
-      _current_server.set(addr, _stateless_proxy);
+      // Work out whether to blacklist this address by default (i.e. if the
+      // UACTsx gives up on it without explicitly determining its health. We
+      // blacklist by default if:
+      //
+      // -  The request has a transaction associated with it, meaning that the
+      //    request is not an ACK request. ACKs do not have a response so there
+      //    is no clear indication that it has succeeded.
+      //
+      // -  The address is a stateful proxy. For stateful proxies, the most
+      //    likely thing is that the host has failed in some weird way that the
+      //    UACTsx doesn't cope with, so the best thing to do is blacklist the
+      //    host.  State*less* proxies are only blacklisted on transport
+      //    failures. These are easy to spot, so it is unlikely the UACTsx
+      //    didn't spot this, and the best thing to do is mark the host as
+      //    successful.
+      bool blacklist_by_default = (_tsx != nullptr) && !_stateless_proxy;
+      _current_server.set(addr, blacklist_by_default);
+
+      if (Log::enabled(Log::DEBUG_LEVEL))
+      {
+        std::string host_str = addr.to_string();
+        TRC_DEBUG("Selected host %s, %s blacklist by default",
+                  host_str.c_str(), blacklist_by_default ? "will" : "will not");
+      }
+
       return true;
     }
     else
@@ -2294,7 +2318,7 @@ bool BasicProxy::UACTsx::get_next_server()
 //
 
 BasicProxy::UACTsx::Target::Target() :
-  _addr(), _is_set(false), _health_known(false), _stateless_proxy(false)
+  _addr(), _is_set(false), _health_known(false), _blacklist_by_default(false)
 {}
 
 BasicProxy::UACTsx::Target::~Target()
@@ -2302,7 +2326,7 @@ BasicProxy::UACTsx::Target::~Target()
   unset();
 }
 
-void BasicProxy::UACTsx::Target::set(AddrInfo& addr, bool stateless_proxy)
+void BasicProxy::UACTsx::Target::set(AddrInfo& addr, bool blacklist_by_default)
 {
   // A new address is being set, so unset the current one.
   unset();
@@ -2310,7 +2334,7 @@ void BasicProxy::UACTsx::Target::set(AddrInfo& addr, bool stateless_proxy)
   _addr = addr;
   _is_set = true;
   _health_known = false;
-  _stateless_proxy = stateless_proxy;
+  _blacklist_by_default = blacklist_by_default;
 }
 
 bool BasicProxy::UACTsx::Target::is_set() { return _is_set; }
@@ -2341,21 +2365,13 @@ void BasicProxy::UACTsx::Target::unset()
     // We have a target already and we don't know its health (because the caller
     // hasn't told us). However we need to call success or blacklist on the
     // address.
-    //
-    // For stateful proxies, the most likely thing is that the host has failed
-    // in some weird way that the BasicProxy doesn't cope with, so the best
-    // thing to do is blacklist the host.
-    //
-    // State*less* proxies are only blacklisted on transport failures. These are
-    // easy to spot, so it is unlikely the BasicProxy didn't spot this, and the
-    // best thing to do is mark the host as successful.
-    if (_stateless_proxy)
+    if (_blacklist_by_default)
     {
-      PJUtils::success(_addr);
+      PJUtils::blacklist(_addr);
     }
     else
     {
-      PJUtils::blacklist(_addr);
+      PJUtils::success(_addr);
     }
   }
 }

--- a/src/basicproxy.cpp
+++ b/src/basicproxy.cpp
@@ -2295,7 +2295,7 @@ bool BasicProxy::UACTsx::get_next_server()
       if (Log::enabled(Log::DEBUG_LEVEL))
       {
         std::string host_str = addr.to_string();
-        TRC_DEBUG("Selected host %s, %s blacklist by default",
+        TRC_DEBUG("Selected host %s (%s be blacklisted by default)",
                   host_str.c_str(), blacklist_by_default ? "will" : "will not");
       }
 

--- a/src/ut/basicproxy_test.cpp
+++ b/src/ut/basicproxy_test.cpp
@@ -4102,6 +4102,7 @@ TEST_F(BasicProxyTest, FailedProbeDoesNotUngraylist)
   delete tp;
 }
 
+
 // Test that an ACK does not blacklist a target (due to not getting a response).
 TEST_F(BasicProxyTest, AckDoesNotBlacklist)
 {
@@ -4173,7 +4174,7 @@ TEST_F(BasicProxyTest, AckDoesNotBlacklist)
   ReqMatcher("INVITE").matches(tdata->msg);
 
   // Check that it was sent to the first server, which should not have been
-  // graylisted by being sent an ACK.
+  // blacklisted by being sent an ACK.
   EXPECT_STREQ("TCP", tdata->tp_info.transport->type_name) << "Wrong transport type";
   EXPECT_EQ(5060, tdata->tp_info.transport->remote_name.port) << "Wrong transport port";
   server1 = str_pj(tdata->tp_info.transport->remote_name.host);


### PR DESCRIPTION
This PR fixes a bug in graylisting where a host would get blacklisted whenever it gets sent an ACK. 

The problem was that the `Target` class white/blacklists the host automatically if it hasn't been told the state of the host by the time the `Target` gets destroyed or unset (e.g. because we're moving onto another target). This caused a problem for ACKs since the only way we know a host is definitely healthy is receiving a response from it, and ACKs don't have responses. 

I've fixed this by having the `UACTsx` tell the `Target` whether the host should be blacklisted by default. This flag is only set for requests that have a PJSIP transaction (meaning they require a response), and the host is not a stateless proxy. 

Tested in UT. ST will follow when I've merged this PR to the integration branch. 