### PR TITLE
Recover from CSeq desync (fix)

### DIFF
--- a/src/subscriber_data_manager.cpp
+++ b/src/subscriber_data_manager.cpp
@@ -292,12 +292,12 @@ void SubscriberDataManager::classify_bindings(const std::string& aor_id,
     }
     else
     {
-      // The binding is in both AoRs.
+      // The binding is in both AoRs. 
       if (aor_orig_b_match->second->_uri.compare(aor_current_b.second->_uri) != 0)
       {
         // Change of Contact URI. If the contact URI has been changed, we need to
-        // terminate the old contact (ref TS24.229 -  NOTE 2 in 5.4.2.1.2
-        // "Notification about registration state") and create a new one.
+        // terminate the old contact (ref TS24.229 -  NOTE 2 in 5.4.2.1.2	
+        // "Notification about registration state") and create a new one.  
         // We do this by adding a DEACTIVATED and then a CREATED ClassifiedBinding.
         ClassifiedBinding* deactivated_record =
            new ClassifiedBinding(aor_orig_b_match->first,
@@ -681,16 +681,16 @@ void SubscriberDataManager::NotifySender::send_notifys(
       }
       else
       {
-        // The binding is in both AoRs.
+        // The binding is in both AoRs. 
         NotifyUtils::ContactEvent event;
 
         if (aor_orig_b_match->second->_uri.compare(binding->_uri) != 0)
         {
           // Change of Contact URI. If the contact URI has been changed, we need to
-          // terminate the old contact (ref TS24.229 -  NOTE 2 in 5.4.2.1.2
-          // "Notification about registration state") and create a new one.
+          // terminate the old contact (ref TS24.229 -  NOTE 2 in 5.4.2.1.2	
+          // "Notification about registration state") and create a new one.  
           // We do this by adding a DEACTIVATED and then a CREATED ClassifiedBinding.
-          TRC_DEBUG("Binding %s has changed URIs from %s to %s",
+          TRC_DEBUG("Binding %s has changed URIs from %s to %s", 
                                       b_id.c_str(),
                                       aor_orig_b_match->second->_uri.c_str(),
                                       binding->_uri.c_str());
@@ -797,7 +797,6 @@ void SubscriberDataManager::NotifySender::send_notifys(
                 reasons.c_str());
 
       pjsip_tx_data* tdata_notify = NULL;
-
       pj_status_t status = NotifyUtils::create_subscription_notify(
                                             &tdata_notify,
                                             subscription,

--- a/src/subscriber_data_manager.cpp
+++ b/src/subscriber_data_manager.cpp
@@ -292,12 +292,12 @@ void SubscriberDataManager::classify_bindings(const std::string& aor_id,
     }
     else
     {
-      // The binding is in both AoRs. 
+      // The binding is in both AoRs.
       if (aor_orig_b_match->second->_uri.compare(aor_current_b.second->_uri) != 0)
       {
         // Change of Contact URI. If the contact URI has been changed, we need to
-        // terminate the old contact (ref TS24.229 -  NOTE 2 in 5.4.2.1.2	
-        // "Notification about registration state") and create a new one.  
+        // terminate the old contact (ref TS24.229 -  NOTE 2 in 5.4.2.1.2
+        // "Notification about registration state") and create a new one.
         // We do this by adding a DEACTIVATED and then a CREATED ClassifiedBinding.
         ClassifiedBinding* deactivated_record =
            new ClassifiedBinding(aor_orig_b_match->first,
@@ -681,16 +681,16 @@ void SubscriberDataManager::NotifySender::send_notifys(
       }
       else
       {
-        // The binding is in both AoRs. 
+        // The binding is in both AoRs.
         NotifyUtils::ContactEvent event;
 
         if (aor_orig_b_match->second->_uri.compare(binding->_uri) != 0)
         {
           // Change of Contact URI. If the contact URI has been changed, we need to
-          // terminate the old contact (ref TS24.229 -  NOTE 2 in 5.4.2.1.2	
-          // "Notification about registration state") and create a new one.  
+          // terminate the old contact (ref TS24.229 -  NOTE 2 in 5.4.2.1.2
+          // "Notification about registration state") and create a new one.
           // We do this by adding a DEACTIVATED and then a CREATED ClassifiedBinding.
-          TRC_DEBUG("Binding %s has changed URIs from %s to %s", 
+          TRC_DEBUG("Binding %s has changed URIs from %s to %s",
                                       b_id.c_str(),
                                       aor_orig_b_match->second->_uri.c_str(),
                                       binding->_uri.c_str());
@@ -797,6 +797,7 @@ void SubscriberDataManager::NotifySender::send_notifys(
                 reasons.c_str());
 
       pjsip_tx_data* tdata_notify = NULL;
+
       pj_status_t status = NotifyUtils::create_subscription_notify(
                                             &tdata_notify,
                                             subscription,

--- a/src/subscriptionsproutlet.cpp
+++ b/src/subscriptionsproutlet.cpp
@@ -610,8 +610,9 @@ Store::Status SubscriptionSproutletTsx::update_subscription_in_stores(
         }
         else if (remote_aor_pair->get_current()->_notify_cseq > local_notify_cseq)
         {
-          // If the remote CSeq is larger, do not increment it.
-          remote_aor_pair->get_current()->_notify_cseq -= 1;
+          // If the remote CSeq is larger, do not increment it. It's not easy to
+          // test this with the current UT infrastructure.
+          remote_aor_pair->get_current()->_notify_cseq -= 1; // LCOV_EXCL_LINE
         }
 
         update_subscription(subscription, new_subscription, aor, remote_aor_pair, _cached_aors);

--- a/src/subscriptionsproutlet.cpp
+++ b/src/subscriptionsproutlet.cpp
@@ -604,17 +604,17 @@ Store::Status SubscriptionSproutletTsx::update_subscription_in_stores(
       }
       else
       {
-        if (remote_aor_pair->get_current()->_notify_cseq != local_notify_cseq)
+        // Attempt to recover in the case that CSeqs are out of sync between the
+        // local and remote stores.
+        if (remote_aor_pair->get_current()->_notify_cseq < local_notify_cseq)
         {
-          // Overwrite the CSeq value on the remote AoR pair, and log an error.
-          if (remote_aor_pair->get_current()->_notify_cseq < local_notify_cseq)
-          {
-            remote_aor_pair->get_current()->_notify_cseq = local_notify_cseq;
-          }
-          else
-          {
-            remote_aor_pair->get_current()->_notify_cseq = local_notify_cseq - 1;
-          }
+          // If the remote CSeq is smaller, overwrite it with the local one.
+          remote_aor_pair->get_current()->_notify_cseq = local_notify_cseq;
+        }
+        else
+        {
+          // If the remote CSeq is larger, do not increment it.
+          remote_aor_pair->get_current()->_notify_cseq -= 1;
         }
 
         update_subscription(subscription, new_subscription, aor, remote_aor_pair, _cached_aors);

--- a/src/subscriptionsproutlet.cpp
+++ b/src/subscriptionsproutlet.cpp
@@ -527,20 +527,25 @@ Store::Status SubscriptionSproutletTsx::update_subscription_in_stores(
     return status;
   }
 
-  // If the NOTIFY Cseq values on the local AoR pair and the remote AoR pair get
-  // out of sync, we need a way to recover. We store the local value, and
-  // overwrite the remote value if necessary. This means that we will recover
-  // once a subscription is updated, possibly after sending some NOTIFYs with
-  // incorrect CSeq values.
-  // This isn't an ideal solution - this entire area of code is due to be
-  // refactored, at which point a more permanent fix should be implemented.
-  int local_notify_cseq = local_aor_pair->get_current()->_notify_cseq;
+  int local_notify_cseq = -1;
 
   // Write to the local store, handling any CAS error
   do
   {
     update_subscription(subscription, new_subscription, aor, local_aor_pair, _cached_aors);
     local_aor_pair->get_current()->_associated_uris = *associated_uris;
+
+    // If the NOTIFY Cseq values on the local AoR pair and the remote AoR pair get
+    // out of sync, we need a way to recover. We store the local value, and
+    // overwrite the remote value if necessary. This means that we will recover
+    // once a subscription is updated, possibly after sending some NOTIFYs with
+    // incorrect CSeq values.
+    // This isn't an ideal solution - this entire area of code is due to be
+    // refactored, at which point a more permanent fix should be implemented.
+    local_notify_cseq = local_aor_pair->get_current()->_notify_cseq;
+    TRC_DEBUG("Read local CSeq %d for AoR %s",
+              local_notify_cseq,
+              aor.c_str());
 
     status = subscription->_sdm->set_aor_data(aor, SubscriberDataManager::EventTrigger::USER, local_aor_pair, trail());
     if (status == Store::DATA_CONTENTION)
@@ -602,11 +607,14 @@ Store::Status SubscriptionSproutletTsx::update_subscription_in_stores(
         if (remote_aor_pair->get_current()->_notify_cseq != local_notify_cseq)
         {
           // Overwrite the CSeq value on the remote AoR pair, and log an error.
-          TRC_WARNING("Remote CSeq %d differs from local CSeq %d for AoR %s, overwriting remote CSeq",
-                      remote_aor_pair->get_current()->_notify_cseq,
-                      local_notify_cseq,
-                      aor.c_str());
-          remote_aor_pair->get_current()->_notify_cseq = local_notify_cseq;
+          if (remote_aor_pair->get_current()->_notify_cseq < local_notify_cseq)
+          {
+            remote_aor_pair->get_current()->_notify_cseq = local_notify_cseq;
+          }
+          else
+          {
+            remote_aor_pair->get_current()->_notify_cseq = local_notify_cseq - 1;
+          }
         }
 
         update_subscription(subscription, new_subscription, aor, remote_aor_pair, _cached_aors);

--- a/src/subscriptionsproutlet.cpp
+++ b/src/subscriptionsproutlet.cpp
@@ -611,7 +611,7 @@ Store::Status SubscriptionSproutletTsx::update_subscription_in_stores(
           // If the remote CSeq is smaller, overwrite it with the local one.
           remote_aor_pair->get_current()->_notify_cseq = local_notify_cseq;
         }
-        else
+        else if (remote_aor_pair->get_current()->_notify_cseq > local_notify_cseq)
         {
           // If the remote CSeq is larger, do not increment it.
           remote_aor_pair->get_current()->_notify_cseq -= 1;


### PR DESCRIPTION
Fixes some issues with [#2029](https://github.com/Metaswitch/sprout/pull/2029). Namely:

- The CSeq is correctly updated when we hit data contention writing to the local store;
- The spammy log has been removed;
- The CSeq counter is more resilient to read/write race conditions.

I've tested these changes as follows.

- [x] `make full_test` passes (with a line excluded - see previous PR for caveats about code quality etc here)
- [x] live tests pass
- [x] custom live testing with individual SUBSCRIBE/REGISTERS uses correct CSeqs and recovers from simulated netsplit

Recovery can be slow if there is a large discrepancy in CSeqs, but after sufficiently many SUBSCRIBEs the counter _will_ recover, which is better than the current behavior.

- [x] stress testing with frequent SUBSCRIBE/REGISTERS from 2000 subscribers uses correct CSeqs
- [x] another-clearwater-stress-tool at rated load shows no regressions