### PR TITLE
[Reviewer: AJH] Options polling to Sprout with URI parameter "user=phone" included

### DIFF
--- a/src/uri_classifier.cpp
+++ b/src/uri_classifier.cpp
@@ -160,17 +160,6 @@ URIClass URIClassifier::classify_uri(const pjsip_uri* uri, bool prefer_sip, bool
           ret = enforce_global ? LOCAL_PHONE_NUMBER : GLOBAL_PHONE_NUMBER;
           classified = true;
         }
-        else
-        {
-          classified = false;
-          ret = (local_to_node) ? NODE_LOCAL_SIP_URI : HOME_DOMAIN_SIP_URI;
-        }
-      }
-      else
-      {
-        classified = false;
-        ret = (local_to_node) ? NODE_LOCAL_SIP_URI : HOME_DOMAIN_SIP_URI;
-      }
     }
     if (!classified)
     {

--- a/src/uri_classifier.cpp
+++ b/src/uri_classifier.cpp
@@ -160,6 +160,7 @@ URIClass URIClassifier::classify_uri(const pjsip_uri* uri, bool prefer_sip, bool
           ret = enforce_global ? LOCAL_PHONE_NUMBER : GLOBAL_PHONE_NUMBER;
           classified = true;
         }
+      }
     }
     if (!classified)
     {

--- a/src/uri_classifier.cpp
+++ b/src/uri_classifier.cpp
@@ -159,12 +159,12 @@ URIClass URIClassifier::classify_uri(const pjsip_uri* uri, bool prefer_sip, bool
         }
         else
         {
-          ret = HOME_DOMAIN_SIP_URI;
+          ret = (local_to_node) ? NODE_LOCAL_SIP_URI : HOME_DOMAIN_SIP_URI;
         }
       }
       else
       {
-        ret = HOME_DOMAIN_SIP_URI;
+        ret = (local_to_node) ? NODE_LOCAL_SIP_URI : HOME_DOMAIN_SIP_URI;
       }
     }
     // Not a phone number - classify it based on domain

--- a/src/uri_classifier.cpp
+++ b/src/uri_classifier.cpp
@@ -138,6 +138,7 @@ URIClass URIClassifier::classify_uri(const pjsip_uri* uri, bool prefer_sip, bool
               prefer_sip ? "true" : "false",
               treat_number_as_phone ? "true" : "false");
 
+    bool classified = false;
     // SIP URI that's 'really' a phone number - apply the same logic as for TEL URIs
     if ((!pj_strcmp(&((pjsip_sip_uri*)uri)->user_param, &STR_USER_PHONE) ||
          (home_domain && treat_number_as_phone && !is_gruu)))
@@ -152,33 +153,29 @@ URIClass URIClassifier::classify_uri(const pjsip_uri* uri, bool prefer_sip, bool
         if (boost::regex_match(user_tokens[0], results, CHARS_ALLOWED_IN_GLOBAL_NUM))
         {
           ret = GLOBAL_PHONE_NUMBER;
+          classified = true;
         }
         else if (boost::regex_match(user_tokens[0], results, CHARS_ALLOWED_IN_LOCAL_NUM))
         {
           ret = enforce_global ? LOCAL_PHONE_NUMBER : GLOBAL_PHONE_NUMBER;
+          classified = true;
         }
         else
         {
+          classified = false;
           ret = (local_to_node) ? NODE_LOCAL_SIP_URI : HOME_DOMAIN_SIP_URI;
         }
       }
       else
       {
+        classified = false;
         ret = (local_to_node) ? NODE_LOCAL_SIP_URI : HOME_DOMAIN_SIP_URI;
       }
     }
-    // Not a phone number - classify it based on domain
-    else if (home_domain)
+    if (!classified)
     {
-      ret = HOME_DOMAIN_SIP_URI;
-    }
-    else if (local_to_node)
-    {
-      ret = NODE_LOCAL_SIP_URI;
-    }
-    else
-    {
-      ret = OFFNET_SIP_URI;
+      // Not a phone number - classify it based on domain
+      ret = (home_domain) ? HOME_DOMAIN_SIP_URI : ((local_to_node) ? NODE_LOCAL_SIP_URI : OFFNET_SIP_URI);
     }
   }
 

--- a/src/ut/common_sip_processing_test.cpp
+++ b/src/ut/common_sip_processing_test.cpp
@@ -233,17 +233,8 @@ TEST_F(CommonProcessingTest, OptionsPollPingICSCF)
 
   /// Case 2.
   // Inject an OPTIONS poll request.
-  Message msg2;
-  msg2._first_hop = true;
-  msg2._method = "OPTIONS";
-  msg2._requri = std::string("sip:poll-sip@127.0.0.1:") + std::to_string(ICSCF_PORT) + std::string(";user=phone");
-  msg2._via = "127.0.0.1";
-  msg2._todomain = std::string("127.0.0.1:") + std::to_string(ICSCF_PORT);
-  msg2._to = "poll-sip";
-  msg2._fromdomain = "127.0.0.1";
-  msg2._from = msg2._to;
-  msg2._contentlength = false;
-  msg2._extra = "Contact: <sip:127.0.0.1>\nAccept: application/sdp\nContent-Length: 0";
+  Message msg2 = msg1;
+  msg2._requri += std::string(";user=phone");
   inject_msg(msg2.get_request(), _tp);
 
   // Expect a 200 OK response.
@@ -256,17 +247,10 @@ TEST_F(CommonProcessingTest, OptionsPollPingICSCF)
 
   /// Case 3.
   // Inject an OPTIONS poll request.
-  Message msg3;
-  msg3._first_hop = true;
-  msg3._method = "OPTIONS";
+  Message msg3 = msg1;
   msg3._requri = std::string("sip:127.0.0.1:") + std::to_string(ICSCF_PORT) + std::string(";user=phone");
-  msg3._via = "127.0.0.1";
-  msg3._todomain = std::string("127.0.0.1:") + std::to_string(ICSCF_PORT);
   msg3._to = "";
-  msg3._fromdomain = "127.0.0.1";
   msg3._from = msg3._to;
-  msg3._contentlength = false;
-  msg3._extra = "Contact: <sip:127.0.0.1>\nAccept: application/sdp\nContent-Length: 0";
   inject_msg(msg3.get_request(), _tp);
 
   // Expect a 200 OK response.

--- a/src/ut/common_sip_processing_test.cpp
+++ b/src/ut/common_sip_processing_test.cpp
@@ -181,6 +181,102 @@ static pjsip_module mod_reject =
 
 using TestingCommon::Message;
 
+TEST_F(CommonProcessingTest, OptionsPollPingICSCF)
+{
+  /// Test OPTIONS request to a local node address (ICSCF) in the following 3 cases:
+  /// Case 1. Standard OPTIONS ping
+  /// Case 2. "user=phone" URI parameter is incorrectly added to the request URI and
+  ///         the URI contains the user part.
+  ///         The parameter should be ignored and a 200 OK response received.
+  /// Case 3. "user=phone" URI parameter is incorrectly added to the request URI and
+  ///         the URI does not contain the user part.
+  ///         The parameter should be ignored and a 200 OK response received.
+
+  pjsip_tx_data* tdata;
+
+  //Create a TCP connection to the I-CSCF listening port.  
+  _tp = new TransportFlow(TransportFlow::Protocol::TCP,
+                                        ICSCF_PORT,
+                                        "127.0.0.1",
+                                        49152);
+
+  // Set up a new Load monitor with enough tokens for each test.
+  delete(_lm);
+  _lm = new LoadMonitor(0, 3, 0, 0, 0);
+  init_common_sip_processing(_requests_counter, _health_checker);
+
+  pjsip_endpt_register_module(stack_data.endpt, &mod_ok);
+
+  /// Case 1.
+  // Inject an OPTIONS poll request.
+  Message msg1;
+  msg1._first_hop = true;
+  msg1._method = "OPTIONS";
+  msg1._requri = std::string("sip:poll-sip@127.0.0.1:") + std::to_string(ICSCF_PORT);
+  msg1._via = "127.0.0.1";
+  msg1._todomain = std::string("127.0.0.1:") + std::to_string(ICSCF_PORT);
+  msg1._to = "poll-sip";
+  msg1._fromdomain = "127.0.0.1";
+  msg1._from = msg1._to;
+  msg1._contentlength = false;
+  msg1._extra = "Contact: <sip:127.0.0.1>\nAccept: application/sdp\nContent-Length: 0";
+  inject_msg(msg1.get_request(), _tp);
+
+  // Expect a 200 OK response.
+  ASSERT_EQ(1, txdata_count());
+  tdata = current_txdata();
+  RespMatcher r1(200);
+  r1.matches(tdata->msg);
+
+  free_txdata();
+
+  /// Case 2.
+  // Inject an OPTIONS poll request.
+  Message msg2;
+  msg2._first_hop = true;
+  msg2._method = "OPTIONS";
+  msg2._requri = std::string("sip:poll-sip@127.0.0.1:") + std::to_string(ICSCF_PORT) + std::string(";user=phone");
+  msg2._via = "127.0.0.1";
+  msg2._todomain = std::string("127.0.0.1:") + std::to_string(ICSCF_PORT);
+  msg2._to = "poll-sip";
+  msg2._fromdomain = "127.0.0.1";
+  msg2._from = msg2._to;
+  msg2._contentlength = false;
+  msg2._extra = "Contact: <sip:127.0.0.1>\nAccept: application/sdp\nContent-Length: 0";
+  inject_msg(msg2.get_request(), _tp);
+
+  // Expect a 200 OK response.
+  ASSERT_EQ(1, txdata_count());
+  tdata = current_txdata();
+  RespMatcher r2(200);
+  r2.matches(tdata->msg);
+
+  free_txdata();
+
+  /// Case 3.
+  // Inject an OPTIONS poll request.
+  Message msg3;
+  msg3._first_hop = true;
+  msg3._method = "OPTIONS";
+  msg3._requri = std::string("sip:127.0.0.1:") + std::to_string(ICSCF_PORT) + std::string(";user=phone");
+  msg3._via = "127.0.0.1";
+  msg3._todomain = std::string("127.0.0.1:") + std::to_string(ICSCF_PORT);
+  msg3._to = "";
+  msg3._fromdomain = "127.0.0.1";
+  msg3._from = msg3._to;
+  msg3._contentlength = false;
+  msg3._extra = "Contact: <sip:127.0.0.1>\nAccept: application/sdp\nContent-Length: 0";
+  inject_msg(msg3.get_request(), _tp);
+
+  // Expect a 200 OK response.
+  ASSERT_EQ(1, txdata_count());
+  tdata = current_txdata();
+  RespMatcher r3(200);
+  r3.matches(tdata->msg);
+
+  free_txdata();
+}
+
 TEST_F(CommonProcessingTest, RequestAllowed)
 {
   // Tests that, when there is a token in the load monitor's bucket, a

--- a/src/ut/common_sip_processing_test.cpp
+++ b/src/ut/common_sip_processing_test.cpp
@@ -195,6 +195,7 @@ TEST_F(CommonProcessingTest, OptionsPollPingICSCF)
   pjsip_tx_data* tdata;
 
   //Create a TCP connection to the I-CSCF listening port.  
+  delete(_tp);
   _tp = new TransportFlow(TransportFlow::Protocol::TCP,
                                         ICSCF_PORT,
                                         "127.0.0.1",
@@ -275,6 +276,8 @@ TEST_F(CommonProcessingTest, OptionsPollPingICSCF)
   r3.matches(tdata->msg);
 
   free_txdata();
+
+  pjsip_endpt_unregister_module(stack_data.endpt, &mod_ok);
 }
 
 TEST_F(CommonProcessingTest, RequestAllowed)

--- a/src/ut/testingcommon.cpp
+++ b/src/ut/testingcommon.cpp
@@ -296,9 +296,13 @@ std::string Message::get_request()
 
   // The remote target.
   std::string target = std::string(_toscheme).append(":").append(_to);
+  if (!_to.empty())
+  {
+    target.append("@");
+  }
   if (!_todomain.empty())
   {
-    target.append("@").append(_todomain);
+    target.append(_todomain);
   }
 
   // Set the request uri and the route variables.
@@ -327,7 +331,7 @@ std::string Message::get_request()
                    "%1$s %9$s SIP/2.0\r\n"
                    "Via: SIP/2.0/TCP %13$s;rport;branch=z9hG4bK%16$s\r\n"
                    "%12$s"
-                   "From: <sip:%2$s@%3$s>;tag=10.114.61.213+1+8c8b232a+5fb751cf\r\n"
+                   "From: <sip:%2$s%17$s%3$s>;tag=10.114.61.213+1+8c8b232a+5fb751cf\r\n"
                    "%10$s\r\n"
                    "Max-Forwards: %8$d\r\n"
                    "Call-ID: %11$s\r\n"
@@ -355,7 +359,8 @@ std::string Message::get_request()
                    /* 13 */ _via.c_str(),
                    /* 14 */ route.c_str(),
                    /* 15 */ _cseq,
-                   /* 16 */ branch.c_str()
+                   /* 16 */ branch.c_str(),
+                   /* 17 */ _from.empty() ? "" : "@"
                      );
 
   EXPECT_LT(n, (int)sizeof(buf));

--- a/src/ut/testingcommon.cpp
+++ b/src/ut/testingcommon.cpp
@@ -296,12 +296,12 @@ std::string Message::get_request()
 
   // The remote target.
   std::string target = std::string(_toscheme).append(":").append(_to);
-  if (!_to.empty())
-  {
-    target.append("@");
-  }
   if (!_todomain.empty())
   {
+    if (!_to.empty())
+    {
+      target.append("@");
+    }
     target.append(_todomain);
   }
 


### PR DESCRIPTION
Hi Alex, would you mind reviewing this fix?

This is a simple fix to URI classifier. Sprout classified local node URIs, such as those used for Options polls, incorrectly when the "user=phone" URI parameter was spuriously specified. 
I have also had to modify the UT framework a bit by allowing to send requests containing no user part in the SIP URI (so that the '@' sign is not included).

I have written a new UT to test my changes and all UTs passed, as well as run a live test on our L3 test system (running v11.0.2).