### PR TITLE
Make a log that can be hit on each call INFO level

### DIFF
--- a/src/basicproxy.cpp
+++ b/src/basicproxy.cpp
@@ -1890,7 +1890,7 @@ void BasicProxy::UACTsx::cancel_pending_tsx(int st_code, const std::string& reas
         }
 
         // There are some known but hard-to-hit ways for this to fail - we
-        // only WARN for these:
+        // only log at INFO level for these:
         //
         // - EEXISTS can be hit if we've already sent out the CANCEL and then
         //   see a transport failure on the incoming side of the call - that
@@ -1900,8 +1900,8 @@ void BasicProxy::UACTsx::cancel_pending_tsx(int st_code, const std::string& reas
         //   send the CANCEL is unavailable.
         if ((status == PJ_EEXISTS) || (status == PJ_EINVALIDOP))
         {
-          TRC_WARNING("Error sending CANCEL, %s",
-                      PJUtils::pj_status_to_string(status).c_str());
+          TRC_INFO("Error sending CANCEL, %s",
+                   PJUtils::pj_status_to_string(status).c_str());
         }
         else if (status != PJ_SUCCESS)
         {


### PR DESCRIPTION
This fixes up the log that you were seeing in your stress runs. Tested by running the UTs. 