### PR TITLE
[Reviewer: Huw] Don't call deb and deb-only on plugins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ endef
 
 # Define the possible make targets for the plugins and generate the makefile
 # rules.
-PLUGIN_TARGETS := build test clean deb deb-only
+PLUGIN_TARGETS := build test clean deb-only
 $(foreach target,$(PLUGIN_TARGETS),$(eval $(call plugin_target_template,$(target))))
 
 #
@@ -111,7 +111,7 @@ include build-infra/cw-deb.mk
 deb-only: plugins-deb-only
 
 .PHONY: deb
-deb: build plugins-deb deb-only
+deb: build deb-only
 
 .PHONY: all build test clean distclean
 


### PR DESCRIPTION
Not urgent, but a nice build improvement.

Currently plugins get built twice by Sprout.

The model is:

- `deb` builds the target and the Debian package
- `deb-only` just packages the plugin

Thus when calling Sprout `deb` we need to build the plugin, and call `deb-only`,
not build, `deb` and `deb-only`.

Currently,

- `build` calls `plugin-build` which calls `make` in a plugin (which builds the plugin).
- `plugins-deb` calls `deb` in the plugin which builds the package
- `deb-only` calls `plugins-deb-only` calls `deb-only` in the plugin, which rebuilds the package (sigh).

Given that we are calling build, the right fix, I think, is to not call `plugins-deb` when calling `deb` as it'll have been done by either a combination of a) `build` and b) `deb-only`.
