### PR TITLE
Updates sbin and divides sbin and bin scripts

### DIFF
--- a/debian/sprout-scscf.links
+++ b/debian/sprout-scscf.links
@@ -1,5 +1,6 @@
-/usr/share/clearwater/clearwater-config-manager/scripts/remove_shared_ifcs_xml /usr/bin/cw-remove_shared_ifcs_xml
-/usr/share/clearwater/clearwater-config-manager/scripts/remove_fallback_ifcs_xml /usr/bin/cw-remove_fallback_ifcs_xml
+/usr/share/clearwater/clearwater-config-manager/scripts/remove_shared_ifcs_xml /usr/sbin/cw-remove_shared_ifcs_xml
+/usr/share/clearwater/clearwater-config-manager/scripts/remove_fallback_ifcs_xml /usr/sbin/cw-remove_fallback_ifcs_xml
+
 /usr/share/clearwater/clearwater-config-manager/scripts/validate_shared_ifcs_xml /usr/bin/cw-validate_shared_ifcs_xml
 /usr/share/clearwater/clearwater-config-manager/scripts/validate_fallback_ifcs_xml /usr/bin/cw-validate_fallback_ifcs_xml
 /usr/share/clearwater/clearwater-config-manager/scripts/display_shared_ifcs /usr/bin/cw-display_shared_ifcs


### PR DESCRIPTION
This reorders links to put a gap between sbin and bin, also makes the remove scripts require sudo