### PR TITLE
[Reviewer: Seb] Update rogers dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -24,7 +24,7 @@ Description: Debugging symbols for sprout-libs
 
 Package: sprout-node
 Architecture: any
-Depends: sprout (= ${binary:Version}), clearwater-memcached, chronos, astaire
+Depends: sprout (= ${binary:Version}), clearwater-memcached, chronos, astaire, rogers
 Description: sprout-node, the SIP Router node
 
 Package: sprout-node-dbg
@@ -32,7 +32,7 @@ Architecture: any
 Section: debug
 Priority: extra
 Depends: sprout-node (= ${binary:Version})
-Recommends: sprout-dbg, chronos-dbg
+Recommends: sprout-dbg, chronos-dbg, memcached-dbg, astaire-dbg, rogers-dbg
 Description: Debugging symbols for sprout-node, the SIP Router node
 
 Package: sprout


### PR DESCRIPTION
The AIO node doesn't currently install rogers - as it installs `ellis-node bono-node restund sprout-node homer-node homestead-node clearwater-prov-tools` (as per https://github.com/Metaswitch/clearwater-infrastructure/blob/master/scripts/clearwater-aio-install.sh#L48 ).

This updates sprout-node to reference `rogers`, which it should anyway, which fixes that.