### PR TITLE
[Reviewer: Seb] Tweak log levels to prevent log spam in expected cases

### DIFF
--- a/src/enumservice.cpp
+++ b/src/enumservice.cpp
@@ -237,7 +237,7 @@ std::string JSONEnumService::lookup_uri_from_user(const std::string &user, SAS::
 
   if (pfix == NULL)
   {
-    TRC_WARNING("No matching number range %s from ENUM lookup", user.c_str());
+    TRC_INFO("No matching number range %s from ENUM lookup", user.c_str());
     SAS::Event event(trail, SASEvent::ENUM_INCOMPLETE, 0);
     event.add_var_param(user);
     SAS::report_event(event);

--- a/src/registrarsproutlet.cpp
+++ b/src/registrarsproutlet.cpp
@@ -1080,8 +1080,9 @@ AoRPair* RegistrarSproutletTsx::write_to_store(
       if (!store_access_ok)
       {
         // This means that there was an error accessing the store. We don't hit
-        // this if we just fail to find any bindings.
-        TRC_ERROR("Store access error: Failed to get AoR binding for %s", aor.c_str());
+        // this if we just fail to find any bindings. This is already SAS logged
+        // at a lower level, so just drop a debug log.
+        TRC_DEBUG("Store access error: Failed to get AoR binding for %s", aor.c_str());
         break;
       }
       out_no_existing_bindings_found = out_no_existing_bindings_found && aor_pair->get_current()->bindings().empty();

--- a/src/registration_utils.cpp
+++ b/src/registration_utils.cpp
@@ -812,8 +812,9 @@ bool RegistrationUtils::get_aor_data(AoRPair** aor_pair,
       ((*aor_pair)->get_current() == NULL))
   {
     // Failed to get data for the AoR because there is no connection
-    // to the store.
-    TRC_ERROR("Store connection error.  Failed to get AoR binding for %s from store", aor_id.c_str());
+    // to the store. This will already have been SAS logged by the AoR store.
+    TRC_DEBUG("Store connection error.  Failed to get AoR binding for %s from store",
+              aor_id.c_str());
     return false;
   }
 


### PR DESCRIPTION
Seb,

I've tweaked a couple of log levels. In all cases, the event will be being SAS logged anyway, and these are per call events, so we shouldn't really have engineering logs for them at Warning level.

There's more detail in the commits themselves.