### PR TITLE
Deregister AS in AoR Timeout Task

### DIFF
--- a/include/handlers.h
+++ b/include/handlers.h
@@ -52,14 +52,20 @@ public:
   {
     Config(SubscriberDataManager* sdm,
            std::vector<SubscriberDataManager*> remote_sdms,
-           HSSConnection* hss) :
+           HSSConnection* hss,
+           FIFCService* fifc_service,
+           IFCConfiguration ifc_configuration) :
       _sdm(sdm),
       _remote_sdms(remote_sdms),
-      _hss(hss)
+      _hss(hss),
+      _fifc_service(fifc_service),
+      _ifc_configuration(ifc_configuration)
     {}
     SubscriberDataManager* _sdm;
     std::vector<SubscriberDataManager*> _remote_sdms;
     HSSConnection* _hss;
+    FIFCService* _fifc_service;
+    IFCConfiguration _ifc_configuration;
   };
 
   AoRTimeoutTask(HttpStack::Request& req,

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -456,12 +456,13 @@ AoRPair* DeregistrationTask::deregister_bindings(
 {
   AoRPair* aor_pair = NULL;
   bool all_bindings_expired = false;
+  bool got_ifcs;
   Store::Status set_rc;
   std::vector<std::string> impis_to_dereg;
 
   // Get registration data
   HSSConnection::irs_info irs_info;
-  bool got_ifcs = get_reg_data(_cfg->_hss, aor_id, irs_info, trail());
+  got_ifcs = get_reg_data(_cfg->_hss, aor_id, irs_info, trail());
 
   do
   {

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -233,7 +233,7 @@ void AoRTimeoutTask::process_aor_timeout(std::string aor_id)
 
   // Determine the set of IMPUs in the Implicit Registration Set
   HSSConnection::irs_info irs_info;
-  get_reg_data(_cfg->_hss, aor_id, irs_info, trail());
+  bool got_ifcs = get_reg_data(_cfg->_hss, aor_id, irs_info, trail());
 
   bool all_bindings_expired = false;
   AoRPair* aor_pair = get_and_set_local_aor_data(_cfg->_sdm,
@@ -261,6 +261,18 @@ void AoRTimeoutTask::process_aor_timeout(std::string aor_id)
                                *aor_pair,
                                _cfg->_hss,
                                trail());
+
+      if (got_ifcs)
+      {
+        RegistrationUtils::deregister_with_application_servers(irs_info._service_profiles[aor_id],
+                                                               _cfg->_fifc_service,
+                                                               _cfg->_ifc_configuration,
+                                                               _cfg->_sdm,
+                                                               _cfg->_remote_sdms,
+                                                               _cfg->_hss,
+                                                               aor_id,
+                                                               trail());
+      }
     }
   }
   else
@@ -444,13 +456,12 @@ AoRPair* DeregistrationTask::deregister_bindings(
 {
   AoRPair* aor_pair = NULL;
   bool all_bindings_expired = false;
-  bool got_ifcs;
   Store::Status set_rc;
   std::vector<std::string> impis_to_dereg;
 
   // Get registration data
   HSSConnection::irs_info irs_info;
-  got_ifcs = get_reg_data(_cfg->_hss, aor_id, irs_info, trail());
+  bool got_ifcs = get_reg_data(_cfg->_hss, aor_id, irs_info, trail());
 
   do
   {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2430,7 +2430,13 @@ int main(int argc, char* argv[])
 
   AoRTimeoutTask::Config aor_timeout_config(local_sdm,
                                             remote_sdms,
-                                            hss_connection);
+                                            hss_connection,
+                                            fifc_service,
+                                            IFCConfiguration(opt.apply_fallback_ifcs,
+                                                             opt.reject_if_no_matching_ifcs,
+                                                             opt.dummy_app_server,
+                                                             NULL,
+                                                             NULL));
   AuthTimeoutTask::Config auth_timeout_config(local_impi_store,
                                               hss_connection);
 

--- a/src/registration_utils.cpp
+++ b/src/registration_utils.cpp
@@ -311,6 +311,7 @@ void RegistrationUtils::deregister_with_application_servers(Ifcs& ifcs,
   }
   else
   {
+    TRC_DEBUG("Creating third party deregistration for %s", served_user.c_str());
     RegistrationUtils::register_with_application_servers(ifcs,
                                                          fifc_service,
                                                          ifc_configuration,

--- a/src/ut/chronoshandlers_test.cpp
+++ b/src/ut/chronoshandlers_test.cpp
@@ -398,10 +398,9 @@ class ChronosAoRTimeoutTasksMockStoreTest : public SipTest
 
 };
 
-
+// Test that deregister is sent to AS when all bindings expired
 TEST_F(ChronosAoRTimeoutTasksMockStoreTest, DeregisterAS)
 {
-  // Test that deregister is sent to AS when all bindings expired
   AoR* aor = new AoR("sip:6505550231@homedomain");
   AoR* aor2 = new AoR(*aor);
   AoRPair* aor_pair = new AoRPair(aor, aor2);
@@ -438,7 +437,6 @@ TEST_F(ChronosAoRTimeoutTasksMockStoreTest, DeregisterAS)
                               "    </ApplicationServer>\n"
                               "  </InitialFilterCriteria>\n"
                               "</ServiceProfile></IMSSubscription>");
-  TransportFlow tpAS(TransportFlow::Protocol::UDP, stack_data.scscf_port, "1.2.3.4", 56789);
 
   // Parse and handle the request
   std::string body = "{\"aor_id\": \"sip:6505550231@homedomain\"}";
@@ -454,6 +452,7 @@ TEST_F(ChronosAoRTimeoutTasksMockStoreTest, DeregisterAS)
   pjsip_msg* out = current_txdata()->msg;
   ReqMatcher r1("REGISTER");
   ASSERT_NO_FATAL_FAILURE(r1.matches(out));
+  EXPECT_THAT(r1.uri(), testing::MatchesRegex(".*sip:1.2.3.4:56789.*"));
 }
 
 TEST_F(ChronosAoRTimeoutTasksMockStoreTest, SubscriberDataManagerWritesFail)

--- a/src/ut/chronoshandlers_test.cpp
+++ b/src/ut/chronoshandlers_test.cpp
@@ -43,8 +43,13 @@ public:
 
   void build_timeout_request(std::string body, htp_method method)
   {
+    IFCConfiguration ifc_configuration(false, false, "", NULL, NULL);
     req = new MockHttpStack::Request(stack, "/", "timers", "", body, method);
-    config = new AoRTimeoutTask::Config(store, {remote_store1, remote_store2}, mock_hss);
+    config = new AoRTimeoutTask::Config(store, 
+                                        {remote_store1, remote_store2}, 
+                                        mock_hss, 
+                                        NULL, 
+                                        ifc_configuration);
     handler = new ChronosAoRTimeoutTask(*req, config, 0);
   }
 
@@ -372,10 +377,11 @@ class ChronosAoRTimeoutTasksMockStoreTest : public SipTest
 
   void SetUp()
   {
+    IFCConfiguration ifc_configuration(false, false, "", NULL, NULL);
     store = new MockSubscriberDataManager();
     fake_hss = new FakeHSSConnection();
     req = new MockHttpStack::Request(&stack, "/", "timers");
-    config = new AoRTimeoutTask::Config(store, {}, fake_hss);
+    config = new AoRTimeoutTask::Config(store, {}, fake_hss, NULL, ifc_configuration);
     handler = new ChronosAoRTimeoutTask(*req, config, 0);
   }
 

--- a/src/ut/chronoshandlers_test.cpp
+++ b/src/ut/chronoshandlers_test.cpp
@@ -240,6 +240,8 @@ TEST_F(ChronosAoRTimeoutTasksTest, LocalAoRNoBindingsTest)
 // Test with a remote store, and both AoRs with no bindings
 TEST_F(ChronosAoRTimeoutTasksTest, NoBindingsTest)
 {
+  CapturingTestLogger log(5);
+
   std::string body = "{\"aor_id\": \"sip:6505550231@homedomain\"}";
 
   build_timeout_request(body, htp_method_POST);
@@ -319,6 +321,7 @@ TEST_F(ChronosAoRTimeoutTasksTest, NoBindingsTest)
   ASSERT_EQ(irs_query._req_type, HSSConnection::DEREG_TIMEOUT);
   ASSERT_EQ(irs_query._server_name, "sip:scscf.sprout.homedomain:5058;transport=TCP");
 
+  EXPECT_TRUE(log.contains("Creating third party deregistration"));
 }
 
 // Test with NULL AoRs


### PR DESCRIPTION
This PR makes AoRTimeoutTask sends third party REGISTER when all bindings have expired, similar to DeregistrationTask and DeleteImpuTask and consistent with TS24.229.
1. The task calls deregister_with_application_server after updating hss, similar to RegistrationUtils::remove_bindings. Spec p.235-238 suggests that ordering as well.
2. AoRTimeoutTask now gets fifc_service and ifc_configuration in its Config, for the use of deregister_with_application_server.
2. UT checks deregister_with_application_server is called by log, which isn't ideal. Unfortunately deregister_with_application_server is an utility function and does not return success or not (I feel it should), so handler_test is checking this call by log as well.

full_test passed