### PR TITLE
[Reviewer EM] Send out terminate+create contact in NOTIFY if Contact URI changes

### DIFF
--- a/src/subscriber_data_manager.cpp
+++ b/src/subscriber_data_manager.cpp
@@ -681,7 +681,7 @@ void SubscriberDataManager::NotifySender::send_notifys(
       }
       else
       {
-        // The binding is in both AoRs. Check if the expiry time has changed at all
+        // The binding is in both AoRs. 
         NotifyUtils::ContactEvent event;
 
         if (aor_orig_b_match->second->_uri.compare(binding->_uri) != 0)

--- a/src/subscriber_data_manager.cpp
+++ b/src/subscriber_data_manager.cpp
@@ -292,8 +292,21 @@ void SubscriberDataManager::classify_bindings(const std::string& aor_id,
     }
     else
     {
-      // The binding is in both AoRs. Check if the expiry time has changed at all
-      if (aor_orig_b_match->second->_expires < aor_current_b.second->_expires)
+      // The binding is in both AoRs. 
+      if (aor_orig_b_match->second->_uri.compare(aor_current_b.second->_uri) != 0)
+      {
+        // Change of Contact URI. If the contact URI has been changed, we need to
+        // terminate the old contact (ref TS24.229 -  NOTE 2 in 5.4.2.1.2	
+        // "Notification about registration state") and create a new one.  
+        // We do this by adding a DEACTIVATED and then a CREATED ClassifiedBinding.
+        ClassifiedBinding* deactivated_record =
+           new ClassifiedBinding(aor_orig_b_match->first,
+                                 aor_orig_b_match->second,
+                                 NotifyUtils::ContactEvent::DEACTIVATED);
+        classified_bindings.push_back(deactivated_record);
+        event = NotifyUtils::ContactEvent::CREATED;
+      }
+      else if (aor_orig_b_match->second->_expires < aor_current_b.second->_expires)
       {
         TRC_DEBUG("Binding %s in AoR %s has been refreshed",
                   aor_current_b.first.c_str(),
@@ -671,7 +684,25 @@ void SubscriberDataManager::NotifySender::send_notifys(
         // The binding is in both AoRs. Check if the expiry time has changed at all
         NotifyUtils::ContactEvent event;
 
-        if (aor_orig_b_match->second->_expires < binding->_expires)
+        if (aor_orig_b_match->second->_uri.compare(binding->_uri) != 0)
+        {
+          // Change of Contact URI. If the contact URI has been changed, we need to
+          // terminate the old contact (ref TS24.229 -  NOTE 2 in 5.4.2.1.2	
+          // "Notification about registration state") and create a new one.  
+          // We do this by adding a DEACTIVATED and then a CREATED ClassifiedBinding.
+          TRC_DEBUG("Binding %s has changed URIs from %s to %s", 
+                                      b_id.c_str(),
+                                      aor_orig_b_match->second->_uri.c_str(),
+                                      binding->_uri.c_str());
+          NotifyUtils::BindingNotifyInformation* deactivated_bni =
+             new NotifyUtils::BindingNotifyInformation(b_id,
+                                                       aor_orig_b_match->second,
+                                                       NotifyUtils::ContactEvent::DEACTIVATED);
+          binding_info_to_notify.push_back(deactivated_bni);
+          event = NotifyUtils::ContactEvent::CREATED;
+          bindings_changed = true;
+        }
+        else if (aor_orig_b_match->second->_expires < binding->_expires)
         {
           TRC_DEBUG("Binding %s has been refreshed", b_id.c_str());
           event = NotifyUtils::ContactEvent::REFRESHED;

--- a/src/ut/registrar_test.cpp
+++ b/src/ut/registrar_test.cpp
@@ -306,7 +306,8 @@ public:
   void check_notify(pjsip_msg* out,
                     std::string expected_aor,
                     std::string reg_state,
-                    std::pair<std::string, std::string> contact_values)
+                    std::pair<std::string, std::string> contact_values,
+                    bool check_last = false)
   {
     char buf[16384];
     int n = out->body->print_body(out->body, buf, sizeof(buf));
@@ -331,7 +332,15 @@ public:
     ASSERT_TRUE(reg_info);
     rapidxml::xml_node<> *registration = reg_info->first_node("registration");
     ASSERT_TRUE(registration);
-    rapidxml::xml_node<> *contact = registration->first_node("contact");
+    rapidxml::xml_node<> *contact;
+    if (check_last)
+    {
+      contact = registration->last_node("contact");      
+    }
+    else
+    {
+      contact = registration->first_node("contact");      
+    }
     ASSERT_TRUE(contact);
 
     ASSERT_EQ(expected_aor, std::string(registration->first_attribute("aor")->value()));
@@ -2984,9 +2993,22 @@ TEST_F(RegistrarTest, RegistrationWithSubscription)
   inject_msg(respond_to_current_txdata(200));
   free_txdata();
 
+  // Change the Contact URI on the registration
+  msg._contact = "sip:f5cc3de4334589d89c661a7acf228ed7@10.114.61.214:5061;transport=tcp;ob";
+  msg._cseq = "16570";
+  msg._unique += 1;
+  inject_msg(msg.get());
+  ASSERT_EQ(2, txdata_count());
+  out = pop_txdata()->msg;
+  EXPECT_EQ("NOTIFY", str_pj(out->line.status.reason));
+  check_notify(out, aor, "active", std::make_pair("terminated", "deactivated"));
+  check_notify(out, aor, "active", std::make_pair("active", "created"), true);
+  inject_msg(respond_to_current_txdata(200));
+  free_txdata();
+
   // Delete the registration
   msg._expires = "Expires: 0";
-  msg._cseq = "16570";
+  msg._cseq = "16571";
   msg._unique += 1;
   inject_msg(msg.get());
   ASSERT_EQ(2, txdata_count());

--- a/src/ut/registrar_test.cpp
+++ b/src/ut/registrar_test.cpp
@@ -307,7 +307,7 @@ public:
                     std::string expected_aor,
                     std::string reg_state,
                     std::pair<std::string, std::string> contact_values,
-                    bool check_last = false)
+                    int check_contact = 0)
   {
     char buf[16384];
     int n = out->body->print_body(out->body, buf, sizeof(buf));
@@ -333,14 +333,12 @@ public:
     rapidxml::xml_node<> *registration = reg_info->first_node("registration");
     ASSERT_TRUE(registration);
     rapidxml::xml_node<> *contact;
-    if (check_last)
+    contact = registration->first_node("contact");      
+    for (int ii; ii < check_contact; ii++)
     {
-      contact = registration->last_node("contact");      
+      contact = contact->next_sibling();      
     }
-    else
-    {
-      contact = registration->first_node("contact");      
-    }
+
     ASSERT_TRUE(contact);
 
     ASSERT_EQ(expected_aor, std::string(registration->first_attribute("aor")->value()));
@@ -3002,7 +3000,7 @@ TEST_F(RegistrarTest, RegistrationWithSubscription)
   out = pop_txdata()->msg;
   EXPECT_EQ("NOTIFY", str_pj(out->line.status.reason));
   check_notify(out, aor, "active", std::make_pair("terminated", "deactivated"));
-  check_notify(out, aor, "active", std::make_pair("active", "created"), true);
+  check_notify(out, aor, "active", std::make_pair("active", "created"), 1);
   inject_msg(respond_to_current_txdata(200));
   free_txdata();
 


### PR DESCRIPTION
Hi Ellie

Can you review this "terminate and recreate Contact in NOTIFY if Contact URI changes" fix?  I think the customer is going to want it in 11.1 - can we get it in despite the code freeze?

Some notes

- I tested live using sipp scripts to sending in a UDP REGISTER to a given IMPU first from one client box and then from another.  I confirmed that the P-CSCF was apparently happy to delete the old contact
- I haven't changed the logic for analytics, which means that (I think), we'll get both a call to

_analytics->registration(classified_binding->_b->_address_of_record,
                               classified_binding->_id,
                               classified_binding->_b->_uri,
                               0);

and to 

      _analytics->registration(classified_binding->_b->_address_of_record,
                               classified_binding->_id,
                               classified_binding->_b->_uri,
                               classified_binding->_b->_expires - now);
Is this acceptable?
