### PR TITLE
[Reviewer: EM] Ignore load monitor for emergency requests and AS requests

### DIFF
--- a/src/thread_dispatcher.cpp
+++ b/src/thread_dispatcher.cpp
@@ -467,18 +467,13 @@ static bool ignore_load_monitor(pjsip_rx_data* rdata,
     return true;
   }
 
-  // Always accept MESSAGEs with "urn:service:sos" in the request URI.
-  const pjsip_method message_method= { PJSIP_OTHER_METHOD, { "MESSAGE", 7 }};
+  // Always accept messages with "urn:service:sos" in the request URI.
   pjsip_uri* req_uri = rdata->msg_info.msg->line.req.uri;
-  if ((pjsip_method_cmp(&method, &message_method) == 0) &&
-      (PJSIP_URI_SCHEME_IS_URN(req_uri)))
+  std::string req_uri_str = PJUtils::uri_to_string(PJSIP_URI_IN_REQ_URI, req_uri);
+  if (req_uri_str == "urn:service:sos")
   {
-    std::string req_uri_str = PJUtils::uri_to_string(PJSIP_URI_IN_REQ_URI, req_uri);
-    if (req_uri_str == "urn:service:sos")
-    {
-      log_ignore_load_monitor(trail, URN_SERVICE_SOS);
-      return true;
-    } // LCOV_EXCL_LINE - For some reason this isn't covered.
+    log_ignore_load_monitor(trail, URN_SERVICE_SOS);
+    return true;
   }
 
   return false;

--- a/src/ut/thread_dispatcher_test.cpp
+++ b/src/ut/thread_dispatcher_test.cpp
@@ -270,6 +270,56 @@ TEST_F(ThreadDispatcherTest, NeverRejectInDialogTest)
   msg._method = "UPDATE";
   msg._in_dialog = true;
 
+  EXPECT_CALL(*mod_mock, on_rx_request(_)).WillOnce(Return(PJ_TRUE));
+  EXPECT_CALL(load_monitor, get_target_latency_us()).WillOnce(Return(100000));
+  EXPECT_CALL(load_monitor, request_complete(_, _));
+
+  inject_msg_thread(msg.get_request());
+  process_queue_element();
+}
+
+// On receiving a request that contains an ODI token in the top route header,
+// the thread dispatcher should not call into the load monitor - it should
+// process the request regardless of load.
+TEST_F(ThreadDispatcherTest, NeverRejectASRequestTest)
+{
+  TestingCommon::Message msg;
+  msg._method = "INVITE";
+  msg._route = "Route: <sip:odi_i5u09fdngj45@10.225.20.254;service=scscf>";
+
+  EXPECT_CALL(*mod_mock, on_rx_request(_)).WillOnce(Return(PJ_TRUE));
+  EXPECT_CALL(load_monitor, get_target_latency_us()).WillOnce(Return(100000));
+  EXPECT_CALL(load_monitor, request_complete(_, _));
+
+  inject_msg_thread(msg.get_request());
+  process_queue_element();
+}
+
+// On recieving an emergency registration, the thread dispatcher should not call
+// into the load monitor - it should process the request regardless of load.
+TEST_F(ThreadDispatcherTest, NeverRejectEmergencyRegTest)
+{
+  TestingCommon::Message msg;
+  msg._method = "REGISTER";
+  msg._extra = "Contact: <sip:dfgkjk34j5kjdfg0fd8g34jdfhgk345h@10.114.61.213:5061;transport=tcp;ob>;expires=3600;+sip.ice;reg-id=1\r\n"
+               "Contact: <sip:f5cc3de4334589d89c661a7acf228ed7@10.114.61.213:5061;transport=tcp;sos;ob>;expires=3600;+sip.ice;reg-id=1";
+
+  EXPECT_CALL(*mod_mock, on_rx_request(_)).WillOnce(Return(PJ_TRUE));
+  EXPECT_CALL(load_monitor, get_target_latency_us()).WillOnce(Return(100000));
+  EXPECT_CALL(load_monitor, request_complete(_, _));
+
+  inject_msg_thread(msg.get_request());
+  process_queue_element();
+}
+
+// On recieving a MESSAGE with urn:service:sos in the request URI, the thread
+// dispatcher should not call into the load monitor - it should process the
+// request regardless of load.
+TEST_F(ThreadDispatcherTest, NeverRejectUrnServiceSosTest)
+{
+  TestingCommon::Message msg;
+  msg._method = "MESSAGE";
+  msg._requri = "urn:service:sos";
 
   EXPECT_CALL(*mod_mock, on_rx_request(_)).WillOnce(Return(PJ_TRUE));
   EXPECT_CALL(load_monitor, get_target_latency_us()).WillOnce(Return(100000));

--- a/src/ut/thread_dispatcher_test.cpp
+++ b/src/ut/thread_dispatcher_test.cpp
@@ -310,7 +310,7 @@ TEST_F(ThreadDispatcherTest, NeverRejectRegisterTest)
   process_queue_element();
 }
 
-// On recieving a MESSAGE with urn:service:sos in the request URI, the thread
+// On recieving a message with urn:service:sos in the request URI, the thread
 // dispatcher should not call into the load monitor - it should process the
 // request regardless of load.
 TEST_F(ThreadDispatcherTest, NeverRejectUrnServiceSosTest)

--- a/src/ut/thread_dispatcher_test.cpp
+++ b/src/ut/thread_dispatcher_test.cpp
@@ -295,14 +295,12 @@ TEST_F(ThreadDispatcherTest, NeverRejectASRequestTest)
   process_queue_element();
 }
 
-// On recieving an emergency registration, the thread dispatcher should not call
-// into the load monitor - it should process the request regardless of load.
-TEST_F(ThreadDispatcherTest, NeverRejectEmergencyRegTest)
+// On recieving a registration, the thread dispatcher should not call into the
+// load monitor - it should process the request regardless of load.
+TEST_F(ThreadDispatcherTest, NeverRejectRegisterTest)
 {
   TestingCommon::Message msg;
   msg._method = "REGISTER";
-  msg._extra = "Contact: <sip:dfgkjk34j5kjdfg0fd8g34jdfhgk345h@10.114.61.213:5061;transport=tcp;ob>;expires=3600;+sip.ice;reg-id=1\r\n"
-               "Contact: <sip:f5cc3de4334589d89c661a7acf228ed7@10.114.61.213:5061;transport=tcp;sos;ob>;expires=3600;+sip.ice;reg-id=1";
 
   EXPECT_CALL(*mod_mock, on_rx_request(_)).WillOnce(Return(PJ_TRUE));
   EXPECT_CALL(load_monitor, get_target_latency_us()).WillOnce(Return(100000));


### PR DESCRIPTION
Ignores load monitor for:
 - Requests containing an ODI token.
 - all registrations.
 - MESSAGEs with "urn:service:sos" in the request URI.

SAS PR to follow.