### PR TITLE
Correct minor rph.json validation issues

### DIFF
--- a/sprout-base.root/usr/share/clearwater/clearwater-config-manager/scripts/config_validation/rph_validation.py
+++ b/sprout-base.root/usr/share/clearwater/clearwater-config-manager/scripts/config_validation/rph_validation.py
@@ -74,7 +74,7 @@ for priority_block in raw_config[PRIORITY_BLOCKS]:
             # names could be present in any mix of upper/lower case. For string
             # comparison reasons, convert them all to be lower case.
             if header.lower() in parsed_config:
-                error_list.append("{} is present more than once.".format(header))
+                error_list.append("{} is present more than once.".format(header.lower()))
             else:
                 parsed_config.update({header.lower(): priority})
 

--- a/sprout-base.root/usr/share/clearwater/clearwater-config-manager/scripts/config_validation/rph_validation.py
+++ b/sprout-base.root/usr/share/clearwater/clearwater-config-manager/scripts/config_validation/rph_validation.py
@@ -70,10 +70,13 @@ for priority_block in raw_config[PRIORITY_BLOCKS]:
     if RPH_VALUES in priority_block:
         headers_with_priority = priority_block[RPH_VALUES]
         for header in headers_with_priority:
-            if header in parsed_config:
+            # RFC 4412 states namespace names are case insensitive, so these
+            # names could be present in any mix of upper/lower case. For string
+            # comparison reasons, convert them all to be lower case.
+            if header.lower() in parsed_config:
                 error_list.append("{} is present more than once.".format(header))
             else:
-                parsed_config.update({header: priority})
+                parsed_config.update({header.lower(): priority})
 
 # Check the priorites are set in a way which is valid.
 # A higher priority header cannot be given a lower priority than a lower
@@ -93,9 +96,9 @@ for header_list in HEADERS_LISTS:
                     error_list.append(error)
                 else:
                     next_priority = parsed_config[higher_priority_header]
-                    if next_priority <= header_priority:
-                        error = "{} is not a higher priority than {}, which " \
-                                "is not permitted.".format(
+                    if next_priority < header_priority:
+                        error = "{} is a lower priority than {}, which is " \
+                                "not permitted.".format(
                                         higher_priority_header, header)
                         error_list.append(error)
         place_in_list += 1


### PR DESCRIPTION
I've edited the rph.json validation to:

- be case insensitive when parsing rph headers (Metaswitch/clearwater-issues#2803)
- allow higher priority headers to be the _same_ priority as lower priority headers (although they still can't be lower priority (Metaswitch/clearwater-issues#2804)

I've live tested this:
With file:
```
{
  "priority_blocks":
    [
      {
        "priority": 1,
        "rph_values": ["eTs.0", "ets.0"]
      },
      {
        "priority": 2,
        "rph_values": ["EtS.0"]
     }
   ]
}
```
I got the error message below when I attempted to validate it:
```
ubuntu@ip-10-0-119-195:~/codebase/sprout/sprout-base.root/usr/share/clearwater/clearwater-config-manager/scripts/config_validation$ python rph_validation.py rph_schema.json rph.json
rph.json is not valid.
The errors are printed below:
ets.0 is present more than once.
ets.0 is present more than once.
ubuntu@ip-10-0-119-195:~/codebase/sprout/sprout-base.root/usr/share/clearwater/clearwater-config-manager/scripts/config_validation$
```
With the file:
```
{
    "priority_blocks":
    [
      {
        "priority": 1,
        "rph_values": ["ets.0"]
      },
      {
        "priority": 2,
       "rph_values": ["ets.1", "wps.0", "wps.1"]
     }
   ]
 }
```
The errors I got were:
```
ubuntu@ip-10-0-119-195:~/codebase/sprout/sprout-base.root/usr/share/clearwater/clearwater-config-manager/scripts/config_validation$ python rph_validation.py rph_schema.json rph.json
rph.json is not valid.
The errors are printed below:
ets.0 is a lower priority than ets.1, which is not permitted.
ubuntu@ip-10-0-119-195:~/codebase/sprout/sprout-base.root/usr/share/clearwater/clearwater-config-manager/scripts/config_validation$
```
Notice, there were only errors about ets priorities, not wps.

The case insensitivity is still applied when checking the priorities are acceptable. So this file below is still rejected:
```
{
    "priority_blocks":
    [
      {
        "priority": 1,
        "rph_values": ["eTs.0"]
      },
      {
        "priority": 2,
       "rph_values": ["EtS.1"]
     }
   ]
 }
```
With this error message:
```
ubuntu@ip-10-0-119-195:~/codebase/sprout/sprout-base.root/usr/share/clearwater/clearwater-config-manager/scripts/config_validation$ python rph_validation.py rph_schema.json rph.json
rph.json is not valid.
The errors are printed below:
ets.0 is a lower priority than ets.1, which is not permitted.
ubuntu@ip-10-0-119-195:~/codebase/sprout/sprout-base.root/usr/share/clearwater/clearwater-config-manager/scripts/config_validation$
```