### PR TITLE
[Reviewer RJW2] Quote pcfa params

### DIFF
--- a/include/pjutils.h
+++ b/include/pjutils.h
@@ -277,6 +277,11 @@ void add_pcfa_header(pjsip_msg* msg,
                      const std::deque<std::string>& ecfs,
                      const bool replace);
 
+void add_pcfa_param(pj_list_type *cf_list,
+                    pj_pool_t* pool,
+                    const pj_str_t name,
+                    std::string value);
+
 pjsip_uri* translate_sip_uri_to_tel_uri(const pjsip_sip_uri* sip_uri,
                                         pj_pool_t* pool);
 

--- a/src/ut/fakehssconnection.cpp
+++ b/src/ut/fakehssconnection.cpp
@@ -64,7 +64,7 @@ void FakeHSSConnection::set_impu_result(const std::string& impu,
                                         std::string subxml,
                                         std::string extra_params,
                                         const std::string& wildcard,
-                                        const std::string& chargingaddrsxml)
+                                        std::string chargingaddrsxml)
 {
   set_impu_result_internal(impu,
                            type,
@@ -83,7 +83,7 @@ void FakeHSSConnection::set_impu_result_with_prev(const std::string& impu,
                                                   std::string subxml,
                                                   std::string extra_params,
                                                   const std::string& wildcard,
-                                                  const std::string& chargingaddrsxml)
+                                                  std::string chargingaddrsxml)
 {
   set_impu_result_internal(impu,
                            type,
@@ -102,7 +102,7 @@ void FakeHSSConnection::set_impu_result_internal(const std::string& impu,
                                                  std::string subxml,
                                                  std::string extra_params,
                                                  const std::string& wildcard,
-                                                 const std::string& chargingaddrsxml)
+                                                 std::string chargingaddrsxml)
 {
   std::string url = "/impu/" + Utils::url_escape(impu) + "/reg-data" + extra_params;
 
@@ -113,6 +113,15 @@ void FakeHSSConnection::set_impu_result_internal(const std::string& impu,
               "  <InitialFilterCriteria>\n"
               "  </InitialFilterCriteria>\n"
               "</ServiceProfile></IMSSubscription>");
+  }
+
+  if (chargingaddrsxml.empty())
+  {
+    chargingaddrsxml = ("<ChargingAddresses>\n"
+                        "  <CCF priority=\"1\">ccf1</CCF>\n"
+                        "  <ECF priority=\"1\">ecf1</ECF>\n"
+                        "  <ECF priority=\"2\">ecf2</ECF>\n"
+                        "</ChargingAddresses>");
   }
 
   std::string prev_state_string = "";

--- a/src/ut/fakehssconnection.cpp
+++ b/src/ut/fakehssconnection.cpp
@@ -63,7 +63,8 @@ void FakeHSSConnection::set_impu_result(const std::string& impu,
                                         const std::string& state,
                                         std::string subxml,
                                         std::string extra_params,
-                                        const std::string& wildcard)
+                                        const std::string& wildcard,
+                                        const std::string& chargingaddrsxml)
 {
   set_impu_result_internal(impu,
                            type,
@@ -71,7 +72,8 @@ void FakeHSSConnection::set_impu_result(const std::string& impu,
                            "",
                            subxml,
                            extra_params,
-                           wildcard);
+                           wildcard,
+                           chargingaddrsxml);
 }
 
 void FakeHSSConnection::set_impu_result_with_prev(const std::string& impu,
@@ -80,7 +82,8 @@ void FakeHSSConnection::set_impu_result_with_prev(const std::string& impu,
                                                   const std::string& prev_state,
                                                   std::string subxml,
                                                   std::string extra_params,
-                                                  const std::string& wildcard)
+                                                  const std::string& wildcard,
+                                                  const std::string& chargingaddrsxml)
 {
   set_impu_result_internal(impu,
                            type,
@@ -88,7 +91,8 @@ void FakeHSSConnection::set_impu_result_with_prev(const std::string& impu,
                            prev_state,
                            subxml,
                            extra_params,
-                           wildcard);
+                           wildcard,
+                           chargingaddrsxml);
 }
 
 void FakeHSSConnection::set_impu_result_internal(const std::string& impu,
@@ -97,7 +101,8 @@ void FakeHSSConnection::set_impu_result_internal(const std::string& impu,
                                                  const std::string& prev_state,
                                                  std::string subxml,
                                                  std::string extra_params,
-                                                 const std::string& wildcard)
+                                                 const std::string& wildcard,
+                                                 const std::string& chargingaddrsxml)
 {
   std::string url = "/impu/" + Utils::url_escape(impu) + "/reg-data" + extra_params;
 
@@ -109,12 +114,6 @@ void FakeHSSConnection::set_impu_result_internal(const std::string& impu,
               "  </InitialFilterCriteria>\n"
               "</ServiceProfile></IMSSubscription>");
   }
-
-  std::string chargingaddrsxml = ("<ChargingAddresses>\n"
-                                  "  <CCF priority=\"1\">ccf1</CCF>\n"
-                                  "  <ECF priority=\"1\">ecf1</ECF>\n"
-                                  "  <ECF priority=\"2\">ecf2</ECF>\n"
-                                  "</ChargingAddresses>");
 
   std::string prev_state_string = "";
   if (prev_state != "")

--- a/src/ut/fakehssconnection.hpp
+++ b/src/ut/fakehssconnection.hpp
@@ -41,25 +41,15 @@ public:
                        std::string,
                        std::string = "",
                        const std::string& wildcard = "",
-                       const std::string& chargingaddrsxml =
-                                           "<ChargingAddresses>\n"
-                                           "  <CCF priority=\"1\">ccf1</CCF>\n"
-                                           "  <ECF priority=\"1\">ecf1</ECF>\n"
-                                           "  <ECF priority=\"2\">ecf2</ECF>\n"
-                                           "</ChargingAddresses>");
+                       std::string chargingaddrsxml = "");
 void set_impu_result_with_prev(const std::string&,
-  const std::string&,
-  const std::string&,
-  const std::string&,
-  std::string,
-  std::string = "",
-  const std::string& wildcard = "",
-  const std::string& chargingaddrsxml =
-  "<ChargingAddresses>\n"
-  "  <CCF priority=\"1\">ccf1</CCF>\n"
-  "  <ECF priority=\"1\">ecf1</ECF>\n"
-  "  <ECF priority=\"2\">ecf2</ECF>\n"
-  "</ChargingAddresses>");
+                               const std::string&,
+                               const std::string&,
+                               const std::string&,
+                               std::string,
+                               std::string = "",
+                               const std::string& wildcard = "",
+                               std::string chargingaddrsxml = "");
 void delete_result(const std::string& url);
   void set_rc(const std::string& url, long rc);
   void delete_rc(const std::string& url);
@@ -77,7 +67,7 @@ private:
                                 std::string,
                                 std::string,
                                 const std::string& wildcard,
-                                const std::string& chargingaddrsxml);
+                                std::string chargingaddrsxml);
 
   long get_json_object(const std::string& path, rapidjson::Document*& object, SAS::TrailId trail);
   long get_xml_object(const std::string& path, rapidxml::xml_document<>*& root, SAS::TrailId trail);

--- a/src/ut/fakehssconnection.hpp
+++ b/src/ut/fakehssconnection.hpp
@@ -40,15 +40,27 @@ public:
                        const std::string&,
                        std::string,
                        std::string = "",
-                       const std::string& wildcard = "");
-  void set_impu_result_with_prev(const std::string&,
-                                 const std::string&,
-                                 const std::string&,
-                                 const std::string&,
-                                 std::string,
-                                 std::string = "",
-                                 const std::string& wildcard = "");
-  void delete_result(const std::string& url);
+                       const std::string& wildcard = "",
+                       const std::string& chargingaddrsxml =
+                                           "<ChargingAddresses>\n"
+                                           "  <CCF priority=\"1\">ccf1</CCF>\n"
+                                           "  <ECF priority=\"1\">ecf1</ECF>\n"
+                                           "  <ECF priority=\"2\">ecf2</ECF>\n"
+                                           "</ChargingAddresses>");
+void set_impu_result_with_prev(const std::string&,
+  const std::string&,
+  const std::string&,
+  const std::string&,
+  std::string,
+  std::string = "",
+  const std::string& wildcard = "",
+  const std::string& chargingaddrsxml =
+  "<ChargingAddresses>\n"
+  "  <CCF priority=\"1\">ccf1</CCF>\n"
+  "  <ECF priority=\"1\">ecf1</ECF>\n"
+  "  <ECF priority=\"2\">ecf2</ECF>\n"
+  "</ChargingAddresses>");
+void delete_result(const std::string& url);
   void set_rc(const std::string& url, long rc);
   void delete_rc(const std::string& url);
   bool url_was_requested(const std::string& url, const std::string& body);
@@ -63,8 +75,9 @@ private:
                                 const std::string&,
                                 const std::string&,
                                 std::string,
-                                std::string = "",
-                                const std::string& wildcard = "");
+                                std::string,
+                                const std::string& wildcard,
+                                const std::string& chargingaddrsxml);
 
   long get_json_object(const std::string& path, rapidjson::Document*& object, SAS::TrailId trail);
   long get_xml_object(const std::string& path, rapidxml::xml_document<>*& root, SAS::TrailId trail);

--- a/src/ut/registrar_test.cpp
+++ b/src/ut/registrar_test.cpp
@@ -1008,8 +1008,9 @@ TEST_F(RegistrarTest, SimpleMainlineExpiresHeader)
 /// appropriate headers are passed through
 TEST_F(RegistrarTest, SimpleMainlinePassthrough)
 {
+  _hss_connection->set_impu_result_with_prev("sip:6505550231@homedomain", "reg", RegDataXMLUtils::STATE_REGISTERED, RegDataXMLUtils::STATE_NOT_REGISTERED, "", "?private_id=Alice");
   // Set some interesting Charging Function values
-  _hss_connection->set_impu_result_with_prev("sip:6505550231@homedomain", "reg", RegDataXMLUtils::STATE_REGISTERED, RegDataXMLUtils::STATE_NOT_REGISTERED, "", "?private_id=Alice", "",
+  _hss_connection->set_impu_result("sip:6505550231@homedomain", "reg", RegDataXMLUtils::STATE_REGISTERED, "", "", "",
     "<ChargingAddresses>\n"
     "  <CCF priority=\"1\">token%</CCF>\n"
     "  <CCF priority=\"2\">aaa://example.host;transport=TCP</CCF>\n"

--- a/src/ut/registrar_test.cpp
+++ b/src/ut/registrar_test.cpp
@@ -1008,8 +1008,15 @@ TEST_F(RegistrarTest, SimpleMainlineExpiresHeader)
 /// appropriate headers are passed through
 TEST_F(RegistrarTest, SimpleMainlinePassthrough)
 {
-  _hss_connection->set_impu_result_with_prev("sip:6505550231@homedomain", "reg", RegDataXMLUtils::STATE_REGISTERED, RegDataXMLUtils::STATE_NOT_REGISTERED, "", "?private_id=Alice");
-
+  // Set some interesting Charging Function values
+  _hss_connection->set_impu_result_with_prev("sip:6505550231@homedomain", "reg", RegDataXMLUtils::STATE_REGISTERED, RegDataXMLUtils::STATE_NOT_REGISTERED, "", "?private_id=Alice", "",
+    "<ChargingAddresses>\n"
+    "  <CCF priority=\"1\">token%</CCF>\n"
+    "  <CCF priority=\"2\">aaa://example.host;transport=TCP</CCF>\n"
+    "  <ECF priority=\"1\">\"aaa://example.host;transport=UDP\"</ECF>\n"
+    "  <ECF priority=\"2\">[fd2c:de55:7690:7777::ac12:aa6]</ECF>\n"
+    "</ChargingAddresses>"
+  );
   Message msg;
   msg._expires = "Expires: 300";
   msg._contact_params = ";+sip.ice;reg-id=1";
@@ -1019,7 +1026,9 @@ TEST_F(RegistrarTest, SimpleMainlinePassthrough)
   EXPECT_EQ(200, out->line.status.code);
   EXPECT_EQ("OK", str_pj(out->line.status.reason));
   EXPECT_EQ("P-Charging-Vector: icid-value=\"100\"", get_headers(out, "P-Charging-Vector"));
-  EXPECT_EQ("P-Charging-Function-Addresses: ccf=ccf1;ecf=ecf1;ecf=ecf2", get_headers(out, "P-Charging-Function-Addresses"));
+  // Check the contents of the PCFA header.  Only the 2nd value above should be quoted, as the 1st and 4th values match
+  // the required spec for a "token" or IPv6 address, and the 3rd value was already quoted.
+  EXPECT_EQ("P-Charging-Function-Addresses: ccf=token%;ccf=\"aaa://example.host;transport=TCP\";ecf=\"aaa://example.host;transport=UDP\";ecf=[fd2c:de55:7690:7777::ac12:aa6]", get_headers(out, "P-Charging-Function-Addresses"));
   EXPECT_EQ(1,((SNMP::FakeSuccessFailCountTable*)SNMP::FAKE_REGISTRATION_STATS_TABLES.init_reg_tbl)->_attempts);
   EXPECT_EQ(1,((SNMP::FakeSuccessFailCountTable*)SNMP::FAKE_REGISTRATION_STATS_TABLES.init_reg_tbl)->_successes);
 
@@ -1462,7 +1471,16 @@ TEST_F(RegistrarTest, AppServersPassthrough)
                               "      <DefaultHandling>0</DefaultHandling>\n"
                               "    </ApplicationServer>\n"
                               "  </InitialFilterCriteria>\n"
-                              "</ServiceProfile></IMSSubscription>");
+                              "</ServiceProfile></IMSSubscription>",
+                              "",
+                              "",
+                              // Set some more sample Charging Function names to exercise quoting logic
+                              "<ChargingAddresses>\n"
+                              "  <CCF priority=\"1\">1.2.3.4</CCF>\n"
+                              "  <CCF priority=\"2\">quote=this</CCF>\n"
+                              "  <ECF priority=\"1\">quote;this;as;well</CCF>\n"
+                              "</ChargingAddresses>"
+                          );
 
   TransportFlow tpAS(TransportFlow::Protocol::UDP, stack_data.scscf_port, "1.2.3.4", 56789);
 
@@ -1482,7 +1500,8 @@ TEST_F(RegistrarTest, AppServersPassthrough)
 
   // Test the headers we expect to have passed through
   EXPECT_EQ("P-Charging-Vector: icid-value=\"100\"", get_headers(out, "P-Charging-Vector"));
-  EXPECT_EQ("P-Charging-Function-Addresses: ccf=ccf1;ecf=ecf1;ecf=ecf2", get_headers(out, "P-Charging-Function-Addresses"));
+  // Check quoting.  Note that IP addresses don't need to be quoted inthe PCFA.
+  EXPECT_EQ("P-Charging-Function-Addresses: ccf=1.2.3.4;ccf=\"quote=this\";ecf=\"quote;this;as;well\"", get_headers(out, "P-Charging-Function-Addresses"));
 
   tpAS.expect_target(current_txdata(), false);
   inject_msg(respond_to_current_txdata(200));

--- a/src/ut/registrar_test.cpp
+++ b/src/ut/registrar_test.cpp
@@ -1476,9 +1476,10 @@ TEST_F(RegistrarTest, AppServersPassthrough)
                               "",
                               // Set some more sample Charging Function names to exercise quoting logic
                               "<ChargingAddresses>\n"
-                              "  <CCF priority=\"1\">1.2.3.4</CCF>\n"
-                              "  <CCF priority=\"2\">quote=this</CCF>\n"
-                              "  <ECF priority=\"1\">quote;this;as;well</CCF>\n"
+                              "  <CCF priority=\"1\">4.3.2.1</CCF>\n"
+                              "  <CCF priority=\"2\">\\\"\\</CCF>\n"
+                              "  <ECF priority=\"1\">quote=this</CCF>\n"
+                              "  <ECF priority=\"2\">quote;this;as;well</CCF>\n"
                               "</ChargingAddresses>"
                           );
 
@@ -1500,8 +1501,8 @@ TEST_F(RegistrarTest, AppServersPassthrough)
 
   // Test the headers we expect to have passed through
   EXPECT_EQ("P-Charging-Vector: icid-value=\"100\"", get_headers(out, "P-Charging-Vector"));
-  // Check quoting.  Note that IP addresses don't need to be quoted inthe PCFA.
-  EXPECT_EQ("P-Charging-Function-Addresses: ccf=1.2.3.4;ccf=\"quote=this\";ecf=\"quote;this;as;well\"", get_headers(out, "P-Charging-Function-Addresses"));
+  // Check quoting.  Note that IP addresses don't need to be quoted in the PCFA.
+  EXPECT_EQ("P-Charging-Function-Addresses: ccf=4.3.2.1;ccf=\"\\\\\\\"\\\\\";ecf=\"quote=this\";ecf=\"quote;this;as;well\"", get_headers(out, "P-Charging-Function-Addresses"));
 
   tpAS.expect_target(current_txdata(), false);
   inject_msg(respond_to_current_txdata(200));

--- a/src/ut/registrar_test.cpp
+++ b/src/ut/registrar_test.cpp
@@ -1016,6 +1016,7 @@ TEST_F(RegistrarTest, SimpleMainlinePassthrough)
     "  <CCF priority=\"2\">aaa://example.host;transport=TCP</CCF>\n"
     "  <ECF priority=\"1\">\"aaa://example.host;transport=UDP\"</ECF>\n"
     "  <ECF priority=\"2\">[fd2c:de55:7690:7777::ac12:aa6]</ECF>\n"
+    "  <ECF priority=\"3\">&quot;aaa://another.example.host;transport=TCP&quot;</ECF>\n"
     "</ChargingAddresses>"
   );
   Message msg;
@@ -1029,7 +1030,7 @@ TEST_F(RegistrarTest, SimpleMainlinePassthrough)
   EXPECT_EQ("P-Charging-Vector: icid-value=\"100\"", get_headers(out, "P-Charging-Vector"));
   // Check the contents of the PCFA header.  Only the 2nd value above should be quoted, as the 1st and 4th values match
   // the required spec for a "token" or IPv6 address, and the 3rd value was already quoted.
-  EXPECT_EQ("P-Charging-Function-Addresses: ccf=token%;ccf=\"aaa://example.host;transport=TCP\";ecf=\"aaa://example.host;transport=UDP\";ecf=[fd2c:de55:7690:7777::ac12:aa6]", get_headers(out, "P-Charging-Function-Addresses"));
+  EXPECT_EQ("P-Charging-Function-Addresses: ccf=token%;ccf=\"aaa://example.host;transport=TCP\";ecf=\"aaa://example.host;transport=UDP\";ecf=[fd2c:de55:7690:7777::ac12:aa6];ecf=\"aaa://another.example.host;transport=TCP\"", get_headers(out, "P-Charging-Function-Addresses"));
   EXPECT_EQ(1,((SNMP::FakeSuccessFailCountTable*)SNMP::FAKE_REGISTRATION_STATS_TABLES.init_reg_tbl)->_attempts);
   EXPECT_EQ(1,((SNMP::FakeSuccessFailCountTable*)SNMP::FAKE_REGISTRATION_STATS_TABLES.init_reg_tbl)->_successes);
 

--- a/src/ut/sip_parser_test.cpp
+++ b/src/ut/sip_parser_test.cpp
@@ -286,7 +286,7 @@ TEST_F(SipParserTest, PChargingFunctionAddresses)
              "Max-Forwards: 63\n"
              "From: <sip:6505551234@homedomain>;tag=1234\n"
              "To: <sip:6505554321@homedomain>\n"
-             "P-Charging-Function-Addresses: ecf=10.0.0.1; ccf=10.0.0.2; ecf=10.0.0.3; ccf=10.0.0.4; other-param=test-value\n"
+             "P-Charging-Function-Addresses: ecf=10.0.0.1; ccf=\"aaa://example.com;transport=TCP\"; ecf=[fd2c:de55:7690:7777::ac12:aa6]; ccf=token%; other-param=\"test;value\"\n"
              "Contact: <sip:6505551234@10.0.0.1:5060;transport=TCP;ob>\n"
              "Call-ID: 1-13919@10.151.20.48\n"
              "CSeq: 1 INVITE\n"
@@ -330,8 +330,8 @@ TEST_F(SipParserTest, PChargingFunctionAddresses)
     written = hdr->vptr->print_on(hdr, buf, i);
     i++;
   }
-  EXPECT_EQ(written, 105);
-  EXPECT_STREQ("P-Charging-Function-Addresses: ccf=10.0.0.2;ccf=10.0.0.4;ecf=10.0.0.1;ecf=10.0.0.3;other-param=test-value", buf);
+  EXPECT_EQ(written, 153);
+  EXPECT_STREQ("P-Charging-Function-Addresses: ccf=\"aaa://example.com;transport=TCP\";ccf=token%;ecf=10.0.0.1;ecf=[fd2c:de55:7690:7777::ac12:aa6];other-param=\"test;value\"", buf);
 }
 
 TEST_F(SipParserTest, PChargingFunctionAddressesIPv6)


### PR DESCRIPTION
Hi Richard

Are you OK to review this change for me (we discussed last week - its the fact that we don't quote "gen-values" of Charging function params in PCFA headers, contrary to the BNF in RFCs 3588 and 3261)? It would be good if you could find time to do this this week as the MMF workaround we gave to the customer might not work (as it would need to differentiate between ';' chars that are part of the values and not ccf/ecf parm separators).

I've taken care to quote only values that contain non-host/token characters (making the assumption that any value that starts with '[' is an IPv6 address and therefore doesn't need quoting, as is made elsewhere in sip_parser).

Note that I had to add a _hss_connection->set_impu_result to TEST_F(RegistrarTest, SimpleMainlinePassthrough), rather than change the existing _hss_connection->set_impu_result_with_prev call.  It seems that Sprout queries the regdata _without_ the ?private_id parameter when its trying to get CF values.

Tested live with a CCF value of aaa://hostname;transport=TCP as well as the UT updates below.

cpp-common PR to follow