### PR TITLE
Fix up expect_target function in UTs

### DIFF
--- a/src/ut/siptest.cpp
+++ b/src/ut/siptest.cpp
@@ -349,11 +349,26 @@ void SipTest::TransportFlow::expect_target(const pjsip_tx_data* tdata, bool stri
       << " / actual " << tdata->tp_info.transport->obj_name
       << " " << tdata->tp_info.transport->info;
   }
-
-  if (!strcmp(_transport->type_name, "UDP"))
+  else
   {
+    // pj_sockaddr_cmp will compare the port as well as the address.
     bool remote_addr_eq = (pj_sockaddr_cmp(&_rem_addr, &tdata->tp_info.dst_addr) == 0);
-    EXPECT_EQ(remote_addr_eq, true) << "Wrong destination address";
+    char expected_addr[PJ_INET6_ADDRSTRLEN];
+    char actual_addr[PJ_INET6_ADDRSTRLEN];
+    pj_inet_ntop(_rem_addr.addr.sa_family,
+                 pj_sockaddr_get_addr((pj_sockaddr_t*)&_rem_addr),
+                 expected_addr,
+                 sizeof(expected_addr));
+    pj_inet_ntop(_rem_addr.addr.sa_family,
+                 pj_sockaddr_get_addr((pj_sockaddr_t*)&tdata->tp_info.dst_addr),
+                 actual_addr,
+                 sizeof(actual_addr));
+    EXPECT_EQ(remote_addr_eq, true)
+      << "Wrong destination address:"
+      << " expected " << expected_addr
+      << ":" << pj_sockaddr_get_port((pj_sockaddr_t*)&_rem_addr)
+      << " / actual " << actual_addr
+      << ":" << *(&tdata->tp_info.dst_port);
   }
 }
 


### PR DESCRIPTION
This is the start of the fix to Metaswitch/clearwater-issues#2825.

I have edited expect_target() so that it **always** checks the target, (either strictly, or less strictly).

This fix causes some tests to fail, so it cannot be checked in until these are corrected.
Most of these failing tests have been corrected in #2045, which has been checked in.
Currently 9 UTs are still failing, these must be fixed before this change can be checked in.