### PR TITLE
[Reviewer: Adam] 250 worker threads per core

### DIFF
--- a/sprout-base.root/etc/init.d/sprout
+++ b/sprout-base.root/etc/init.d/sprout
@@ -91,7 +91,7 @@ get_settings()
 
         # Set up defaults for user settings then pull in any overrides.
         # Sprout uses blocking look-up services, so must run multi-threaded.
-        num_worker_threads=$(($(grep processor /proc/cpuinfo | wc -l) * 50))
+        num_worker_threads=$(($(grep processor /proc/cpuinfo | wc -l) * 250))
         num_http_threads=$(($(grep processor /proc/cpuinfo | wc -l) * 50))
 
         # Testing has shown that we can handle at least 250 requests per second per core - this is


### PR DESCRIPTION
Default to 250 sprout worker threads per core, because the threads are blocking.

I've live tested that this defaults correctly, and we've already live tested that this number of threads fixes the latency issues.