### PR TITLE
[Reviewer: RJW2] Allow non-PJSIP threads to place work on the worker thread queue

### DIFF
--- a/include/pjutils.h
+++ b/include/pjutils.h
@@ -196,8 +196,11 @@ public:
 // object that can safely be run on another thread.
 typedef Callback* (*send_callback_builder)(void* token, pjsip_event* event);
 
-// Runs the specified callback on a worker thread
-void run_callback_on_worker_thread(PJUtils::Callback* cb);
+// Runs the specified callback on a worker thread.
+// `is_pjsip_thread` is used to allow a non-PJSIP owned thread (e.g. an HTTP
+// thread) to indicate that it can't possibly be the transport thread.
+void run_callback_on_worker_thread(PJUtils::Callback* cb,
+                                   bool is_pjsip_thread = true);
 
 pj_status_t send_request(pjsip_tx_data* tdata,
                          int retries=0,

--- a/include/thread_dispatcher.h
+++ b/include/thread_dispatcher.h
@@ -111,7 +111,6 @@ struct SipEvent
 bool process_queue_element();
 
 // Add a Callback object to the queue, to be run on a worker thread.
-// This MUST be called from the main PJSIP transport thread.
 void add_callback_to_queue(PJUtils::Callback*);
 
 // Implements eventq::Backend as a std::priority_queue of SipEvent structs.

--- a/src/chronoshandlers.cpp
+++ b/src/chronoshandlers.cpp
@@ -57,7 +57,7 @@ void ChronosAoRTimeoutTask::run()
 
   send_http_reply(HTTP_OK);
 
-  PJUtils::run_callback_on_worker_thread(new ChronosAoRTimeoutTaskHandler(this));
+  PJUtils::run_callback_on_worker_thread(new ChronosAoRTimeoutTaskHandler(this), false);
 }
 
 HTTPCode ChronosAoRTimeoutTask::parse_response(std::string body)

--- a/src/pjutils.cpp
+++ b/src/pjutils.cpp
@@ -1233,15 +1233,16 @@ static void on_tsx_state(pjsip_transaction* tsx, pjsip_event* event)
 
 /// Runs a Callback object on a worker thread.
 /// Takes ownership of the Callback and is responsible for deleting it
-void PJUtils::run_callback_on_worker_thread(PJUtils::Callback* cb)
+void PJUtils::run_callback_on_worker_thread(PJUtils::Callback* cb,
+                                            bool is_pjsip_thread)
 {
   // The UTs have a different threading model - in those we run the callback
   // directly on whatever thread we're on
 #ifndef UNIT_TEST
-  if (is_pjsip_transport_thread())
+  if (is_pjsip_transport_thread() || !is_pjsip_thread)
   {
-    // We're on the transport thread, so we must add the callback to the worker
-    // thread's queue
+    // We're either on the transport thread or on a non-PJSIP owned thread, so
+    // add the callback to the worker thread queue
     // This relinquishes ownership of the Callback object
     add_callback_to_queue(cb);
   }

--- a/src/thread_dispatcher.cpp
+++ b/src/thread_dispatcher.cpp
@@ -622,12 +622,6 @@ void add_callback_to_queue(PJUtils::Callback* cb)
   // future we may want to look at prioritizing them
   qe.priority = SipEventPriorityLevel::NORMAL_PRIORITY;
 
-  // Track the current queue size
-  if (queue_size_table)
-  {
-    queue_size_table->accumulate(sip_event_queue.size()); // LCOV_EXCL_LINE
-  }
-
   // Add the SipEvent
   TRC_DEBUG("Queuing callback %p for worker threads with priority %d",
             cb,


### PR DESCRIPTION
As discussed, the recent change to try to move Chronos timer pop handling to a worker thread wasn't working because only the transport thread was allowed to place work on the queue.

This PR removes that restriction. The queue is already protected by a lock, so we just don't report the queue size when adding work this way, which is OK because the transport thread will report the correct size when it next places a message on the queu.

It's not tested other than by `make test`, so we should run load through this change before we merge it.