### PR TITLE
Tidy up overload code

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1713,7 +1713,7 @@ int main(int argc, char* argv[])
   opt.max_call_list_length = 0;
   opt.memento_threads = 25;
   opt.call_list_ttl = 604800;
-  opt.target_latency_us = 100000;
+  opt.target_latency_us = 10000;
   opt.cass_target_latency_us = 1000000;
   opt.max_tokens = 1000;
   opt.init_token_rate = 100.0;

--- a/src/thread_dispatcher.cpp
+++ b/src/thread_dispatcher.cpp
@@ -308,11 +308,16 @@ static bool ignore_load_monitor(pjsip_rx_data* rdata)
     // LCOV_EXCL_STOP
   }
 
-  // Always accept ACK and OPTIONS requests. Monit probes Sprout using OPTIONS
-  // polls, so these are allowed through the load monitor to prevent Monit
-  // killing Sprout during overload.
-  pjsip_method_e method_id = rdata->msg_info.msg->line.req.method.id;
-  if (method_id == PJSIP_ACK_METHOD || method_id == PJSIP_OPTIONS_METHOD)
+  // Always accept OPTIONS, ACK and SUBSCRIBE requests.
+  // -  Monit probes Sprout using OPTIONS polls, so these are allowed through
+  //    the load monitor to prevent Monit killing Sprout during overload.
+  // -  There is no way to reject an ACK, so always allow them.
+  // -  SUBSCRIBE flows are effectively follow on work from  having allowed a
+  //    subscriber to register.
+  const pjsip_method& method = rdata->msg_info.msg->line.req.method;
+  if ((pjsip_method_cmp(&method, pjsip_get_options_method()) == 0) ||
+      (pjsip_method_cmp(&method, pjsip_get_ack_method()) == 0) ||
+      (pjsip_method_cmp(&method, pjsip_get_subscribe_method()) == 0))
   {
     return true;
   }

--- a/src/ut/thread_dispatcher_test.cpp
+++ b/src/ut/thread_dispatcher_test.cpp
@@ -169,6 +169,20 @@ TEST_F(ThreadDispatcherTest, NeverRejectOptionsTest)
   process_queue_element();
 }
 
+// On recieving a SUBSCRIBE message, the thread dispatcher should not call into
+// the load monitor - it should process the request regardless of load.
+TEST_F(ThreadDispatcherTest, NeverRejectSubscribeTest)
+{
+  TestingCommon::Message msg;
+  msg._method = "SUBSCRIBE";
+
+  EXPECT_CALL(*mod_mock, on_rx_request(_)).WillOnce(Return(PJ_TRUE));
+  EXPECT_CALL(load_monitor, request_complete(_, _));
+
+  inject_msg_thread(msg.get_request());
+  process_queue_element();
+}
+
 // On recieving a SIP response, the thread dispatcher should not call into the
 // load monitor - it should process the request regardless of load.
 TEST_F(ThreadDispatcherTest, NeverRejectResponseTest)


### PR DESCRIPTION
Two small changes to sprout's overload behavior:

* Now that the latency calculation doesn't include downstream latency, the default target latency should be reduced. I've run a sprout node under rated load and the smoothed latency was typically ~2000us, so setting the default to 10000us seems reasonable. 
* We've agreed to ignore the load monitor on all SUBSCRIBEs, not just dialog creating ones. The argument here is SUBSCRIBEs are really just follow on work from having accepted the REGISTER. 