### PR TITLE
Remove the "nice" capability from the sprout executables

### DIFF
--- a/debian/sprout-base.postinst
+++ b/debian/sprout-base.postinst
@@ -68,7 +68,6 @@ case "$1" in
 
         setup_user
         setup_logging
-        setcap 'cap_sys_nice=eip' /usr/share/clearwater/bin/sprout
         [ ! -x /usr/share/clearwater/bin/clearwater-logging-update ] || /usr/share/clearwater/bin/clearwater-logging-update
         add_section /etc/security/limits.conf sprout /etc/security/limits.conf.sprout
         /usr/share/clearwater/infrastructure/scripts/sprout.monit


### PR DESCRIPTION
We can achieve the same thing using ulimits, and setting the capability breaks advanced backtraces.