### PR TITLE
[Reviewer MIRW] Handle % characters correctly in PJ_LOGs

### DIFF
--- a/src/stack.cpp
+++ b/src/stack.cpp
@@ -229,7 +229,12 @@ static void pjsip_log_handler(int level,
   default: level = 5; break;
   }
 
-  Log::write(level, "pjsip", 0, data);
+  // Pass the data string as a parameter, with a format of "%s", to the standard
+  // common log write routine.
+  // Note that we mustn't pass data as the format string (with no parameters),
+  // because it may contain % characters which we don't want to be accidentally
+  // interpreted as format specifiers.
+  Log::write(level, "pjsip", 0, "%s", data);
 }
 
 


### PR DESCRIPTION
Hi Matt

Would you mind reviewing this small fix for me?  I'm hoping it will fix Rob's crash in https://github.com/Metaswitch/clearwater-issues/issues/1441, which is a critical problem for the upcoming release, so would like to get it in tomorrow if possible.

As we don't seem to be able to repro Rob's scenario, I've tested it by hacking into PJSIP a high severity PJ_LOG call with a parameter containing '%' characters (which I believe is the root cause of Rob's crash).  Without this fix, that gets corrupted in the output - with the fix, the logged string appears as expected.