### PR TITLE
[Reviewer: Seb] Fix and avoid race condition in Sproutlet timers

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1711,8 +1711,8 @@ int main(int argc, char* argv[])
   opt.sip_blacklist_duration = SIPResolver::DEFAULT_BLACKLIST_DURATION;
   opt.http_blacklist_duration = HttpResolver::DEFAULT_BLACKLIST_DURATION;
   opt.astaire_blacklist_duration = AstaireResolver::DEFAULT_BLACKLIST_DURATION;
-  opt.sip_tcp_connect_timeout = 2000;
-  opt.sip_tcp_send_timeout = 2000;
+  opt.sip_tcp_connect_timeout = 1800;
+  opt.sip_tcp_send_timeout = 1800;
   opt.dns_timeout = DnsCachedResolver::DEFAULT_TIMEOUT;
   opt.session_continued_timeout_ms = SCSCFSproutlet::DEFAULT_SESSION_CONTINUED_TIMEOUT;
   opt.session_terminated_timeout_ms = SCSCFSproutlet::DEFAULT_SESSION_TERMINATED_TIMEOUT;

--- a/src/sproutletproxy.cpp
+++ b/src/sproutletproxy.cpp
@@ -1069,10 +1069,12 @@ void SproutletProxy::UASTsx::process_timer_pop(pj_timer_entry* tentry)
 {
   enter_context();
 
-  _pending_timers.erase(tentry);
-  TimerCallbackData* tdata = (TimerCallbackData*)tentry->user_data;
-  tdata->sproutlet_wrapper->on_timer_pop((TimerID)tentry, tdata->context);
-  schedule_requests();
+  if (_pending_timers.erase(tentry) != 0)
+  {
+    TimerCallbackData* tdata = (TimerCallbackData*)tentry->user_data;
+    tdata->sproutlet_wrapper->on_timer_pop((TimerID)tentry, tdata->context);
+    schedule_requests();
+  }
 
   exit_context();
 }


### PR DESCRIPTION
Seb,

If a timer pops, and before being scheduled, it's cancelled, it'll still be executed.

This protects against this by checking whether it's still one of the pending timers.

We also attempt to avoid a race condition by changing the TCP connect timeout away from matching the 2 seconds we have as a value for the AS Session Continued timeout.

Doing this, running stress across a deployment with a failed app server, and running the live tests, I don't see any failures.