### PR TITLE
Hit uncovered code for Admin Dereg

### DIFF
--- a/src/notify_utils.cpp
+++ b/src/notify_utils.cpp
@@ -219,12 +219,10 @@ pj_xml_node* notify_create_reg_state_xml(
           c_event = STR_UNREGISTERED;
           c_state = STR_TERMINATED;
           break;
-        // LCOV_EXCL_START - TODO
         case NotifyUtils::ContactEvent::DEACTIVATED:
           c_event = STR_DEACTIVATED;
           c_state = STR_TERMINATED;
           break;
-        // LCOV_EXCL_STOP
       }
 
       contact_node = create_contact_node(pool,

--- a/src/ut/subscriber_data_manager_test.cpp
+++ b/src/ut/subscriber_data_manager_test.cpp
@@ -488,6 +488,11 @@ TEST_F(BasicSubscriberDataManagerTest, NotifyExpiredSubscription)
   s0->_route_uris.push_back(std::string("<sip:abcdefgh@bono-1.cw-ngv.com;lr>"));
   s0->_expires = now + 300;
 
+  // Add URI
+  std::string aor1 = "5102175691@cw-ngv.com";
+  associated_uris.add_uri(aor1, false);
+  aor_data1->get_current()->_associated_uris = associated_uris;
+
   // Add another pair of binding and subscription.
   b1 = aor_data1->get_current()->get_binding(std::string("urn:uuid:00000000-0000-0000-0000-b4dd32817622:1"));
   b1->_uri = std::string("<sip:5102175691@192.91.191.29:59934;transport=tcp;ob>");
@@ -530,7 +535,6 @@ TEST_F(BasicSubscriberDataManagerTest, NotifyExpiredSubscription)
   b2->_emergency_registration = false;
 
   // Write AoR record back to store.
-  std::string aor1 = "5102175691@cw-ngv.com";
   bool rc = this->_store->set_aor_data(aor1, SubscriberDataManager::EventTrigger::ADMIN, aor_data1, 0);
   EXPECT_TRUE(rc);
   delete aor_data1; aor_data1 = NULL;


### PR DESCRIPTION
Hey Ellie it seemed strange that this code for DEACTIVATED is uncovered and a bug seemed very likely. It so happens that all Admin Dereg cases in handler_test are using Mock SDM, and only one subscriber_data_manager_test uses Admin Dereg.
This one test that should cover the code didn't have associated_uri set before. Now it does and goes through the right function calls. 

`make full_test` passed.