### PR TITLE
[Reviewer: CJR] Make Sprout SAS Compression Configurable

### DIFF
--- a/include/cfgoptions.h
+++ b/include/cfgoptions.h
@@ -134,6 +134,7 @@ struct options
   bool                                 nonce_count_supported;
   std::string                          scscf_node_uri;
   bool                                 sas_signaling_if;
+  bool                                 sas_compress_logs;
   bool                                 disable_tcp_switch;
   std::string                          chronos_hostname;
   std::string                          sprout_chronos_callback_uri;

--- a/include/stack.h
+++ b/include/stack.h
@@ -69,6 +69,8 @@ struct stack_data_struct
   bool record_route_on_completion_of_terminating;
   bool record_route_on_diversion;
 
+  bool sas_compress_logs;
+
   int default_session_expires;
   int max_session_expires;
   int sip_tcp_connect_timeout;
@@ -138,6 +140,7 @@ extern pj_status_t init_stack(const std::string& sas_system_name,
                               int pcscf_untrusted_port,
                               int scscf_port,
                               bool sas_signaling_if,
+                              bool sas_compress_logs,
                               std::set<int> sproutlet_ports,
                               const std::string& local_host,
                               const std::string& public_host,

--- a/sprout-base.root/etc/init.d/sprout
+++ b/sprout-base.root/etc/init.d/sprout
@@ -318,6 +318,7 @@ get_daemon_args()
         [ "$ralf_threads" = "" ]                  || DAEMON_ARGS="$DAEMON_ARGS --ralf-threads=$ralf_threads"
         [ "$non_register_authentication" = "" ]   || DAEMON_ARGS="$DAEMON_ARGS --non-register-authentication=$non_register_authentication"
         [ "$nonce_count_supported" != "Y" ]       || DAEMON_ARGS="$DAEMON_ARGS --nonce-count-supported"
+        [ "$sas_compress_logs" != "N"]            || DAEMON_ARGS="$DAEMON_ARGS --disable-sas-compress-logs"
         [ "$listen_port" = "" ]                   || DAEMON_ARGS="$DAEMON_ARGS --listen-port=$listen_port"
         [ "$blacklisted_scscf_uris" = "" ]        || DAEMON_ARGS="$DAEMON_ARGS --blacklisted-scscfs=$blacklisted_scscf_uris"
 

--- a/src/common_sip_processing.cpp
+++ b/src/common_sip_processing.cpp
@@ -260,7 +260,11 @@ static void sas_log_rx_msg(pjsip_rx_data* rdata)
   event.add_static_param(pjsip_transport_get_type_from_flag(rdata->tp_info.transport->flag));
   event.add_static_param(rdata->pkt_info.src_port);
   event.add_var_param(rdata->pkt_info.src_name);
-  event.add_compressed_param(rdata->msg_info.len, rdata->msg_info.msg_buf, &SASEvent::PROFILE_SIP);
+  Utils::add_sas_param_compressed_if_toggled(event,
+                                             rdata->msg_info.len,
+                                             rdata->msg_info.msg_buf,
+                                             &SASEvent::PROFILE_SIP,
+                                             stack_data.sas_compress_logs);
   SAS::report_event(event);
 }
 
@@ -290,9 +294,11 @@ static void sas_log_tx_msg(pjsip_tx_data *tdata)
     event.add_static_param(pjsip_transport_get_type_from_flag(tdata->tp_info.transport->flag));
     event.add_static_param(tdata->tp_info.dst_port);
     event.add_var_param(tdata->tp_info.dst_name);
-    event.add_compressed_param((int)(tdata->buf.cur - tdata->buf.start),
-                               tdata->buf.start,
-                               &SASEvent::PROFILE_SIP);
+    Utils::add_sas_param_compressed_if_toggled(event,
+                                               (int)(tdata->buf.cur - tdata->buf.start),
+                                               tdata->buf.start,
+                                               &SASEvent::PROFILE_SIP,
+                                               stack_data.sas_compress_logs);
     SAS::report_event(event);
   }
   else

--- a/src/ifc.cpp
+++ b/src/ifc.cpp
@@ -67,8 +67,8 @@ void Ifc::handle_invalid_ifc(std::string error,
                              int instance_id,
                              SAS::TrailId trail)
 {
-  TRC_ERROR("Skip processing invalid iFC for %s: %s", 
-            server_name.c_str(), 
+  TRC_ERROR("Skip processing invalid iFC for %s: %s",
+            server_name.c_str(),
             error.c_str());
   SAS::Event event(trail, sas_event_id, instance_id);
   event.add_var_param(server_name);
@@ -83,8 +83,8 @@ void Ifc::handle_unusual_ifc(std::string error,
                              int instance_id,
                              SAS::TrailId trail)
 {
-  TRC_INFO("Continue processing unusual iFC for %s: %s", 
-           server_name.c_str(), 
+  TRC_INFO("Continue processing unusual iFC for %s: %s",
+           server_name.c_str(),
            error.c_str());
   SAS::Event event(trail, sas_event_id, instance_id);
   event.add_var_param(server_name);
@@ -331,7 +331,7 @@ bool Ifc::spt_matches(const SessionCase& session_case,  //< The session case
                          "the hostport of a SIP URI or a telephone number.",
                          server_name, SASEvent::IFC_UNUSUAL, 0, trail);
     }
-    
+
     req_uri_regex = boost::regex(req_uri,
                                  boost::regex_constants::no_except);
     if (req_uri_regex.status())
@@ -444,7 +444,10 @@ bool Ifc::filter_matches(const SessionCase& session_case,
   rapidxml::print(std::back_inserter(ifc_str), *_ifc, 0);
 
   SAS::Event event(trail, SASEvent::IFC_TESTING, 0);
-  event.add_compressed_param(ifc_str, &SASEvent::PROFILE_SERVICE_PROFILE);
+  Utils::add_sas_param_compressed_if_toggled(event,
+                                             ifc_str,
+                                             &SASEvent::PROFILE_SERVICE_PROFILE,
+                                             stack_data.sas_compress_logs);
   SAS::report_event(event);
   std::string server_name;
 
@@ -453,14 +456,14 @@ bool Ifc::filter_matches(const SessionCase& session_case,
     xml_node<>* as = _ifc->first_node(RegDataXMLUtils::APPLICATION_SERVER);
     if (as == NULL)
     {
-      handle_invalid_ifc("iFC missing ApplicationServer element", server_name, 
+      handle_invalid_ifc("iFC missing ApplicationServer element", server_name,
                          SASEvent::INVALID_IFC_IGNORED, 0, trail);
     }
 
     server_name = XMLUtils::get_first_node_value(as, RegDataXMLUtils::SERVER_NAME);
     if (server_name.empty())
     {
-      handle_invalid_ifc("iFC has no ServerName", server_name, 
+      handle_invalid_ifc("iFC has no ServerName", server_name,
                          SASEvent::INVALID_IFC_IGNORED, 0, trail);
     }
 
@@ -547,7 +550,7 @@ bool Ifc::filter_matches(const SessionCase& session_case,
         }
         else
         {
-          groups[group_id] = cnf ? (groups[group_id] || spt_matched) : 
+          groups[group_id] = cnf ? (groups[group_id] || spt_matched) :
             (groups[group_id] && spt_matched);
         }
 
@@ -592,8 +595,8 @@ bool Ifc::filter_matches(const SessionCase& session_case,
   catch (xml_error err)
   {
     // Generic SAS event to log skipping iFC due to syntactic error in parsing
-    // XML, most likely thrown by utility libraries. 
-    std::string err_str = "iFC XML is syntactically invalid: " 
+    // XML, most likely thrown by utility libraries.
+    std::string err_str = "iFC XML is syntactically invalid: "
       + std::string(err.what());
     TRC_ERROR(err_str.c_str());
     SAS::Event event(trail, SASEvent::INVALID_XML_IGNORED, 0);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -133,6 +133,7 @@ enum OptionTypes
   OPT_IMPI_STORES,
   OPT_SCSCF_NODE_URI,
   OPT_SAS_USE_SIGNALING_IF,
+  OPT_SAS_COMPRESS_LOGS,
   OPT_DISABLE_TCP_SWITCH,
   OPT_DEFAULT_TEL_URI_TRANSLATION,
   OPT_CHRONOS_HOSTNAME,
@@ -227,6 +228,7 @@ const static struct pj_getopt_option long_opt[] =
   { "nonce-count-supported",        no_argument,       0, OPT_NONCE_COUNT_SUPPORTED},
   { "scscf-node-uri",               required_argument, 0, OPT_SCSCF_NODE_URI},
   { "sas-use-signaling-interface",  no_argument,       0, OPT_SAS_USE_SIGNALING_IF},
+  { "disable-sas-compress-logs",    no_argument,       0, OPT_SAS_COMPRESS_LOGS},
   { "disable-tcp-switch",           no_argument,       0, OPT_DISABLE_TCP_SWITCH},
   { "chronos-hostname",             required_argument, 0, OPT_CHRONOS_HOSTNAME},
   { "sprout-chronos-callback-uri",  required_argument, 0, OPT_SPROUT_CHRONOS_CALLBACK_URI},
@@ -441,6 +443,8 @@ static void usage(void)
        "     --sas-use-signaling-interface\n"
        "                            Whether SAS traffic is to be dispatched over the signaling network\n"
        "                            interface rather than the default management interface\n"
+       "     --disable-sas-compress-logs\n"
+       "                            Whether sprout disables compression of any SAS logs.\n"
        "     --disable-tcp-switch\n"
        "                            Whether to disable TCP-to-UDP uplift when messages are greater than.\n"
        "                            1300 bytes.\n"
@@ -1213,6 +1217,11 @@ static pj_status_t init_options(int argc, char* argv[], struct options* options)
       TRC_INFO("SAS connections created in the signaling namespace");
       break;
 
+    case OPT_SAS_COMPRESS_LOGS  :
+      options->sas_compress_logs = false;
+      TRC_INFO("Compression of SAS logs is disabled");
+      break;
+
     case OPT_DISABLE_TCP_SWITCH:
       options->disable_tcp_switch = true;
       TRC_INFO("Switching to TCP is disabled");
@@ -1761,6 +1770,7 @@ int main(int argc, char* argv[])
   opt.nonce_count_supported = false;
   opt.scscf_node_uri = "";
   opt.sas_signaling_if = false;
+  opt.sas_compress_logs = true;
   opt.disable_tcp_switch = false;
   opt.apply_fallback_ifcs = false;
   opt.reject_if_no_matching_ifcs = false;
@@ -2083,6 +2093,7 @@ int main(int argc, char* argv[])
                       opt.pcscf_untrusted_port,
                       opt.port_scscf,
                       opt.sas_signaling_if,
+                      opt.sas_compress_logs,
                       opt.sproutlet_ports,
                       opt.local_host,
                       opt.public_host,
@@ -2663,4 +2674,3 @@ int main(int argc, char* argv[])
 
   return 0;
 }
-

--- a/src/stack.cpp
+++ b/src/stack.cpp
@@ -608,6 +608,7 @@ pj_status_t init_stack(const std::string& system_name,
                        int pcscf_untrusted_port,
                        int scscf_port,
                        bool sas_signaling_if,
+                       bool sas_compress_logs,
                        std::set<int> sproutlet_ports,
                        const std::string& local_host,
                        const std::string& public_host,
@@ -752,6 +753,8 @@ pj_status_t init_stack(const std::string& system_name,
             sas_write,
             sas_signaling_if ? create_connection_in_signaling_namespace
                              : create_connection_in_management_namespace);
+
+  stack_data.sas_compress_logs = sas_compress_logs;
 
   // Initialise PJSIP and all the associated resources.
   status = init_pjsip();


### PR DESCRIPTION
- Sprout reads in --disable-sas-compres-logs from shared_config and stores it off in stack__data as a boolean.
- Functions adding compressed SAS data can the access this boolean and pass it to the CPP-Common Utils function. 