### PR TITLE
Trim whitespace when matching contact filtering tokens

### DIFF
--- a/src/contact_filtering.cpp
+++ b/src/contact_filtering.cpp
@@ -614,10 +614,10 @@ MatchResult match_numeric(const std::string& matcher,
 }
 
 // Only needed for passing in to "transform" below.
-std::string string_to_lowercase(std::string& str)
+std::string string_to_lowercase_and_trim(std::string& str)
 {
   ::boost::algorithm::to_lower(str);
-  return str;
+  return Utils::trim(str);
 }
 
 MatchResult match_tokens(const std::string& matcher,
@@ -629,11 +629,11 @@ MatchResult match_tokens(const std::string& matcher,
   std::vector<std::string> matchee_tokens;
   Utils::split_string(matchee, ',', matchee_tokens, 0, true);
 
-  // Lower-case everything so we can safely compare.
+  // Lower-case everything and strip whitespace so we can safely compare.
   std::transform(matcher_tokens.begin(), matcher_tokens.end(),
-                 matcher_tokens.begin(), string_to_lowercase);
+                 matcher_tokens.begin(), string_to_lowercase_and_trim);
   std::transform(matchee_tokens.begin(), matchee_tokens.end(),
-                 matchee_tokens.begin(), string_to_lowercase);
+                 matchee_tokens.begin(), string_to_lowercase_and_trim);
 
   // Loop over both sets of tokens, to see whether a feature
   // collection (i.e. a single token) could satisfy both predicates.

--- a/src/ut/contact_filtering_test.cpp
+++ b/src/ut/contact_filtering_test.cpp
@@ -104,7 +104,13 @@ TEST_F(ContactFilteringMatchNumericTest, InvalidNumericBackwardsRange) { EXPECT_
 typedef ContactFilteringTest ContactFilteringMatchTokensTest;
 TEST_F(ContactFilteringMatchTokensTest, MatchingTokens) { EXPECT_EQ(YES, match_tokens("hello,world", "goodbye,cruel,world")); }
 TEST_F(ContactFilteringMatchTokensTest, NonMatchingTokens) { EXPECT_EQ(NO, match_tokens("hello,dave", "i,cant,let,you,do,that")); }
-TEST_F(ContactFilteringMatchTokensTest, MatchingTokensCaseInsensitive) { EXPECT_EQ(YES, match_tokens("hello,dave", "Hello,is,it,me,your,looking,for")); }
+TEST_F(ContactFilteringMatchTokensTest, MatchingTokensCaseInsensitive) { EXPECT_EQ(YES, match_tokens("hello,dave", "Hello,is,it,me,youre,looking,for")); }
+TEST_F(ContactFilteringMatchTokensTest, MatchingTokensWithWhitespace)
+{
+  EXPECT_EQ(YES, match_tokens("hello, goodbye , yes,no ,maybe", "goodbye,norma,jean"));
+  EXPECT_EQ(YES, match_tokens("hello, goodbye , yes,no ,maybe", "you,say,yes"));
+  EXPECT_EQ(YES, match_tokens("hello, goodbye , yes,no ,maybe", "I,say,no"));
+}
 
 typedef ContactFilteringTest ContactFilteringMatchFeatureTest;
 TEST_F(ContactFilteringMatchFeatureTest, MatchBoolean)

--- a/src/ut/contact_filtering_test.cpp
+++ b/src/ut/contact_filtering_test.cpp
@@ -108,8 +108,8 @@ TEST_F(ContactFilteringMatchTokensTest, MatchingTokensCaseInsensitive) { EXPECT_
 TEST_F(ContactFilteringMatchTokensTest, MatchingTokensWithWhitespace)
 {
   EXPECT_EQ(YES, match_tokens("hello, goodbye , yes,no ,maybe", "goodbye,norma,jean"));
-  EXPECT_EQ(YES, match_tokens("hello, goodbye , yes,no ,maybe", "you,say,yes"));
-  EXPECT_EQ(YES, match_tokens("hello, goodbye , yes,no ,maybe", "I,say,no"));
+  EXPECT_EQ(YES, match_tokens("hello, goodbye , yes,no ,maybe", "you,say,yes "));
+  EXPECT_EQ(YES, match_tokens("hello, goodbye , yes,no ,maybe", "I, say, no"));
 }
 
 typedef ContactFilteringTest ContactFilteringMatchFeatureTest;


### PR DESCRIPTION
What the title says. From an internal Metaswitch issue:

> When a Polycom VVX300 (and possibly other Polycom phones) registers, it signals RFC3840 feature
> support in the Contact header, by sending a Contact of the form:
> 
> Contact: <sip:5932224461@10.248.255.248:5060>;methods="INVITE, ACK, BYE, CANCEL, OPTIONS, INFO, MESSAGE, SUBSCRIBE, NOTIFY, PRACK, UPDATE, REFER"
> 
> ...
> 
> This causes trouble in an IMS network, where Clearwater fails to match some types of method to the 
> supported methods list (on the grounds that, say, " NOTIFY" with the leading space isn't the same as 
> "NOTIFY" without the space), concludes that the Polycom doesn't support this method, and doesn't send 
> the message to that contact address (and, if the Polycom is the only registered contact address, the 
> message gets rejected).
