### PR TITLE
Fix up incorrect UTs in sprout

### DIFF
--- a/src/ut/scscf_test.cpp
+++ b/src/ut/scscf_test.cpp
@@ -3895,7 +3895,7 @@ TEST_F(SCSCFTest, DefaultHandlingContinueNonExistent)
   ReqMatcher r2("INVITE");
   ASSERT_NO_FATAL_FAILURE(r2.matches(out));
 
-  // INVITE passed onto final destination, so to callee.
+  // INVITE passed to final destination, so to callee.
   tpCallee.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob", r2.uri());
   EXPECT_EQ("", get_headers(out, "Route"));
@@ -4707,7 +4707,7 @@ TEST_F(SCSCFTest, DefaultHandlingContinueNonExistentRRTest)
   ReqMatcher r2("INVITE");
   ASSERT_NO_FATAL_FAILURE(r2.matches(out));
 
-  // INVITE is passed to final destination, so to callee.
+  // INVITE passed to final destination, so to callee.
   tpCallee.expect_target(current_txdata(), false);
 
   // The S-CSCF should record-route itself for both originating and terminating
@@ -5195,7 +5195,7 @@ void SCSCFTestBase::doAsOriginated(const std::string& msg, bool expect_orig)
   out = current_txdata()->msg;
   ASSERT_NO_FATAL_FAILURE(r1.matches(out));
 
-  // INVITE passed on to final destination, so to callee.
+  // INVITE passed to final destination, so to callee.
   tpCallee.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob", r1.uri());
   EXPECT_EQ("", get_headers(out, "Route"));
@@ -5929,7 +5929,7 @@ TEST_F(SCSCFTest, MmtelDoubleCdiv)
   out = current_txdata()->msg;
   ASSERT_NO_FATAL_FAILURE(r1.matches(out));
 
-  // INVITE passed to final destination, which is the final calle (who the call
+  // INVITE passed to final destination, which is the final callee (who the call
   // was diverted twice to).
   tpDivertedToCallee.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:andunnuvvawun@10.114.61.214:5061;transport=tcp;ob", r1.uri());
@@ -6208,7 +6208,7 @@ TEST_F(SCSCFTest, MmtelThenExternal)
   out = current_txdata()->msg;
   ASSERT_NO_FATAL_FAILURE(r1.matches(out));
 
-  // INVITE passed to final destination, which is callee.
+  // INVITE passed to final destination, so to callee.
   tpCallee.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob", r1.uri());
   EXPECT_EQ("", get_headers(out, "Route"));
@@ -6343,7 +6343,7 @@ TEST_F(SCSCFTest, MultipleMmtelFlow)
   out = current_txdata()->msg;
   ASSERT_NO_FATAL_FAILURE(r1.matches(out));
 
-  // INVITE passed to final destination, which is callee.
+  // INVITE passed to final destination, so to callee.
   tpCallee.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob", r1.uri());
   EXPECT_EQ("", get_headers(out, "Route"));
@@ -6847,7 +6847,7 @@ TEST_F(SCSCFTest, OriginatingTerminatingAS)
   out = current_txdata()->msg;
   ASSERT_NO_FATAL_FAILURE(r1.matches(out));
 
-  // INVITE passed directly to terminating UE
+  // INVITE passed to terminating UE (callee).
   tpCallee.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob", r1.uri());
   EXPECT_EQ("", get_headers(out, "Route"));
@@ -7053,6 +7053,7 @@ TEST_F(SCSCFTest, OriginatingTerminatingASTimeout)
   SCOPED_TRACE("INVITE (2)");
   out = current_txdata()->msg;
   ASSERT_NO_FATAL_FAILURE(r1.matches(out));
+
   // INVITE passed to terminating UE (callee).
   tpCallee.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob", r1.uri());
@@ -7310,11 +7311,12 @@ TEST_F(SCSCFTest, OriginatingTerminatingMessageASTimeout)
   inject_msg(out, &tpAS);
   pjsip_tx_data_dec_ref(message_txdata);
 
-  // MESSAGE passed to terminating UE
+  // MESSAGE passed to terminating UE.
   ASSERT_EQ(1, txdata_count());
   out = current_txdata()->msg;
   ASSERT_NO_FATAL_FAILURE(r1.matches(out));
-  // MESSAGE passed to terminating UE, UE2.
+
+  // MESSAGE passed to terminating UE (UE2).
   tpUE2.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob", r1.uri());
   EXPECT_EQ("", get_headers(out, "Route"));

--- a/src/ut/scscf_test.cpp
+++ b/src/ut/scscf_test.cpp
@@ -2623,6 +2623,7 @@ TEST_F(SCSCFTest, SimpleISCMainline)
 
   TransportFlow tpBono(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.99.88.11", 12345);
   TransportFlow tpAS1(TransportFlow::Protocol::UDP, stack_data.scscf_port, "1.2.3.4", 56789);
+  TransportFlow tpCallee(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.114.61.213", 5061);
 
   // ---------- Send INVITE
   // We're within the trust boundary, so no stripping should occur.
@@ -2685,7 +2686,8 @@ TEST_F(SCSCFTest, SimpleISCMainline)
   ReqMatcher r2("INVITE");
   ASSERT_NO_FATAL_FAILURE(r2.matches(out));
 
-  tpBono.expect_target(current_txdata(), false);
+  // INVITE passed to final destination, so to callee.
+  tpCallee.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob", r2.uri());
   EXPECT_EQ("", get_headers(out, "Route"));
 
@@ -5945,6 +5947,7 @@ TEST_F(SCSCFTest, MmtelFlow)
 
   TransportFlow tpBono(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.99.88.11", 12345);
   TransportFlow tpAS1(TransportFlow::Protocol::UDP, stack_data.scscf_port, "5.2.3.4", 56787);
+  TransportFlow tpCallee(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.114.61.213", 5061);
 
   // ---------- Send INVITE
   // We're within the trust boundary, so no stripping should occur.
@@ -6004,7 +6007,8 @@ TEST_F(SCSCFTest, MmtelFlow)
   out = current_txdata()->msg;
   ASSERT_NO_FATAL_FAILURE(r1.matches(out));
 
-  tpBono.expect_target(current_txdata(), false);
+  // INVITE passed to final destination, so to callee.
+  tpCallee.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob", r1.uri());
   EXPECT_EQ("", get_headers(out, "Route"));
   EXPECT_EQ("Privacy: id; header; user", get_headers(out, "Privacy"));

--- a/src/ut/scscf_test.cpp
+++ b/src/ut/scscf_test.cpp
@@ -438,6 +438,7 @@ void SCSCFTestBase::doFourAppServerFlow(std::string record_route_regex, bool app
   TransportFlow tpAS2(TransportFlow::Protocol::UDP, stack_data.scscf_port, "4.2.3.4", 56788);
   TransportFlow tpAS3(TransportFlow::Protocol::UDP, stack_data.scscf_port, "5.2.3.4", 56787);
   TransportFlow tpAS4(TransportFlow::Protocol::UDP, stack_data.scscf_port, "6.2.3.4", 56786);
+  TransportFlow tpCallee(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.114.61.213", 5061);
 
   pjsip_rr_hdr* as1_rr_hdr = pjsip_rr_hdr_create(stack_data.pool);
   as1_rr_hdr->name_addr.uri = (pjsip_uri*)pjsip_sip_uri_create(stack_data.pool, false);
@@ -624,7 +625,8 @@ void SCSCFTestBase::doFourAppServerFlow(std::string record_route_regex, bool app
   out = current_txdata()->msg;
   ASSERT_NO_FATAL_FAILURE(r1.matches(out));
 
-  tpBono.expect_target(current_txdata(), false);
+  // INVITE passed to final destination, so to callee.
+  tpCallee.expect_target(current_txdata(), false);
 
   // ---------- Bono sends a 100 Trying to indicate it has received the request.
   string fresp_bono = respond_to_txdata(current_txdata(), 100);
@@ -2727,6 +2729,7 @@ TEST_F(SCSCFTest, ISCMultipleResponses)
 
   TransportFlow tpBono(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.99.88.11", 12345);
   TransportFlow tpAS1(TransportFlow::Protocol::UDP, stack_data.scscf_port, "1.2.3.4", 56789);
+  TransportFlow tpCallee(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.114.61.213", 5061);
 
   // ---------- Send INVITE
   // We're within the trust boundary, so no stripping should occur.
@@ -2789,7 +2792,8 @@ TEST_F(SCSCFTest, ISCMultipleResponses)
   ReqMatcher r2("INVITE");
   ASSERT_NO_FATAL_FAILURE(r2.matches(out));
 
-  tpBono.expect_target(current_txdata(), false);
+  // INVITE passed to final destination, so to callee.
+  tpCallee.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob", r2.uri());
   EXPECT_EQ("", get_headers(out, "Route"));
 
@@ -2840,6 +2844,7 @@ TEST_F(SCSCFTest, ISCRetargetWithoutCdiv)
 
   TransportFlow tpBono(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.99.88.11", 12345);
   TransportFlow tpAS1(TransportFlow::Protocol::UDP, stack_data.scscf_port, "1.2.3.4", 56789);
+  TransportFlow tpCallee(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.114.61.213", 5061);
 
   // ---------- Send INVITE
   // We're within the trust boundary, so no stripping should occur.
@@ -2900,7 +2905,8 @@ TEST_F(SCSCFTest, ISCRetargetWithoutCdiv)
   ReqMatcher r2("INVITE");
   ASSERT_NO_FATAL_FAILURE(r2.matches(out));
 
-  tpBono.expect_target(current_txdata(), false);
+  // INVITE passed to final destination, so to callee.
+  tpCallee.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob", r2.uri());
   EXPECT_EQ("", get_headers(out, "Route"));
 
@@ -3110,6 +3116,7 @@ TEST_F(SCSCFTest, SimpleNextOrigFlow)
 
   TransportFlow tpBono(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.99.88.11", 12345);
   TransportFlow tpAS1(TransportFlow::Protocol::UDP, stack_data.scscf_port, "1.2.3.4", 56789);
+  TransportFlow tpCallee(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.114.61.213", 5061);
 
   // ---------- Send INVITE
   // We're within the trust boundary, so no stripping should occur.
@@ -3170,7 +3177,8 @@ TEST_F(SCSCFTest, SimpleNextOrigFlow)
   ReqMatcher r2("INVITE");
   ASSERT_NO_FATAL_FAILURE(r2.matches(out));
 
-  tpBono.expect_target(current_txdata(), false);
+  // INVITE passed to final destination, so to callee.
+  tpCallee.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob", r2.uri());
   EXPECT_EQ("", get_headers(out, "Route"));
 
@@ -5104,6 +5112,7 @@ void SCSCFTestBase::doAsOriginated(const std::string& msg, bool expect_orig)
   TransportFlow tpAS0(TransportFlow::Protocol::UDP, stack_data.scscf_port, "6.2.3.4", 56786);
   TransportFlow tpAS1(TransportFlow::Protocol::UDP, stack_data.scscf_port, "1.2.3.4", 56789);
   TransportFlow tpAS2(TransportFlow::Protocol::UDP, stack_data.scscf_port, "5.2.3.4", 56787);
+  TransportFlow tpCallee(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.114.61.213", 5061);
 
   // ---------- Send spontaneous INVITE from AS0.
   inject_msg(msg, &tpAS0);
@@ -5186,7 +5195,8 @@ void SCSCFTestBase::doAsOriginated(const std::string& msg, bool expect_orig)
   out = current_txdata()->msg;
   ASSERT_NO_FATAL_FAILURE(r1.matches(out));
 
-  tpBono.expect_target(current_txdata(), false);
+  // INVITE passed on to final destination, so to callee.
+  tpCallee.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob", r1.uri());
   EXPECT_EQ("", get_headers(out, "Route"));
 
@@ -5247,7 +5257,6 @@ TEST_F(SCSCFTest, AsOriginatedTerm)
 TEST_F(SCSCFTest, Cdiv)
 {
   register_uri(_sdm, _hss_connection, "6505551234", "homedomain", "sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob");
-  register_uri(_sdm, _hss_connection, "6505551000", "homedomain", "sip:wuntootree@10.14.61.213:5061;transport=tcp;ob");
   register_uri(_sdm, _hss_connection, "6505555678", "homedomain", "sip:andunnuvvawun@10.114.61.214:5061;transport=tcp;ob");
   ServiceProfileBuilder service_profile = ServiceProfileBuilder()
     .addIdentity("sip:6505551234@homedomain")
@@ -5267,6 +5276,7 @@ TEST_F(SCSCFTest, Cdiv)
   TransportFlow tpBono(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.99.88.11", 12345);
   TransportFlow tpAS1(TransportFlow::Protocol::UDP, stack_data.scscf_port, "5.2.3.4", 56787);
   TransportFlow tpAS2(TransportFlow::Protocol::UDP, stack_data.scscf_port, "1.2.3.4", 56789);
+  TransportFlow tpDivertedToCallee(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.114.61.214", 5061);
 
   // ---------- Send INVITE
   // We're within the trust boundary, so no stripping should occur.
@@ -5367,7 +5377,9 @@ TEST_F(SCSCFTest, Cdiv)
   out = current_txdata()->msg;
   ASSERT_NO_FATAL_FAILURE(r1.matches(out));
 
-  tpBono.expect_target(current_txdata(), false);
+  // INVITE passed to final destination, which is the final callee (who the call
+  // was diverted to).
+  tpDivertedToCallee.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:andunnuvvawun@10.114.61.214:5061;transport=tcp;ob", r1.uri());
   EXPECT_EQ("", get_headers(out, "Route"));
 
@@ -5381,8 +5393,6 @@ TEST_F(SCSCFTest, Cdiv)
 TEST_F(SCSCFTest, CdivToDifferentDomain)
 {
   register_uri(_sdm, _hss_connection, "6505551234", "homedomain", "sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob");
-  register_uri(_sdm, _hss_connection, "6505551000", "homedomain", "sip:wuntootree@10.14.61.213:5061;transport=tcp;ob");
-  register_uri(_sdm, _hss_connection, "6505555678", "homedomain", "sip:andunnuvvawun@10.114.61.214:5061;transport=tcp;ob");
   ServiceProfileBuilder service_profile = ServiceProfileBuilder()
     .addIdentity("sip:6505551234@homedomain")
     .addIfc(2, {"<SessionCase>4</SessionCase><!-- originating-cdiv -->", "<Method>INVITE</Method>"}, "sip:1.2.3.4:56789;transport=UDP")
@@ -5672,6 +5682,7 @@ TEST_F(SCSCFTest, MmtelCdiv)
 
   TransportFlow tpBono(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.99.88.11", 12345);
   TransportFlow tpAS2(TransportFlow::Protocol::UDP, stack_data.scscf_port, "1.2.3.4", 56789);
+  TransportFlow tpDivertedToCallee(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.114.61.214", 5061);
 
   // ---------- Send INVITE
   // We're within the trust boundary, so no stripping should occur.
@@ -5745,7 +5756,9 @@ TEST_F(SCSCFTest, MmtelCdiv)
   out = current_txdata()->msg;
   ASSERT_NO_FATAL_FAILURE(r1.matches(out));
 
-  tpBono.expect_target(current_txdata(), false);
+  // INVITE passed to final destination, which is the final callee (who the call
+  // was diverted to).
+  tpDivertedToCallee.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:andunnuvvawun@10.114.61.214:5061;transport=tcp;ob", r1.uri());
   EXPECT_EQ("", get_headers(out, "Route"));
   EXPECT_THAT(get_headers(out, "History-Info"),
@@ -5833,6 +5846,7 @@ TEST_F(SCSCFTest, MmtelDoubleCdiv)
 
   TransportFlow tpBono(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.99.88.11", 12345);
   TransportFlow tpAS2(TransportFlow::Protocol::UDP, stack_data.scscf_port, "1.2.3.4", 56789);
+  TransportFlow tpDivertedToCallee(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.114.61.214", 5061);
 
   // ---------- Send INVITE
   // We're within the trust boundary, so no stripping should occur.
@@ -5915,7 +5929,9 @@ TEST_F(SCSCFTest, MmtelDoubleCdiv)
   out = current_txdata()->msg;
   ASSERT_NO_FATAL_FAILURE(r1.matches(out));
 
-  tpBono.expect_target(current_txdata(), false);
+  // INVITE passed to final destination, which is the final calle (who the call
+  // was diverted twice to).
+  tpDivertedToCallee.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:andunnuvvawun@10.114.61.214:5061;transport=tcp;ob", r1.uri());
   EXPECT_EQ("", get_headers(out, "Route"));
 
@@ -6099,6 +6115,7 @@ TEST_F(SCSCFTest, MmtelThenExternal)
   TransportFlow tpBono(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.99.88.11", 12345);
   TransportFlow tpAS1(TransportFlow::Protocol::UDP, stack_data.scscf_port, "1.2.3.4", 56789);
   TransportFlow tpAS2(TransportFlow::Protocol::UDP, stack_data.scscf_port, "5.2.3.4", 56787);
+  TransportFlow tpCallee(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.114.61.213", 5061);
 
   // ---------- Send INVITE
   // We're within the trust boundary, so no stripping should occur.
@@ -6191,7 +6208,8 @@ TEST_F(SCSCFTest, MmtelThenExternal)
   out = current_txdata()->msg;
   ASSERT_NO_FATAL_FAILURE(r1.matches(out));
 
-  tpBono.expect_target(current_txdata(), false);
+  // INVITE passed to final destination, which is callee.
+  tpCallee.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob", r1.uri());
   EXPECT_EQ("", get_headers(out, "Route"));
   EXPECT_EQ("Privacy: id; header; user", get_headers(out, "Privacy"));
@@ -6265,6 +6283,7 @@ TEST_F(SCSCFTest, MultipleMmtelFlow)
 
   TransportFlow tpBono(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.99.88.11", 12345);
   TransportFlow tpAS1(TransportFlow::Protocol::UDP, stack_data.scscf_port, "5.2.3.4", 56787);
+  TransportFlow tpCallee(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.114.61.213", 5061);
 
   // ---------- Send INVITE
   // We're within the trust boundary, so no stripping should occur.
@@ -6324,7 +6343,8 @@ TEST_F(SCSCFTest, MultipleMmtelFlow)
   out = current_txdata()->msg;
   ASSERT_NO_FATAL_FAILURE(r1.matches(out));
 
-  tpBono.expect_target(current_txdata(), false);
+  // INVITE passed to final destination, which is callee.
+  tpCallee.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob", r1.uri());
   EXPECT_EQ("", get_headers(out, "Route"));
   EXPECT_EQ("Privacy: id; header; user", get_headers(out, "Privacy"));
@@ -6706,6 +6726,7 @@ TEST_F(SCSCFTest, OriginatingTerminatingAS)
 
   TransportFlow tpBono(TransportFlow::Protocol::UDP, stack_data.scscf_port, "10.99.88.11", 12345);
   TransportFlow tpAS(TransportFlow::Protocol::UDP, stack_data.scscf_port, "1.2.3.4", 56789);
+  TransportFlow tpCallee(TransportFlow::Protocol::UDP, stack_data.scscf_port, "10.114.61.213", 5061);
 
   // ---------- Send INVITE
   // We're within the trust boundary, so no stripping should occur.
@@ -6826,7 +6847,8 @@ TEST_F(SCSCFTest, OriginatingTerminatingAS)
   out = current_txdata()->msg;
   ASSERT_NO_FATAL_FAILURE(r1.matches(out));
 
-  tpBono.expect_target(current_txdata(), false);
+  // INVITE passed directly to terminating UE
+  tpCallee.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob", r1.uri());
   EXPECT_EQ("", get_headers(out, "Route"));
 
@@ -6894,6 +6916,7 @@ TEST_F(SCSCFTest, OriginatingTerminatingASTimeout)
 {
   TransportFlow tpBono(TransportFlow::Protocol::UDP, stack_data.scscf_port, "10.99.88.11", 12345);
   TransportFlow tpAS(TransportFlow::Protocol::UDP, stack_data.scscf_port, "1.2.3.4", 56789);
+  TransportFlow tpCallee(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.114.61.213", 5061);
 
   register_uri(_sdm, _hss_connection, "6505551234", "homedomain", "sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob");
 
@@ -7030,7 +7053,8 @@ TEST_F(SCSCFTest, OriginatingTerminatingASTimeout)
   SCOPED_TRACE("INVITE (2)");
   out = current_txdata()->msg;
   ASSERT_NO_FATAL_FAILURE(r1.matches(out));
-  tpBono.expect_target(current_txdata(), false);
+  // INVITE passed to terminating UE (callee).
+  tpCallee.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob", r1.uri());
   EXPECT_EQ("", get_headers(out, "Route"));
 
@@ -7163,6 +7187,7 @@ TEST_F(SCSCFTest, OriginatingTerminatingMessageASTimeout)
 {
   TransportFlow tpBono(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.99.88.11", 12345);
   TransportFlow tpAS(TransportFlow::Protocol::TCP, stack_data.scscf_port, "1.2.3.4", 56789);
+  TransportFlow tpUE2(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.114.61.213", 5061);
 
   register_uri(_sdm, _hss_connection, "6505551234", "homedomain", "sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob");
 
@@ -7289,7 +7314,8 @@ TEST_F(SCSCFTest, OriginatingTerminatingMessageASTimeout)
   ASSERT_EQ(1, txdata_count());
   out = current_txdata()->msg;
   ASSERT_NO_FATAL_FAILURE(r1.matches(out));
-  tpBono.expect_target(current_txdata(), false);
+  // MESSAGE passed to terminating UE, UE2.
+  tpUE2.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob", r1.uri());
   EXPECT_EQ("", get_headers(out, "Route"));
 
@@ -8935,6 +8961,7 @@ TEST_F(SCSCFTest, NoMatchingStandardiFCsUseFallbackiFCs)
 
   TransportFlow tpBono(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.99.88.11", 12345);
   TransportFlow tpAS1(TransportFlow::Protocol::UDP, stack_data.scscf_port, "1.2.3.5", 56789);
+  TransportFlow tpCallee(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.114.61.213", 5061);
 
   // ---------- Send INVITE
   // We're within the trust boundary, so no stripping should occur.
@@ -9012,7 +9039,8 @@ TEST_F(SCSCFTest, NoMatchingStandardiFCsUseFallbackiFCs)
   ReqMatcher r3("INVITE");
   ASSERT_NO_FATAL_FAILURE(r3.matches(out));
 
-  tpBono.expect_target(current_txdata(), false);
+  // INVITE passed to final destination, so to callee.
+  tpCallee.expect_target(current_txdata(), false);
 
   // Target sends back 100 Trying
   inject_msg(respond_to_txdata(current_txdata(), 100), &tpBono);
@@ -9045,6 +9073,7 @@ TEST_F(SCSCFTest, NoStandardiFCsUseFallbackiFCs)
 
   TransportFlow tpBono(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.99.88.11", 12345);
   TransportFlow tpAS1(TransportFlow::Protocol::UDP, stack_data.scscf_port, "1.2.3.5", 56789);
+  TransportFlow tpCallee(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.114.61.213", 5061);
 
   // ---------- Send INVITE
   // We're within the trust boundary, so no stripping should occur.
@@ -9122,7 +9151,8 @@ TEST_F(SCSCFTest, NoStandardiFCsUseFallbackiFCs)
   ReqMatcher r3("INVITE");
   ASSERT_NO_FATAL_FAILURE(r3.matches(out));
 
-  tpBono.expect_target(current_txdata(), false);
+  // INVITE passed to final destination, so to callee.
+  tpCallee.expect_target(current_txdata(), false);
 
   // Target sends back 100 Trying
   inject_msg(respond_to_txdata(current_txdata(), 100), &tpBono);
@@ -9201,6 +9231,7 @@ TEST_F(SCSCFTest, MixedRealAndDummyApplicationServer)
 
   TransportFlow tpBono(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.99.88.11", 12345);
   TransportFlow tpAS1(TransportFlow::Protocol::UDP, stack_data.scscf_port, "1.2.3.4", 56789);
+  TransportFlow tpCallee(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.114.61.213", 5061);
 
   // ---------- Send INVITE
   // We're within the trust boundary, so no stripping should occur.
@@ -9253,7 +9284,8 @@ TEST_F(SCSCFTest, MixedRealAndDummyApplicationServer)
   ReqMatcher r2("INVITE");
   ASSERT_NO_FATAL_FAILURE(r2.matches(out));
 
-  tpBono.expect_target(current_txdata(), false);
+  // INVITE passed to final destination, so to callee.
+  tpCallee.expect_target(current_txdata(), false);
 
   // Target sends back 100 Trying
   inject_msg(respond_to_txdata(current_txdata(), 100), &tpBono);

--- a/src/ut/scscf_test.cpp
+++ b/src/ut/scscf_test.cpp
@@ -3858,6 +3858,7 @@ TEST_F(SCSCFTest, DefaultHandlingContinueNonExistent)
 
   TransportFlow tpBono(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.99.88.11", 12345);
   TransportFlow tpAS1(TransportFlow::Protocol::UDP, stack_data.scscf_port, "1.2.3.4", 56789);
+  TransportFlow tpCallee(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.114.61.213", 5061);
 
   // ---------- Send INVITE
   // We're within the trust boundary, so no stripping should occur.
@@ -3886,7 +3887,8 @@ TEST_F(SCSCFTest, DefaultHandlingContinueNonExistent)
   ReqMatcher r2("INVITE");
   ASSERT_NO_FATAL_FAILURE(r2.matches(out));
 
-  tpBono.expect_target(current_txdata(), false);
+  // INVITE passed onto final destination, so to callee.
+  tpCallee.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob", r2.uri());
   EXPECT_EQ("", get_headers(out, "Route"));
 
@@ -3916,6 +3918,7 @@ TEST_F(SCSCFTest, DefaultHandlingContinueNonResponsive)
 
   TransportFlow tpBono(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.99.88.11", 12345);
   TransportFlow tpAS1(TransportFlow::Protocol::UDP, stack_data.scscf_port, "1.2.3.4", 56789);
+  TransportFlow tpCallee(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.114.61.213", 5061);
 
   // ---------- Send INVITE
   // We're within the trust boundary, so no stripping should occur.
@@ -3966,7 +3969,8 @@ TEST_F(SCSCFTest, DefaultHandlingContinueNonResponsive)
   ReqMatcher r2("INVITE");
   ASSERT_NO_FATAL_FAILURE(r2.matches(out));
 
-  tpBono.expect_target(current_txdata(), false);
+  // INVITE passed to final destination, so to callee.
+  tpCallee.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob", r2.uri());
   EXPECT_EQ("", get_headers(out, "Route"));
 
@@ -3994,6 +3998,7 @@ TEST_F(SCSCFTest, DefaultHandlingContinueImmediateError)
 
   TransportFlow tpBono(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.99.88.11", 12345);
   TransportFlow tpAS1(TransportFlow::Protocol::UDP, stack_data.scscf_port, "1.2.3.4", 56789);
+  TransportFlow tpCallee(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.114.61.213", 5061);
 
   // ---------- Send INVITE
   // We're within the trust boundary, so no stripping should occur.
@@ -4046,7 +4051,8 @@ TEST_F(SCSCFTest, DefaultHandlingContinueImmediateError)
   ReqMatcher r2("INVITE");
   ASSERT_NO_FATAL_FAILURE(r2.matches(out));
 
-  tpBono.expect_target(current_txdata(), false);
+  // INVITE passed to final destination, so to callee.
+  tpCallee.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob", r2.uri());
   EXPECT_EQ("", get_headers(out, "Route"));
 
@@ -4077,6 +4083,7 @@ TEST_F(SCSCFTest, DefaultHandlingContinue100ThenError)
 
   TransportFlow tpBono(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.99.88.11", 12345);
   TransportFlow tpAS1(TransportFlow::Protocol::UDP, stack_data.scscf_port, "1.2.3.4", 56789);
+  TransportFlow tpCallee(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.114.61.213", 5061);
 
   // ---------- Send INVITE
   // We're within the trust boundary, so no stripping should occur.
@@ -4135,7 +4142,8 @@ TEST_F(SCSCFTest, DefaultHandlingContinue100ThenError)
   ReqMatcher r2("INVITE");
   ASSERT_NO_FATAL_FAILURE(r2.matches(out));
 
-  tpBono.expect_target(current_txdata(), false);
+  // INVITE passed to final destination, so to callee.
+  tpCallee.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob", r2.uri());
   EXPECT_EQ("", get_headers(out, "Route"));
 
@@ -4260,6 +4268,7 @@ TEST_F(SCSCFTest, DefaultHandlingContinueInviteReturnedThenError)
 
   TransportFlow tpBono(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.99.88.11", 12345);
   TransportFlow tpAS1(TransportFlow::Protocol::UDP, stack_data.scscf_port, "1.2.3.4", 56789);
+  TransportFlow tpCallee(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.114.61.213", 5061);
 
   // ---------- Send INVITE
   // We're within the trust boundary, so no stripping should occur.
@@ -4325,7 +4334,8 @@ TEST_F(SCSCFTest, DefaultHandlingContinueInviteReturnedThenError)
   ReqMatcher r2("INVITE");
   ASSERT_NO_FATAL_FAILURE(r2.matches(out));
 
-  tpBono.expect_target(current_txdata(), false);
+  // INVITE passed to final destination, so to callee.
+  tpCallee.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob", r2.uri());
   EXPECT_EQ("", get_headers(out, "Route"));
 
@@ -4543,6 +4553,7 @@ TEST_F(SCSCFTest, DefaultHandlingMissing)
 
   TransportFlow tpBono(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.99.88.11", 12345);
   TransportFlow tpAS1(TransportFlow::Protocol::UDP, stack_data.scscf_port, "1.2.3.4", 56789);
+  TransportFlow tpCallee(TransportFlow::Protocol::UDP, stack_data.scscf_port, "10.114.61.213", 5061);
 
   // ---------- Send INVITE
   // We're within the trust boundary, so no stripping should occur.
@@ -4571,7 +4582,8 @@ TEST_F(SCSCFTest, DefaultHandlingMissing)
   ReqMatcher r2("INVITE");
   ASSERT_NO_FATAL_FAILURE(r2.matches(out));
 
-  tpBono.expect_target(current_txdata(), false);
+  // INVITE passed to final destination, so to callee.
+  tpCallee.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob", r2.uri());
   EXPECT_EQ("", get_headers(out, "Route"));
 
@@ -4599,6 +4611,7 @@ TEST_F(SCSCFTest, DefaultHandlingMalformed)
 
   TransportFlow tpBono(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.99.88.11", 12345);
   TransportFlow tpAS1(TransportFlow::Protocol::UDP, stack_data.scscf_port, "1.2.3.4", 56789);
+  TransportFlow tpCallee(TransportFlow::Protocol::UDP, stack_data.scscf_port, "10.114.61.213", 5061);
 
   // ---------- Send INVITE
   // We're within the trust boundary, so no stripping should occur.
@@ -4627,7 +4640,8 @@ TEST_F(SCSCFTest, DefaultHandlingMalformed)
   ReqMatcher r2("INVITE");
   ASSERT_NO_FATAL_FAILURE(r2.matches(out));
 
-  tpBono.expect_target(current_txdata(), false);
+  // INVITE passed to final destination, so to callee.
+  tpCallee.expect_target(current_txdata(), false);
   EXPECT_EQ("sip:wuntootreefower@10.114.61.213:5061;transport=tcp;ob", r2.uri());
   EXPECT_EQ("", get_headers(out, "Route"));
 
@@ -4656,6 +4670,7 @@ TEST_F(SCSCFTest, DefaultHandlingContinueNonExistentRRTest)
 
   TransportFlow tpBono(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.99.88.11", 12345);
   TransportFlow tpAS1(TransportFlow::Protocol::UDP, stack_data.scscf_port, "1.2.3.4", 56789);
+  TransportFlow tpCallee(TransportFlow::Protocol::TCP, stack_data.scscf_port, "10.114.61.213", 5061);
 
   // ---------- Send INVITE
   // We're within the trust boundary, so no stripping should occur.
@@ -4684,7 +4699,8 @@ TEST_F(SCSCFTest, DefaultHandlingContinueNonExistentRRTest)
   ReqMatcher r2("INVITE");
   ASSERT_NO_FATAL_FAILURE(r2.matches(out));
 
-  tpBono.expect_target(current_txdata(), false);
+  // INVITE is passed to final destination, so to callee.
+  tpCallee.expect_target(current_txdata(), false);
 
   // The S-CSCF should record-route itself for both originating and terminating
   // billing.

--- a/src/ut/siptest.cpp
+++ b/src/ut/siptest.cpp
@@ -315,6 +315,7 @@ std::string SipTest::TransportFlow::type_name()
 }
 
 
+
 int SipTest::TransportFlow::local_port()
 {
   return _transport->local_name.port;
@@ -349,11 +350,26 @@ void SipTest::TransportFlow::expect_target(const pjsip_tx_data* tdata, bool stri
       << " / actual " << tdata->tp_info.transport->obj_name
       << " " << tdata->tp_info.transport->info;
   }
-
-  if (!strcmp(_transport->type_name, "UDP"))
+  else
   {
+    // pj_sockaddr_cmp will compare the port as well as the address.
     bool remote_addr_eq = (pj_sockaddr_cmp(&_rem_addr, &tdata->tp_info.dst_addr) == 0);
-    EXPECT_EQ(remote_addr_eq, true) << "Wrong destination address";
+    char expected_addr[PJ_INET6_ADDRSTRLEN];
+    char actual_addr[PJ_INET6_ADDRSTRLEN];
+    pj_inet_ntop(_rem_addr.addr.sa_family,
+                 pj_sockaddr_get_addr((pj_sockaddr_t*)&_rem_addr),
+                 expected_addr,
+                 sizeof(expected_addr));
+    pj_inet_ntop(_rem_addr.addr.sa_family,
+                 pj_sockaddr_get_addr((pj_sockaddr_t*)&tdata->tp_info.dst_addr),
+                 actual_addr,
+                 sizeof(actual_addr));
+    EXPECT_EQ(remote_addr_eq, true)
+      << "Wrong destination address:"
+      << " expected " << expected_addr
+      << ":" << pj_sockaddr_get_port((pj_sockaddr_t*)&_rem_addr)
+      << " / actual " << actual_addr
+      << ":" << *(&tdata->tp_info.dst_port);
   }
 }
 

--- a/src/ut/siptest.cpp
+++ b/src/ut/siptest.cpp
@@ -315,7 +315,6 @@ std::string SipTest::TransportFlow::type_name()
 }
 
 
-
 int SipTest::TransportFlow::local_port()
 {
   return _transport->local_name.port;

--- a/src/ut/siptest.cpp
+++ b/src/ut/siptest.cpp
@@ -349,26 +349,11 @@ void SipTest::TransportFlow::expect_target(const pjsip_tx_data* tdata, bool stri
       << " / actual " << tdata->tp_info.transport->obj_name
       << " " << tdata->tp_info.transport->info;
   }
-  else
+
+  if (!strcmp(_transport->type_name, "UDP"))
   {
-    // pj_sockaddr_cmp will compare the port as well as the address.
     bool remote_addr_eq = (pj_sockaddr_cmp(&_rem_addr, &tdata->tp_info.dst_addr) == 0);
-    char expected_addr[PJ_INET6_ADDRSTRLEN];
-    char actual_addr[PJ_INET6_ADDRSTRLEN];
-    pj_inet_ntop(_rem_addr.addr.sa_family,
-                 pj_sockaddr_get_addr((pj_sockaddr_t*)&_rem_addr),
-                 expected_addr,
-                 sizeof(expected_addr));
-    pj_inet_ntop(_rem_addr.addr.sa_family,
-                 pj_sockaddr_get_addr((pj_sockaddr_t*)&tdata->tp_info.dst_addr),
-                 actual_addr,
-                 sizeof(actual_addr));
-    EXPECT_EQ(remote_addr_eq, true)
-      << "Wrong destination address:"
-      << " expected " << expected_addr
-      << ":" << pj_sockaddr_get_port((pj_sockaddr_t*)&_rem_addr)
-      << " / actual " << actual_addr
-      << ":" << *(&tdata->tp_info.dst_port);
+    EXPECT_EQ(remote_addr_eq, true) << "Wrong destination address";
   }
 }
 


### PR DESCRIPTION
This is the continuation of the fix to Metaswitch/clearwater-issues#2825.

I have fixed up 32 tests, which were broken by correcting the `expect_target()` function.
(This function was changed in PR #2046.)
These were all incorrect for the same reason (the final destination was expected as bono, not the callee).

This fix can be checked in now, as `make full_test` passes with this fix in place.