### PR TITLE
[Reviewer: AJH] Make sure get_routing_uri returns a SIP URI

### DIFF
--- a/src/sproutletproxy.cpp
+++ b/src/sproutletproxy.cpp
@@ -484,16 +484,26 @@ bool SproutletProxy::is_uri_local(const pjsip_uri* uri)
 
 pjsip_sip_uri* SproutletProxy::get_routing_uri(const pjsip_msg* req) const
 {
+  // Start off with _root_uri and replace it with a SIP URI from the request,
+  // if there is one.
+  //
+  // TODO: We should make sure any SIP URI we get from the message is reflexive.
   const pjsip_route_hdr* route = (pjsip_route_hdr*)
-                                    pjsip_msg_find_hdr(req, PJSIP_H_ROUTE, NULL);;
-  pjsip_sip_uri* routing_uri;
+                                    pjsip_msg_find_hdr(req, PJSIP_H_ROUTE, NULL);
+  pjsip_sip_uri* routing_uri = _root_uri;
   if (route != NULL)
   {
-    routing_uri = (pjsip_sip_uri*)route->name_addr.uri;
+    if (PJSIP_URI_SCHEME_IS_SIP(route->name_addr.uri))
+    {
+      routing_uri = (pjsip_sip_uri*)route->name_addr.uri;
+    }
   }
   else
   {
-    routing_uri = (pjsip_sip_uri*)req->line.req.uri; // LCOV_EXCL_LINE
+    if (PJSIP_URI_SCHEME_IS_SIP(req->line.req.uri))
+    {
+      routing_uri = (pjsip_sip_uri*)req->line.req.uri; // LCOV_EXCL_LINE
+    }
   }
 
   return routing_uri;
@@ -1848,15 +1858,25 @@ pjsip_sip_uri* SproutletWrapper::next_hop_uri(const std::string& service,
 
 pjsip_sip_uri* SproutletWrapper::get_routing_uri(const pjsip_msg* req) const
 {
+  // Start off with _root_uri and replace it with a SIP URI from the request,
+  // if there is one.
+  //
+  // TODO: We should make sure any SIP URI we get from the message is reflexive.
   const pjsip_route_hdr* route = route_hdr();
-  pjsip_sip_uri* routing_uri;
+  pjsip_sip_uri* routing_uri = _proxy->_root_uri;
   if (route != NULL)
   {
-    routing_uri = (pjsip_sip_uri*)route->name_addr.uri;
+    if (PJSIP_URI_SCHEME_IS_SIP(route->name_addr.uri))
+    {
+      routing_uri = (pjsip_sip_uri*)route->name_addr.uri;
+    }
   }
   else
   {
-    routing_uri = (pjsip_sip_uri*)req->line.req.uri;
+    if (PJSIP_URI_SCHEME_IS_SIP(req->line.req.uri))
+    {
+      routing_uri = (pjsip_sip_uri*)req->line.req.uri;
+    }
   }
 
   return routing_uri;


### PR DESCRIPTION
Alex, this PR provides a fix for a scenario where we could crash in the Sproutlet Proxy if we receive a certain type of SIP message. The conditions required for the crash are:
 - We receive a SIP message with no route header and a Tel URI in the request line.
 - A Sproutlet is matched using a port since there is no SIP URI to match on (and Sproutlets can't be matched on Tel URIs).
 - The Sproutlet is uninterested and forwards it onto another sproutlet by calling `get_routing_uri()`.

Before this fix,  `get_routing_uri()` would return the Tel URI in the request line and cast to a SIP URI which would cause a crash. The fix is to fall back to `_root_uri` in the cases where `get_routing_uri()` would return a Tel URI. Tested in UT by writing a test that crashes/passes before/after my fix and running the scenario that caused the original crash on a live system and verifying that there is no longer a crash.

As discussed, we should also be checking that the URI we return is reflexive. I've added a TODO for that, which I'll address next week.