### PR TITLE
[Reviewer: SS5] Recover from CSeq desync

### DIFF
--- a/include/registrarsproutlet.h
+++ b/include/registrarsproutlet.h
@@ -129,7 +129,8 @@ protected:
                           std::vector<SubscriberDataManager*> backup_sdms,
                                                                       ///<backup stores to read from if no entry in store and no backup data
                           std::string private_id,                     ///<private id that the binding was registered with
-                          bool& out_all_bindings_expired);            ///<[out] whether all bindings have now expired.
+                          bool& out_all_bindings_expired,             ///<[out] whether all bindings have now expired.
+                          int& initial_notify_cseq);                  ///<[out] The CSeq value on the AoR pair before it is written to the store
 
   bool get_private_id(pjsip_msg* req, std::string& id);
   std::string get_binding_id(pjsip_contact_hdr *contact);

--- a/src/registrarsproutlet.cpp
+++ b/src/registrarsproutlet.cpp
@@ -452,13 +452,6 @@ void RegistrarSproutletTsx::process_register_request(pjsip_msg *req)
                                      private_id_for_binding,
                                      all_bindings_expired);
 
-  // We want to write the same CSeq value to the remote stores as we have just
-  // written to the local one. Writing to the store causes the CSeq to be
-  // incremented, so we correct for that by decrementing it.
-  // This isn't an ideal solution - this entire area of code is due to be
-  // refactored, at which point a more permanent fix should be implemented.
-  int local_notify_cseq = aor_pair->get_current()->_notify_cseq - 1;
-
   // Update our view of whether this was in fact an initial registration based
   // on whether we found any bindings. There are race conditions where
   // at the time that Homestead processed the request this looked like an
@@ -487,6 +480,13 @@ void RegistrarSproutletTsx::process_register_request(pjsip_msg *req)
   {
     // Log the bindings.
     log_bindings(aor, aor_pair->get_current());
+
+    // We want to write the same CSeq value to the remote stores as we have just
+    // written to the local one. Writing to the store causes the CSeq to be
+    // incremented, so we correct for that by decrementing it.
+    // This isn't an ideal solution - this entire area of code is due to be
+    // refactored, at which point a more permanent fix should be implemented.
+    int local_notify_cseq = aor_pair->get_current()->_notify_cseq - 1;
 
     // If we have any remote stores, try to store this in them too. We don't worry
     // about failures in this case.

--- a/src/registrarsproutlet.cpp
+++ b/src/registrarsproutlet.cpp
@@ -452,6 +452,13 @@ void RegistrarSproutletTsx::process_register_request(pjsip_msg *req)
                                      private_id_for_binding,
                                      all_bindings_expired);
 
+  // We want to write the same CSeq value to the remote stores as we have just
+  // written to the local one. Writing to the store causes the CSeq to be
+  // incremented, so we correct for that by decrementing it.
+  // This isn't an ideal solution - this entire area of code is due to be
+  // refactored, at which point a more permanent fix should be implemented.
+  int local_notify_cseq = aor_pair->get_current()->_notify_cseq - 1;
+
   // Update our view of whether this was in fact an initial registration based
   // on whether we found any bindings. There are race conditions where
   // at the time that Homestead processed the request this looked like an
@@ -491,6 +498,15 @@ void RegistrarSproutletTsx::process_register_request(pjsip_msg *req)
       {
         int tmp_expiry = 0;
         bool ignored;
+
+        if (aor_pair->get_current()->_notify_cseq != local_notify_cseq)
+        {
+          TRC_DEBUG("Correcting incremented CSeq %d to %d",
+                    aor_pair->get_current()->_notify_cseq,
+                    local_notify_cseq);
+          aor_pair->get_current()->_notify_cseq = local_notify_cseq;
+        }
+
         AoRPair* remote_aor_pair = write_to_store(*it,
                                                   aor,
                                                   &(irs_info._associated_uris),

--- a/src/subscriptionsproutlet.cpp
+++ b/src/subscriptionsproutlet.cpp
@@ -515,6 +515,7 @@ Store::Status SubscriptionSproutletTsx::update_subscription_in_stores(
   // We cache AoRPairs from the local and remote SDMs to avoid having
   // to do repeated remote reads, saving thread time
   std::map<SubscriberDataManager*, AoRPair*> _cached_aors;
+  int cseq = 0;
 
   AoRPair* local_aor_pair = read_and_cache_from_store(subscription->_sdm,
                                                       aor,
@@ -526,6 +527,8 @@ Store::Status SubscriptionSproutletTsx::update_subscription_in_stores(
     status = Store::Status::ERROR;
     return status;
   }
+
+  cseq = local_aor_pair->get_current()->_notify_cseq;
 
   // Write to the local store, handling any CAS error
   do
@@ -592,6 +595,8 @@ Store::Status SubscriptionSproutletTsx::update_subscription_in_stores(
       {
         update_subscription(subscription, new_subscription, aor, remote_aor_pair, _cached_aors);
         remote_aor_pair->get_current()->_associated_uris = *associated_uris;
+
+        remote_aor_pair->get_current()->_notify_cseq = cseq;
 
         rc = sdm->set_aor_data(aor, SubscriberDataManager::EventTrigger::USER, remote_aor_pair, trail());
         if (rc == Store::DATA_CONTENTION)


### PR DESCRIPTION
The CSeq counter for a SUBSCRIBE/NOTIFY dialog is stored on the AoR corresponding to that dialog, and this AoR is stored in memcached both locally and at remote sites. Any time the local SDM increments the CSeq it relies on the client also calling into the remote SDMs to increment the CSeqs on the remote copies of the AoR. Whenever a NOTIFY is sent from the local site, it uses the local CSeq value and increments both the remote and local values, and similarly when a NOTIFY is sent from the local site. 

Due to a netsplit or perhaps another unknown condition (edit: while testing this, I ran into two other existing bugs that consistently cause out-of-sync CSeqs - I think it's only luck that we don't hit them more frequently), the counters can become out of sync between the local and remote sites. This results in NOTIFYs with incorrect CSeq values being sent, as each site uses its local value - the problem persists until the all registrations on the AoR expire.

This pull request adds function allowing Sprout to recover from this case - if the local and remote CSeq counters differ on an AoR when adding/updating/removing a subscription (note that any subscription must be periodically refreshed by the client), the remote CSeq values are overwritten with the local one. (edit: the PR also adds basic fixes for the two bugs described above)

If the local CSeq is larger than the remote ones, the problem is resolved at this point. Otherwise, we may send a number of NOTIFYs with incorrect CSeqs, but the problem will resolve after a small number of these.

It is important to note that the changes made here are **not** intended to remain in the code for long. The SDM and its clients is an area of code known to require refactoring. A cohesive fix for this issue essentially consists of a good chunk of this refactoring, which we do not want to do at this stage, so to avoid throw away work the fix is minimal and by no means ideal.

We hope to schedule this refactoring work shortly, at which point we will be able to resolve these issues in a more satisfactory way. I have put aside my initial work on this fix, PR #1999, in favor of this simpler short-term fix, as it was becoming a sink of time with no real way of finishing short of a complete refactor.