### PR TITLE
[Reviewer: AJH] Check URI is reflexive when getting routing URI

### DIFF
--- a/include/sproutlet.h
+++ b/include/sproutlet.h
@@ -371,8 +371,7 @@ public:
   virtual SAS::TrailId trail() const = 0;
 
   /// Get the URI that caused us to be routed to this Sproutlet or if no such
-  /// URI exists e.g. if the Sproutlet was matched on a port, return the root
-  /// URI.
+  /// URI exists e.g. if the Sproutlet was matched on a port, return NULL.
   ///
   /// @returns            - The URI that routed to this Sproutlet.
   ///
@@ -726,8 +725,7 @@ protected:
     {return _helper->trail();}
 
   /// Get the URI that caused us to be routed to this Sproutlet or if no such
-  /// URI exists e.g. if the Sproutlet was matched on a port, return the root
-  /// URI.
+  /// URI exists e.g. if the Sproutlet was matched on a port, return NULL.
   ///
   /// @returns            - The URI that routed to this Sproutlet.
   ///
@@ -785,8 +783,7 @@ public:
   virtual ~SproutletHelper() {}
 
   /// Get the URI that caused us to be routed to this Sproutlet or if no such
-  /// URI exists e.g. if the Sproutlet was matched on a port, return the root
-  /// URI.
+  /// URI exists e.g. if the Sproutlet was matched on a port, return NULL.
   virtual pjsip_sip_uri* get_routing_uri(const pjsip_msg* req,
                                          const Sproutlet* sproutlet) const = 0;
 

--- a/include/sproutlet.h
+++ b/include/sproutlet.h
@@ -370,7 +370,9 @@ public:
   ///
   virtual SAS::TrailId trail() const = 0;
 
-  /// Get the URI that caused us to be routed to this Sproutlet.
+  /// Get the URI that caused us to be routed to this Sproutlet or if no such
+  /// URI exists e.g. if the Sproutlet was matched on a port, return the root
+  /// URI.
   ///
   /// @returns            - The URI that routed to this Sproutlet.
   ///
@@ -723,7 +725,9 @@ protected:
   SAS::TrailId trail() const
     {return _helper->trail();}
 
-  /// Get the URI that caused us to be routed to this Sproutlet.
+  /// Get the URI that caused us to be routed to this Sproutlet or if no such
+  /// URI exists e.g. if the Sproutlet was matched on a port, return the root
+  /// URI.
   ///
   /// @returns            - The URI that routed to this Sproutlet.
   ///
@@ -780,8 +784,11 @@ public:
   /// Virtual descrustor.
   virtual ~SproutletHelper() {}
 
-  /// Gets the URI that caused this request to be routed to this Sproutlet.
-  virtual pjsip_sip_uri* get_routing_uri(const pjsip_msg* req) const = 0;
+  /// Get the URI that caused us to be routed to this Sproutlet or if no such
+  /// URI exists e.g. if the Sproutlet was matched on a port, return the root
+  /// URI.
+  virtual pjsip_sip_uri* get_routing_uri(const pjsip_msg* req,
+                                         const Sproutlet* sproutlet) const = 0;
 
   /// Constructs the next URI for the Sproutlet that doesn't want to handle a
   /// request.
@@ -795,8 +802,7 @@ public:
   ///
   /// If the URI is not a SIP URI, this function returns FALSE.
   virtual bool is_uri_reflexive(const pjsip_uri* uri,
-                                Sproutlet* sproutlet,
-                                SAS::TrailId trail) = 0;
+                                const Sproutlet* sproutlet) const = 0;
 };
 
 #endif

--- a/include/sproutletproxy.h
+++ b/include/sproutletproxy.h
@@ -110,12 +110,12 @@ protected:
   Sproutlet* service_from_params(pjsip_sip_uri* uri);
 
   bool is_uri_local(const pjsip_uri* uri);
-  pjsip_sip_uri* get_routing_uri(const pjsip_msg* req) const;
+  pjsip_sip_uri* get_routing_uri(const pjsip_msg* req,
+                                 const Sproutlet* sproutlet) const;
   std::string get_local_hostname(const pjsip_sip_uri* uri) const;
   bool is_host_local(const pj_str_t* host) const;
   bool is_uri_reflexive(const pjsip_uri* uri,
-                        Sproutlet* sproutlet,
-                        SAS::TrailId trail);
+                        const Sproutlet* sproutlet) const;
 
   // A struct to wrap tx_data and allowed_host_state in a convenient bundle
   // to pass over interfaces when sending a request.

--- a/src/authenticationsproutlet.cpp
+++ b/src/authenticationsproutlet.cpp
@@ -928,10 +928,14 @@ void AuthenticationSproutletTsx::on_rx_initial_request(pjsip_msg* req)
   // URI as a starting point.
   pjsip_sip_uri* scscf_uri = (pjsip_sip_uri*)pjsip_uri_clone(get_pool(req), stack_data.scscf_uri);
   pjsip_sip_uri* routing_uri = get_routing_uri(req);
-  SCSCFUtils::get_scscf_uri(get_pool(req),
-                            get_local_hostname(routing_uri),
-                            get_local_hostname(scscf_uri),
-                            scscf_uri);
+  if (routing_uri != NULL)
+  {
+    SCSCFUtils::get_scscf_uri(get_pool(req),
+                              get_local_hostname(routing_uri),
+                              get_local_hostname(scscf_uri),
+                              scscf_uri);
+  }
+
   _scscf_uri = PJUtils::uri_to_string(PJSIP_URI_IN_ROUTING_HDR, (pjsip_uri*)scscf_uri);
 
   pjsip_digest_credential* credentials = get_credentials(req);

--- a/src/authenticationsproutlet.cpp
+++ b/src/authenticationsproutlet.cpp
@@ -118,7 +118,7 @@ SproutletTsx* AuthenticationSproutlet::get_tsx(SproutletHelper* helper,
   }
 
   // We're not interested in the message so create a next hop URI.
-  pjsip_sip_uri* base_uri = helper->get_routing_uri(req);
+  pjsip_sip_uri* base_uri = helper->get_routing_uri(req, this);
   next_hop = helper->next_hop_uri(_next_hop_service,
                                   base_uri,
                                   pool);

--- a/src/compositesproutlet.cpp
+++ b/src/compositesproutlet.cpp
@@ -31,15 +31,6 @@ int CompositeSproutletTsx::send_request(pjsip_msg*& req,
     // This is a standalone or dialog-creating request, and we have a next hop
     // configured - use it.
     pjsip_sip_uri* base_uri = get_routing_uri(req);
-
-    if (!is_uri_reflexive((pjsip_uri*)base_uri))
-    {
-      // The URI we've been passed isn't reflexive i.e. will not route back to
-      // the SPN. However we have a service as the next hop meaning it should
-      // come back to the SPN.  Passing in null will use the node's root URI.
-      base_uri = nullptr;
-    }
-
     pjsip_sip_uri* uri = next_hop_uri(_next_hop_service,
                                       base_uri,
                                       get_pool(req));

--- a/src/registrarsproutlet.cpp
+++ b/src/registrarsproutlet.cpp
@@ -144,7 +144,7 @@ SproutletTsx* RegistrarSproutlet::get_tsx(SproutletHelper* helper,
   }
 
   // We're not interested in the message so create a next hop URI.
-  pjsip_sip_uri* base_uri = helper->get_routing_uri(req);
+  pjsip_sip_uri* base_uri = helper->get_routing_uri(req, this);
   next_hop = helper->next_hop_uri(_next_hop_service,
                                   base_uri,
                                   pool);

--- a/src/registrarsproutlet.cpp
+++ b/src/registrarsproutlet.cpp
@@ -319,10 +319,14 @@ void RegistrarSproutletTsx::process_register_request(pjsip_msg *req)
   // URI as a starting point.
   pjsip_sip_uri* scscf_uri = (pjsip_sip_uri*)pjsip_uri_clone(get_pool(req), stack_data.scscf_uri);
   pjsip_sip_uri* routing_uri = get_routing_uri(req);
-  SCSCFUtils::get_scscf_uri(get_pool(req),
-                            get_local_hostname(routing_uri),
-                            get_local_hostname(scscf_uri),
-                            scscf_uri);
+  if (routing_uri != NULL)
+  {
+    SCSCFUtils::get_scscf_uri(get_pool(req),
+                              get_local_hostname(routing_uri),
+                              get_local_hostname(scscf_uri),
+                              scscf_uri);
+  }
+
   _scscf_uri = PJUtils::uri_to_string(PJSIP_URI_IN_ROUTING_HDR, (pjsip_uri*)scscf_uri);
 
   HSSConnection::irs_query irs_query;
@@ -760,10 +764,14 @@ void RegistrarSproutletTsx::process_register_request(pjsip_msg *req)
   // Replace the local hostname part of the Service route URI with the local
   // hostname part of the URI that routed to this sproutlet.
   pjsip_sip_uri* sr_uri = (pjsip_sip_uri*)sr_hdr->name_addr.uri;
-  SCSCFUtils::get_scscf_uri(get_pool(rsp),
-                            get_local_hostname(routing_uri),
-                            get_local_hostname(sr_uri),
-                            sr_uri);
+  if (routing_uri != NULL)
+  {
+    SCSCFUtils::get_scscf_uri(get_pool(rsp),
+                              get_local_hostname(routing_uri),
+                              get_local_hostname(sr_uri),
+                              sr_uri);
+  }
+
   pjsip_msg_insert_first_hdr(rsp, (pjsip_hdr*)sr_hdr);
 
   // Log any URIs that have been left out of the P-Associated-URI because they

--- a/src/scscfsproutlet.cpp
+++ b/src/scscfsproutlet.cpp
@@ -1233,10 +1233,14 @@ pjsip_status_code SCSCFSproutletTsx::determine_served_user(pjsip_msg* req)
       // transaction, using the configured S-CSCF URI as a starting point.
       pjsip_sip_uri* scscf_uri = (pjsip_sip_uri*)pjsip_uri_clone(get_pool(req), _scscf->_scscf_cluster_uri);
       pjsip_sip_uri* routing_uri = get_routing_uri(req);
-      SCSCFUtils::get_scscf_uri(get_pool(req),
-                                get_local_hostname(routing_uri),
-                                get_local_hostname(scscf_uri),
-                                scscf_uri);
+      if (routing_uri != NULL)
+      {
+        SCSCFUtils::get_scscf_uri(get_pool(req),
+                                  get_local_hostname(routing_uri),
+                                  get_local_hostname(scscf_uri),
+                                  scscf_uri);
+      }
+
       _scscf_uri = PJUtils::uri_to_string(PJSIP_URI_IN_ROUTING_HDR, (pjsip_uri*)scscf_uri);
 
       TRC_DEBUG("Looking up iFCs for %s for new AS chain", served_user.c_str());

--- a/src/sproutletproxy.cpp
+++ b/src/sproutletproxy.cpp
@@ -485,11 +485,11 @@ bool SproutletProxy::is_uri_local(const pjsip_uri* uri)
 pjsip_sip_uri* SproutletProxy::get_routing_uri(const pjsip_msg* req,
                                                const Sproutlet* sproutlet) const
 {
-  // Start off with _root_uri and replace it with a SIP URI from the request,
-  // if there is one that matches this Sproutlet.
+  // Get the URI that caused us to be routed to this Sproutlet or if no such
+  // URI exists e.g. if the Sproutlet was matched on a port, return NULL.
   const pjsip_route_hdr* route = (pjsip_route_hdr*)
                                     pjsip_msg_find_hdr(req, PJSIP_H_ROUTE, NULL);
-  pjsip_sip_uri* routing_uri = _root_uri;
+  pjsip_sip_uri* routing_uri = NULL;
   if (route != NULL)
   {
     if ((PJSIP_URI_SCHEME_IS_SIP(route->name_addr.uri)) &&
@@ -1858,10 +1858,10 @@ pjsip_sip_uri* SproutletWrapper::next_hop_uri(const std::string& service,
 
 pjsip_sip_uri* SproutletWrapper::get_routing_uri(const pjsip_msg* req) const
 {
-  // Start off with _root_uri and replace it with a SIP URI from the request,
-  // if there is one that matches this Sproutlet.
+  // Get the URI that caused us to be routed to this Sproutlet or if no such
+  // URI exists e.g. if the Sproutlet was matched on a port, return NULL.
   const pjsip_route_hdr* route = route_hdr();
-  pjsip_sip_uri* routing_uri = _proxy->_root_uri;
+  pjsip_sip_uri* routing_uri = NULL;
   if (route != NULL)
   {
     if ((PJSIP_URI_SCHEME_IS_SIP(route->name_addr.uri)) &&

--- a/src/subscriptionsproutlet.cpp
+++ b/src/subscriptionsproutlet.cpp
@@ -80,7 +80,7 @@ SproutletTsx* SubscriptionSproutlet::get_tsx(SproutletHelper* helper,
   }
 
   // We're not interested in the message so create a next hop URI.
-  pjsip_sip_uri* base_uri = helper->get_routing_uri(req);
+  pjsip_sip_uri* base_uri = helper->get_routing_uri(req, this);
   next_hop = helper->next_hop_uri(_next_hop_service,
                                   base_uri,
                                   pool);

--- a/src/ut/registrar_test.cpp
+++ b/src/ut/registrar_test.cpp
@@ -333,10 +333,10 @@ public:
     rapidxml::xml_node<> *registration = reg_info->first_node("registration");
     ASSERT_TRUE(registration);
     rapidxml::xml_node<> *contact;
-    contact = registration->first_node("contact");      
+    contact = registration->first_node("contact");
     for (int ii = 0; ii < check_contact; ii++)
     {
-      contact = contact->next_sibling();      
+      contact = contact->next_sibling();
     }
 
     ASSERT_TRUE(contact);
@@ -425,7 +425,7 @@ private:
     EXPECT_CALL(*_hss_connection_observer, update_registration_state(_, _, _))
       .WillOnce(DoAll(SaveArg<0>(&irs_query),
                       Return(HTTP_OK)));
-    
+
     hss_connection()->set_impu_result_with_prev("sip:6505550231@homedomain", "reg", RegDataXMLUtils::STATE_REGISTERED, RegDataXMLUtils::STATE_NOT_REGISTERED, "");
 
     inject_msg(msg.get());
@@ -873,7 +873,7 @@ TEST_F(RegistrarTest, SimpleMainlineAuthHeader)
   free_txdata();
 }
 
-// Check that something sensible happens if there is not route header on the request.
+// Check that something sensible happens if there is no route header on the request.
 TEST_F(RegistrarTest, SimpleMainlineAuthHeaderNoRoute)
 {
   // We have a private ID in this test, so set up the expect response
@@ -897,7 +897,7 @@ TEST_F(RegistrarTest, SimpleMainlineAuthHeaderNoRoute)
   EXPECT_EQ("Require: outbound", get_headers(out, "Require")); // because we have path
   EXPECT_EQ(msg._path, get_headers(out, "Path"));
   EXPECT_EQ("P-Associated-URI: <sip:6505550231@homedomain>", get_headers(out, "P-Associated-URI"));
-  EXPECT_EQ("Service-Route: <sip:scscf.homedomain:5058;transport=TCP;lr;orig>", get_headers(out, "Service-Route"));
+  EXPECT_EQ("Service-Route: <sip:scscf.sprout.homedomain:5058;transport=TCP;lr;orig>", get_headers(out, "Service-Route"));
   EXPECT_EQ(1,((SNMP::FakeSuccessFailCountTable*)SNMP::FAKE_REGISTRATION_STATS_TABLES.init_reg_tbl)->_attempts);
   EXPECT_EQ(1,((SNMP::FakeSuccessFailCountTable*)SNMP::FAKE_REGISTRATION_STATS_TABLES.init_reg_tbl)->_successes);
   free_txdata();
@@ -918,7 +918,7 @@ TEST_F(RegistrarTest, SimpleMainlineAuthHeaderNoRoute)
   EXPECT_EQ("Require: outbound", get_headers(out, "Require")); // because we have path
   EXPECT_EQ(msg._path, get_headers(out, "Path"));
   EXPECT_EQ("P-Associated-URI: <sip:6505550231@homedomain>", get_headers(out, "P-Associated-URI"));
-  EXPECT_EQ("Service-Route: <sip:scscf.homedomain:5058;transport=TCP;lr;orig>", get_headers(out, "Service-Route"));
+  EXPECT_EQ("Service-Route: <sip:scscf.sprout.homedomain:5058;transport=TCP;lr;orig>", get_headers(out, "Service-Route"));
   EXPECT_EQ(1,((SNMP::FakeSuccessFailCountTable*)SNMP::FAKE_REGISTRATION_STATS_TABLES.init_reg_tbl)->_attempts);
   EXPECT_EQ(1,((SNMP::FakeSuccessFailCountTable*)SNMP::FAKE_REGISTRATION_STATS_TABLES.init_reg_tbl)->_successes);
   free_txdata();

--- a/src/ut/sproutletproxy_test.cpp
+++ b/src/ut/sproutletproxy_test.cpp
@@ -80,7 +80,7 @@ public:
 
   SproutletTsx* get_tsx(SproutletHelper* helper, const std::string& alias, pjsip_msg* req, pjsip_sip_uri*& next_hop, pj_pool_t* pool, SAS::TrailId trail)
   {
-    pjsip_sip_uri* base_uri = helper->get_routing_uri(req);
+    pjsip_sip_uri* base_uri = helper->get_routing_uri(req, this);
     next_hop = helper->next_hop_uri(_next_hop,
                                     base_uri,
                                     pool);
@@ -2492,6 +2492,182 @@ TEST_F(SproutletProxyTest, CompositeNetworkFunctionTelURI2)
   Message msg1;
   msg1._method = "INVITE";
   msg1._requri = "tel:8088341234";
+  msg1._from = "sip:alice@homedomain";
+  msg1._to = "sip:bob@awaydomain";
+  msg1._via = tp->to_string(false);
+  msg1._forwards = "100";
+  inject_msg(msg1.get_request(), tp);
+
+  // Expecting 100 Trying and forwarded INVITEs.
+  ASSERT_EQ(2, txdata_count());
+
+  // Check the 100 Trying.
+  tdata = current_txdata();
+  RespMatcher(100).matches(tdata->msg);
+  tp->expect_target(tdata);
+  EXPECT_EQ("To: <sip:bob@awaydomain>", get_headers(tdata->msg, "To")); // No tag
+  free_txdata();
+
+  // Check the INVITE contains the Foo header added by teltest2 and send a
+  // 100 Trying.
+  pjsip_tx_data* req = pop_txdata();
+  expect_target("TCP", "10.10.20.1", 5060, req);
+  ReqMatcher("INVITE").matches(req->msg);
+  EXPECT_EQ("Foo: <sip:bar@baz>", get_headers(req->msg, "Foo"));
+  inject_msg(respond_to_txdata(req, 100));
+
+  // Send a 200 OK response.
+  inject_msg(respond_to_txdata(req, 200));
+  ASSERT_EQ(1, txdata_count());
+
+  // Check the 200 OK.
+  tdata = current_txdata();
+  RespMatcher(200).matches(tdata->msg);
+  tp->expect_target(tdata);
+  free_txdata();
+
+  // All done!
+  ASSERT_EQ(0, txdata_count());
+
+  delete tp;
+}
+
+TEST_F(SproutletProxyTest, CompositeNetworkFunctionReqURI)
+{
+  // Tests passing a request through a Network Function composed of multiple
+  // sproutlets, when the request is routed by the request URI.
+  pjsip_tx_data* tdata;
+
+  // Create a TCP transport that will deliver inbound messages on. The port is
+  // random to make sure that we don't match a Sproutlet based on the port.
+  TransportFlow* tp = new TransportFlow(TransportFlow::Protocol::TCP,
+                                        43498,
+                                        "1.2.3.4",
+                                        49152);
+
+  // Inject a request with no Route header, and a Tel URI.
+  Message msg1;
+  msg1._method = "INVITE";
+  msg1._requri = "sip:bob@teltest1.proxy1.homedomain:5060;transport=TCP";
+  msg1._from = "sip:alice@homedomain";
+  msg1._to = "sip:bob@awaydomain";
+  msg1._via = tp->to_string(false);
+  msg1._forwards = "100";
+  inject_msg(msg1.get_request(), tp);
+
+  // Expecting 100 Trying and forwarded INVITEs.
+  ASSERT_EQ(2, txdata_count());
+
+  // Check the 100 Trying.
+  tdata = current_txdata();
+  RespMatcher(100).matches(tdata->msg);
+  tp->expect_target(tdata);
+  EXPECT_EQ("To: <sip:bob@awaydomain>", get_headers(tdata->msg, "To")); // No tag
+  free_txdata();
+
+  // Check the INVITE contains the Foo header added by teltest2 and send a
+  // 100 Trying.
+  pjsip_tx_data* req = pop_txdata();
+  expect_target("TCP", "10.10.20.1", 5060, req);
+  ReqMatcher("INVITE").matches(req->msg);
+  EXPECT_EQ("Foo: <sip:bar@baz>", get_headers(req->msg, "Foo"));
+  inject_msg(respond_to_txdata(req, 100));
+
+  // Send a 200 OK response.
+  inject_msg(respond_to_txdata(req, 200));
+  ASSERT_EQ(1, txdata_count());
+
+  // Check the 200 OK.
+  tdata = current_txdata();
+  RespMatcher(200).matches(tdata->msg);
+  tp->expect_target(tdata);
+  free_txdata();
+
+  // All done!
+  ASSERT_EQ(0, txdata_count());
+
+  delete tp;
+}
+
+TEST_F(SproutletProxyTest, CompositeNetworkFunctionReqURI2)
+{
+  // Tests passing a request through a Network Function composed of multiple
+  // sproutlets, when the request is routed by the request URI, and the first
+  // sproutlet is not interested in handling the request.
+  pjsip_tx_data* tdata;
+
+  // Create a TCP transport that will deliver inbound messages on. The port is
+  // random to make sure that we don't match a Sproutlet based on the port.
+  TransportFlow* tp = new TransportFlow(TransportFlow::Protocol::TCP,
+                                        43498,
+                                        "1.2.3.4",
+                                        49152);
+
+  // Inject a request with no Route header, and a Tel URI.
+  Message msg1;
+  msg1._method = "INVITE";
+  msg1._requri = "sip:bob@teltest3.proxy1.homedomain:5060;transport=TCP";
+  msg1._from = "sip:alice@homedomain";
+  msg1._to = "sip:bob@awaydomain";
+  msg1._via = tp->to_string(false);
+  msg1._forwards = "100";
+  inject_msg(msg1.get_request(), tp);
+
+  // Expecting 100 Trying and forwarded INVITEs.
+  ASSERT_EQ(2, txdata_count());
+
+  // Check the 100 Trying.
+  tdata = current_txdata();
+  RespMatcher(100).matches(tdata->msg);
+  tp->expect_target(tdata);
+  EXPECT_EQ("To: <sip:bob@awaydomain>", get_headers(tdata->msg, "To")); // No tag
+  free_txdata();
+
+  // Check the INVITE contains the Foo header added by teltest2 and send a
+  // 100 Trying.
+  pjsip_tx_data* req = pop_txdata();
+  expect_target("TCP", "10.10.20.1", 5060, req);
+  ReqMatcher("INVITE").matches(req->msg);
+  EXPECT_EQ("Foo: <sip:bar@baz>", get_headers(req->msg, "Foo"));
+  inject_msg(respond_to_txdata(req, 100));
+
+  // Send a 200 OK response.
+  inject_msg(respond_to_txdata(req, 200));
+  ASSERT_EQ(1, txdata_count());
+
+  // Check the 200 OK.
+  tdata = current_txdata();
+  RespMatcher(200).matches(tdata->msg);
+  tp->expect_target(tdata);
+  free_txdata();
+
+  // All done!
+  ASSERT_EQ(0, txdata_count());
+
+  delete tp;
+}
+
+TEST_F(SproutletProxyTest, CompositeNetworkFunctionNonLocalReqURI)
+{
+  // Tests passing a request through a Network Function composed of multiple
+  // sproutlets, when the request is routed by port (but the message contains
+  // a non-local SIP URI in the request line), and the first sproutlet is not
+  // interested in handling the request.
+  pjsip_tx_data* tdata;
+
+  // Create a TCP transport that will deliver inbound messages on the port
+  // 44666.  This port is owned by the teltest3 sproutlet, which forwards on to
+  // the teltest2 sproutlet, even though it doesn't have a routable SIP URI to
+  // hand.
+  TransportFlow* tp = new TransportFlow(TransportFlow::Protocol::TCP,
+                                        44666,
+                                        "1.2.3.4",
+                                        49152);
+
+  // Inject a request with no Route header, and a Tel URI.
+  Message msg1;
+  msg1._method = "INVITE";
+  msg1._requri = "sip:bob@notalocaluri:5060;transport=TCP";
   msg1._from = "sip:alice@homedomain";
   msg1._to = "sip:bob@awaydomain";
   msg1._via = tp->to_string(false);


### PR DESCRIPTION
Alex,

This PR enhances `get_routing_uri()` to check that the URI it finds on a request is reflexive before returning it as a routing URI. Please can you review. This addresses the scenario where a message can contain a non-local SIP URI that we then use to route between Sproutlets which will fail.

I've had to change the Sproutlet API slightly with this change but the impacts are quite small. I've added UTs to get full coverage in this area of code.

Thanks,

Sathiyan