### PR TITLE
[Reviewer: KH1] Add case insensitive compare function to RPH map

### DIFF
--- a/include/rphservice.h
+++ b/include/rphservice.h
@@ -51,8 +51,8 @@ private:
   Alarm* _alarm;
   std::string _configuration;
 
-  // RPH values are case insensitive, so write a case insensitive compare
-  // function to pass to the map.
+  // RFC 4412 section 3.1 states that RPH values are case-insensitive, so write
+  // a case-insensitive compare function to pass to the map.
   struct str_cmp_ci
   {
     bool operator() (std::string k1, std::string k2) const

--- a/include/rphservice.h
+++ b/include/rphservice.h
@@ -15,6 +15,7 @@
 #include <map>
 #include <string>
 #include <boost/thread.hpp>
+#include <boost/algorithm/string.hpp>
 
 #include "updater.h"
 #include "sip_event_priority.h"
@@ -49,7 +50,19 @@ public:
 private:
   Alarm* _alarm;
   std::string _configuration;
-  std::map<std::string, SIPEventPriorityLevel> _rph_map;
+
+  // RPH values are case insensitive, so write a case insensitive compare
+  // function to pass to the map.
+  struct str_cmp_ci
+  {
+    bool operator() (std::string k1, std::string k2) const
+    {
+      boost::algorithm::to_lower(k1);
+      boost::algorithm::to_lower(k2);
+      return k1 < k2;
+    }
+  };
+  std::map<std::string, SIPEventPriorityLevel, str_cmp_ci> _rph_map;
   Updater<void, RPHService>* _updater;
 
   // Mark as mutable to flag that this can be modified without affecting the

--- a/src/rphservice.cpp
+++ b/src/rphservice.cpp
@@ -79,7 +79,7 @@ void RPHService::update_rph()
   rapidjson::Document doc;
   doc.Parse<0>(rph_str.c_str());
 
-  std::map<std::string, SIPEventPriorityLevel> new_rph_map;
+  std::map<std::string, SIPEventPriorityLevel, str_cmp_ci> new_rph_map;
 
   if (doc.HasParseError())
   {
@@ -205,7 +205,7 @@ SIPEventPriorityLevel RPHService::lookup_priority(std::string rph_value,
   // Lookup the key in the map. If it doesn't exist, we will return the default
   // priority of 0.
   TRC_DEBUG("Looking up priority of RPH value \"%s\"", rph_value.c_str());
-  std::map<std::string, SIPEventPriorityLevel>::iterator result = _rph_map.find(rph_value);
+  std::map<std::string, SIPEventPriorityLevel, str_cmp_ci>::iterator result = _rph_map.find(rph_value);
   if (result != _rph_map.end())
   {
     priority = result->second;

--- a/src/ut/rphservice_test.cpp
+++ b/src/ut/rphservice_test.cpp
@@ -105,24 +105,27 @@ TEST_F(RPHServiceTest, DuplicatedValueRPHFile)
 
 TEST_F(RPHServiceTest, ValidRPHFile)
 {
+  CapturingTestLogger log;
   EXPECT_CALL(*_mock_alarm, clear()).Times(AtLeast(1));
   RPHService rph(_mock_alarm, string(UT_DIR).append("/test_rph.json"));
+  EXPECT_TRUE(log.contains("RPH configuration successfully updated"));
 
-  // Check that the map is correctly populated.
-  EXPECT_EQ(rph.lookup_priority("wps.4", 0), SIPEventPriorityLevel::HIGH_PRIORITY_1);
-  EXPECT_EQ(rph.lookup_priority("ets.4", 0), SIPEventPriorityLevel::HIGH_PRIORITY_1);
-  EXPECT_EQ(rph.lookup_priority("wps.3", 0), SIPEventPriorityLevel::HIGH_PRIORITY_3);
+  // Check that the map is correctly populated. Mix up cases to check that case
+  // insensitive matching works.
+  EXPECT_EQ(rph.lookup_priority("wPs.4", 0), SIPEventPriorityLevel::HIGH_PRIORITY_1);
+  EXPECT_EQ(rph.lookup_priority("EtS.4", 0), SIPEventPriorityLevel::HIGH_PRIORITY_1);
+  EXPECT_EQ(rph.lookup_priority("WPS.3", 0), SIPEventPriorityLevel::HIGH_PRIORITY_3);
   EXPECT_EQ(rph.lookup_priority("ets.3", 0), SIPEventPriorityLevel::HIGH_PRIORITY_3);
   EXPECT_EQ(rph.lookup_priority("foo", 0), SIPEventPriorityLevel::HIGH_PRIORITY_4);
-  EXPECT_EQ(rph.lookup_priority("wps.2", 0), SIPEventPriorityLevel::HIGH_PRIORITY_5);
-  EXPECT_EQ(rph.lookup_priority("ets.2", 0), SIPEventPriorityLevel::HIGH_PRIORITY_5);
-  EXPECT_EQ(rph.lookup_priority("wps.1", 0), SIPEventPriorityLevel::HIGH_PRIORITY_7);
-  EXPECT_EQ(rph.lookup_priority("ets.1", 0), SIPEventPriorityLevel::HIGH_PRIORITY_7);
-  EXPECT_EQ(rph.lookup_priority("wps.0", 0), SIPEventPriorityLevel::HIGH_PRIORITY_9);
-  EXPECT_EQ(rph.lookup_priority("ets.0", 0), SIPEventPriorityLevel::HIGH_PRIORITY_9);
-  EXPECT_EQ(rph.lookup_priority("dsn.flash-override", 0), SIPEventPriorityLevel::HIGH_PRIORITY_10);
-  EXPECT_EQ(rph.lookup_priority("drsn.flash-override", 0), SIPEventPriorityLevel::HIGH_PRIORITY_13);
-  EXPECT_EQ(rph.lookup_priority("drsn.flash-override-override", 0), SIPEventPriorityLevel::HIGH_PRIORITY_15);
+  EXPECT_EQ(rph.lookup_priority("WPs.2", 0), SIPEventPriorityLevel::HIGH_PRIORITY_5);
+  EXPECT_EQ(rph.lookup_priority("eTS.2", 0), SIPEventPriorityLevel::HIGH_PRIORITY_5);
+  EXPECT_EQ(rph.lookup_priority("wPs.1", 0), SIPEventPriorityLevel::HIGH_PRIORITY_7);
+  EXPECT_EQ(rph.lookup_priority("ETS.1", 0), SIPEventPriorityLevel::HIGH_PRIORITY_7);
+  EXPECT_EQ(rph.lookup_priority("wpS.0", 0), SIPEventPriorityLevel::HIGH_PRIORITY_9);
+  EXPECT_EQ(rph.lookup_priority("ETs.0", 0), SIPEventPriorityLevel::HIGH_PRIORITY_9);
+  EXPECT_EQ(rph.lookup_priority("dSn.flASH-OVerride", 0), SIPEventPriorityLevel::HIGH_PRIORITY_10);
+  EXPECT_EQ(rph.lookup_priority("dRSn.flash-oVeRridE", 0), SIPEventPriorityLevel::HIGH_PRIORITY_13);
+  EXPECT_EQ(rph.lookup_priority("dRsn.Flash-overrIde-OVERRIDE", 0), SIPEventPriorityLevel::HIGH_PRIORITY_15);
 
   // Check that if we lookup an unknown RPH value, that we get back the default
   // priority.

--- a/src/ut/test_badly_ordered_rph.json
+++ b/src/ut/test_badly_ordered_rph.json
@@ -1,10 +1,10 @@
 {
   "priority_blocks" : [
       { "priority" : 1,
-        "rph_values" : ["wps.0"]
+        "rph_values" : ["wPs.0"]
       },
       { "priority" : 2,
-        "rph_values" : ["wps.2"]
+        "rph_values" : ["WpS.2"]
       },
       { "priority" : 3,
         "rph_values" : ["wps.1"]

--- a/src/ut/test_duplicated_value_rph.json
+++ b/src/ut/test_duplicated_value_rph.json
@@ -4,7 +4,7 @@
         "rph_values" : ["wps.0"]
       },
       { "priority" : 2,
-        "rph_values" : ["wps.0"]
+        "rph_values" : ["WPS.0"]
       }
     ]
 }

--- a/src/ut/test_rph.json
+++ b/src/ut/test_rph.json
@@ -1,7 +1,7 @@
 {
   "priority_blocks" : [
     { "priority" : 1,
-      "rph_values" : ["wps.4", "ets.4"]
+      "rph_values" : ["WPS.4", "eTs.4"]
     },
     {
       "priority" : 2,
@@ -9,7 +9,7 @@
     },
     {
       "priority" : 3,
-      "rph_values" : ["wps.3", "ets.3"]
+      "rph_values" : ["wPS.3", "ETs.3"]
     },
     {
       "priority" : 4,
@@ -17,7 +17,7 @@
     },
     {
       "priority" : 5,
-      "rph_values" : ["wps.2", "ets.2"]
+      "rph_values" : ["wps.2", "ETS.2"]
     },
     {
       "priority" : 6,
@@ -25,7 +25,7 @@
     },
     {
       "priority" : 7,
-      "rph_values" : ["wps.1", "ets.1"]
+      "rph_values" : ["Wps.1", "ets.1"]
     },
     {
       "priority" : 8,
@@ -33,11 +33,11 @@
     },
     {
       "priority" : 9,
-      "rph_values" : ["wps.0", "ets.0"]
+      "rph_values" : ["WPs.0", "etS.0"]
     },
     {
       "priority" : 10,
-      "rph_values" : ["dsn.flash-override"]
+      "rph_values" : ["dSn.flAsh-oveRRIDE"]
     },
     {
       "priority" : 11,
@@ -49,7 +49,7 @@
     },
     {
       "priority" : 13,
-      "rph_values" : ["drsn.flash-override"]
+      "rph_values" : ["drsn.FLAsh-override"]
     },
     {
       "priority" : 14,
@@ -57,7 +57,7 @@
     },
     {
       "priority" : 15,
-      "rph_values" : ["drsn.flash-override-override"]
+      "rph_values" : ["drsn.flash-OVERRIDE-OVERRIDE"]
     }
   ]
 }


### PR DESCRIPTION
Adds a case insensitive key_compare function for the RPH map so that an RPH value with different case to the one configured still returns the correct priority.

Tested by changing the cases of random characters in RPH values in the UTs. I did this in the config files to check that config validation still works, and in the tests to check key lookups work with different cases.

