### PR TITLE
[Reviewer: Krista] Accept-Contact fixes

### DIFF
--- a/src/custom_headers.cpp
+++ b/src/custom_headers.cpp
@@ -1275,7 +1275,7 @@ int pjsip_reject_contact_hdr_print_on(void* void_hdr,
   return buf-startbuf;
 }
 
-pjsip_hdr* parse_hdr_accept_contact(pjsip_parse_ctx* ctx)
+pjsip_hdr* parse_hdr_accept_contact( pjsip_parse_ctx *ctx )
 {
   // The Accept-Contact header has the following ABNF:
   //
@@ -1288,60 +1288,77 @@ pjsip_hdr* parse_hdr_accept_contact(pjsip_parse_ctx* ctx)
   //
   // But we allow any value for the header (not just *).
 
+  pjsip_accept_contact_hdr *first = NULL;
   pj_pool_t* pool = ctx->pool;
   pj_scanner* scanner = ctx->scanner;
   const pjsip_parser_const_t* pc = pjsip_parser_const();
-  pjsip_accept_contact_hdr* hdr = pjsip_accept_contact_hdr_create(pool);
   pj_str_t name;
   pj_str_t value;
   pjsip_param *param;
 
-  // Read and ignore the value.
-  pj_str_t header_value;
-  pj_scan_get(scanner, &pc->pjsip_TOKEN_SPEC, &header_value);
-
-  // Skip any following whitespace (to the end of the line)
-  pj_scan_skip_whitespace(scanner);
-
-  // If we're EOF or looking at a newline, we're done.
-  while (!pj_scan_is_eof(scanner) &&
-         (*scanner->curptr != '\r') &&
-         (*scanner->curptr != '\n'))
+  while (true)
   {
-    // We might need to swallow the ';'.
-    if (!pj_scan_is_eof(scanner) && *scanner->curptr == ';')
+    pjsip_accept_contact_hdr *hdr = pjsip_accept_contact_hdr_create(pool);
+    if (first == NULL)
     {
-      pj_scan_get_char(scanner);
-    }
-
-    pjsip_parse_param_imp(scanner, pool, &name, &value, 0);
-    param = PJ_POOL_ALLOC_T(pool, pjsip_param);
-    param->name = name;
-    param->value = value;
-
-    if (!pj_stricmp2(&name, "require"))
-    {
-      hdr->required_match = true;
-    }
-    else if (!pj_stricmp2(&name, "explicit"))
-    {
-      hdr->explicit_match = true;
+        first = hdr;
     }
     else
     {
-      pj_list_insert_before(&hdr->feature_set, param);
+      pj_list_insert_before(first, hdr);
     }
 
-    // Skip any following whitespace (to the end of the line)
-    pj_scan_skip_whitespace(scanner);
+    // Read and ignore the value.
+    pj_str_t header_value;
+    pj_scan_get(scanner, &pc->pjsip_TOKEN_SPEC, &header_value);
+
+    // If we're EOF or looking at a newline, we're done.
+    while (!pj_scan_is_eof(scanner) &&
+           (*scanner->curptr != ',') &&
+           (*scanner->curptr != '\r') &&
+           (*scanner->curptr != '\n'))
+    {
+      // We might need to swallow the ';'.
+      if (!pj_scan_is_eof(scanner) && *scanner->curptr == ';')
+      {
+        pj_scan_get_char(scanner);
+      }
+
+      pjsip_parse_param_imp(scanner, pool, &name, &value, 0);
+      param = PJ_POOL_ALLOC_T(pool, pjsip_param);
+      param->name = name;
+      param->value = value;
+
+      if (!pj_stricmp2(&name, "require"))
+      {
+        hdr->required_match = true;
+      }
+      else if (!pj_stricmp2(&name, "explicit"))
+      {
+        hdr->explicit_match = true;
+      }
+      else
+      {
+        pj_list_insert_before(&hdr->feature_set, param);
+      }
+
+      // Skip any following whitespace (to the end of the line)
+      pj_scan_skip_whitespace(scanner);
+    }
+
+    if (*scanner->curptr != ',')
+    {
+      break;
+    }
+
+    pj_scan_get_char(scanner);
+
   }
 
   // We're done parsing this header.
   pjsip_parse_end_hdr_imp(scanner);
-
-  return (pjsip_hdr*)hdr;
+  return (pjsip_hdr*)first;
 }
-
 
 pjsip_accept_contact_hdr* pjsip_accept_contact_hdr_create(pj_pool_t* pool)
 {

--- a/src/custom_headers.cpp
+++ b/src/custom_headers.cpp
@@ -1301,7 +1301,7 @@ pjsip_hdr* parse_hdr_accept_contact( pjsip_parse_ctx *ctx )
     pjsip_accept_contact_hdr *hdr = pjsip_accept_contact_hdr_create(pool);
     if (first == NULL)
     {
-        first = hdr;
+      first = hdr;
     }
     else
     {

--- a/src/ut/sip_parser_test.cpp
+++ b/src/ut/sip_parser_test.cpp
@@ -22,6 +22,13 @@ using namespace std;
 
 #define EXPECT_PJEQ(X, Y) EXPECT_EQ(PJUtils::pj_str_to_string(&X), string(Y))
 
+enum CloneType
+{
+  None,
+  Shallow,
+  Full
+};
+
 /// Fixture for SIP Parser testing
 class SipParserTest : public SipTest
 {
@@ -35,6 +42,10 @@ public:
   {
     SipTest::TearDownTestCase();
   }
+
+  std::vector<std::string> parse_and_print_multi(std::string header, std::string hname, CloneType ct = CloneType::None);
+  std::string parse_and_print_one(std::string header, std::string hname, CloneType ct = CloneType::None);
+  bool verify_parses(std::string header, std::string hname);
 };
 
 TEST_F(SipParserTest, PChargingVector)
@@ -543,7 +554,13 @@ TEST_F(SipParserTest, SessionExpiresUAC)
   EXPECT_STREQ("Session-Expires: 600;refresher=uac;other-param=10;more-param=42", buf);
 }
 
-TEST_F(SipParserTest, AcceptContact)
+std::string SipParserTest::parse_and_print_one(std::string header, std::string hname, CloneType ct)
+{
+  std::vector<std::string> ret = parse_and_print_multi(header, hname, ct);
+  return ret[0];
+}
+
+std::vector<std::string> SipParserTest::parse_and_print_multi(std::string header, std::string hname, CloneType ct)
 {
   pj_pool_t *main_pool = pjsip_endpt_create_pool(stack_data.endpt, "rtd%p",
                                                  PJSIP_POOL_RDATA_LEN,
@@ -551,6 +568,95 @@ TEST_F(SipParserTest, AcceptContact)
   pj_pool_t *clone_pool = pjsip_endpt_create_pool(stack_data.endpt, "rtd%p",
                                                   PJSIP_POOL_RDATA_LEN,
                                                   PJSIP_POOL_RDATA_INC);
+  std::vector<std::string> ret;
+  std::vector<pjsip_hdr*> initial_headers;
+  std::vector<pjsip_hdr*> final_headers;
+
+  string str("INVITE sip:6505554321@homedomain SIP/2.0\n"
+             "Via: SIP/2.0/TCP 10.0.0.1:5060;rport;branch=z9hG4bKPjPtVFjqo;alias\n"
+             "Max-Forwards: 63\n"
+             "From: <sip:6505551234@homedomain>;tag=1234\n"
+             "To: <sip:6505554321@homedomain>\n"
+             "Contact: <sip:6505551234@10.0.0.1:5060;transport=TCP;ob>\n"
+             "Call-ID: 1-13919@10.151.20.48\n"
+             "CSeq: 1 INVITE\n"
+             + header +
+             "Content-Length: 0\n\n");
+
+  pjsip_rx_data* rdata = build_rxdata(str, _tp_default, main_pool);
+  parse_rxdata(rdata);
+
+  pj_str_t header_name;
+  pj_cstr(&header_name, hname.c_str());
+  pjsip_hdr* hdr = (pjsip_hdr*)pjsip_msg_find_hdr_by_name(rdata->msg_info.msg,
+                                                            &header_name,
+                                                            NULL);
+
+  while (hdr != NULL)
+  {
+    initial_headers.push_back(hdr);
+    hdr = (pjsip_hdr*)pjsip_msg_find_hdr_by_name(rdata->msg_info.msg,
+                                                            &header_name,
+                                                            hdr->next);
+  }
+
+  for (pjsip_hdr* initial_hdr : initial_headers)
+  {
+    pjsip_hdr* hdr_to_print;
+
+    if (ct == CloneType::Full)
+    {
+      hdr_to_print = (pjsip_hdr*)initial_hdr->vptr->clone(clone_pool, initial_hdr);
+    }
+    else if (ct == CloneType::Shallow)
+    {
+      hdr_to_print = (pjsip_hdr*)initial_hdr->vptr->shallow_clone(clone_pool, (void*)initial_hdr);
+    }
+    else
+    {
+      hdr_to_print = initial_hdr;
+    }
+
+    final_headers.push_back(hdr_to_print);
+  }
+
+  initial_headers.clear();
+
+  if (ct != CloneType::None)
+  {
+    pj_pool_release(main_pool);
+  }
+
+  for (pjsip_hdr* hdr : final_headers)
+  {
+    char buf[1024] = {0};
+    int written = hdr->vptr->print_on(hdr, buf, 0);
+    EXPECT_EQ(written, -1);
+    int i = 1;
+    while ((written == -1) && (i <= 1024))
+    {
+      written = hdr->vptr->print_on(hdr, buf, i);
+      i++;
+    }
+
+    ret.push_back(buf);
+  }
+
+  pj_pool_release(clone_pool);
+
+  if (ct == CloneType::None)
+  {
+    pj_pool_release(main_pool);
+  }
+
+  return ret;
+}
+
+TEST_F(SipParserTest, AcceptContact)
+{
+  pj_pool_t *main_pool = pjsip_endpt_create_pool(stack_data.endpt, "rtd%p",
+                                                 PJSIP_POOL_RDATA_LEN,
+                                                 PJSIP_POOL_RDATA_INC);
 
   string str("INVITE sip:6505554321@homedomain SIP/2.0\n"
              "Via: SIP/2.0/TCP 10.0.0.1:5060;rport;branch=z9hG4bKPjPtVFjqo;alias\n"
@@ -575,55 +681,86 @@ TEST_F(SipParserTest, AcceptContact)
   EXPECT_EQ(true, hdr->required_match);
   EXPECT_EQ(true, hdr->explicit_match);
   EXPECT_EQ(1u, pj_list_size(&hdr->feature_set));
+  pj_pool_release(main_pool);
+}
 
-  pjsip_accept_contact_hdr* clone = (pjsip_accept_contact_hdr*)hdr->vptr->clone(clone_pool, (void*)hdr);
-  EXPECT_EQ(true, clone->required_match);
-  EXPECT_EQ(true, clone->explicit_match);
-  EXPECT_EQ(1u, pj_list_size(&clone->feature_set));
+TEST_F(SipParserTest, AcceptContactMultiple)
+{
+  pj_pool_t *main_pool = pjsip_endpt_create_pool(stack_data.endpt, "rtd%p",
+                                                 PJSIP_POOL_RDATA_LEN,
+                                                 PJSIP_POOL_RDATA_INC);
 
-  pjsip_accept_contact_hdr* sclone = (pjsip_accept_contact_hdr*)hdr->vptr->shallow_clone(clone_pool, (void*)clone);
-  EXPECT_EQ(true, sclone->required_match);
-  EXPECT_EQ(true, sclone->explicit_match);
-  EXPECT_EQ(1u, pj_list_size(&sclone->feature_set));
+  string str("INVITE sip:6505554321@homedomain SIP/2.0\n"
+             "Via: SIP/2.0/TCP 10.0.0.1:5060;rport;branch=z9hG4bKPjPtVFjqo;alias\n"
+             "Max-Forwards: 63\n"
+             "From: <sip:6505551234@homedomain>;tag=1234\n"
+             "To: <sip:6505554321@homedomain>\n"
+             "Contact: <sip:6505551234@10.0.0.1:5060;transport=TCP;ob>\n"
+             "Call-ID: 1-13919@10.151.20.48\n"
+             "CSeq: 1 INVITE\n"
+             "Accept-Contact: *;+sip.instance=\"<i:am:a:robot>\";+xyz;explicit,*;require;+abcd\n"
+             "Content-Length: 0\n\n");
 
-  char buf[1024];
-  memset(buf, 0, 1024);
-  pjsip_hdr* generic_hdr = (pjsip_hdr*)sclone;
-  int written = generic_hdr->vptr->print_on(sclone, buf, 0);
-  EXPECT_EQ(written, -1);
-  int i = 1;
-  while ((written == -1) && (i <= 1024)) {
-    written = generic_hdr->vptr->print_on(sclone, buf, i);
-    i++;
-  }
-  EXPECT_EQ(written, 65);
-  EXPECT_STREQ("Accept-Contact: *;+sip.instance=\"<i:am:a:robot>\";explicit;require", buf);
-  pj_pool_release(clone_pool);
-
-  // Repeat parse check with a minimal Accept-Contact header
-  string str2("INVITE sip:6505554321@homedomain SIP/2.0\n"
-              "Via: SIP/2.0/TCP 10.0.0.1:5060;rport;branch=z9hG4bKPjPtVFjqo;alias\n"
-              "Max-Forwards: 63\n"
-              "From: <sip:6505551234@homedomain>;tag=1234\n"
-              "To: <sip:6505554321@homedomain>\n"
-              "Contact: <sip:6505551234@10.0.0.1:5060;transport=TCP;ob>\n"
-              "Call-ID: 1-13919@10.151.20.48\n"
-              "CSeq: 1 INVITE\n"
-              "Accept-Contact: *\n"
-              "Content-Length: 0\n\n");
-
-  rdata = build_rxdata(str2, _tp_default, main_pool);
+  pjsip_rx_data* rdata = build_rxdata(str, _tp_default, main_pool);
   parse_rxdata(rdata);
-  hdr =
+
+  pj_str_t header_name = pj_str("Accept-Contact");
+  pjsip_accept_contact_hdr* hdr =
       (pjsip_accept_contact_hdr*)pjsip_msg_find_hdr_by_name(rdata->msg_info.msg,
                                                             &header_name,
                                                             NULL);
   EXPECT_NE(hdr, (pjsip_accept_contact_hdr*)NULL);
+  EXPECT_EQ(true, hdr->explicit_match);
   EXPECT_NE(true, hdr->required_match);
+  EXPECT_EQ(2u, pj_list_size(&hdr->feature_set));
+
+  hdr = (pjsip_accept_contact_hdr*)pjsip_msg_find_hdr_by_name(rdata->msg_info.msg,
+                                                            &header_name,
+                                                            hdr->next);
+  EXPECT_NE(hdr, (pjsip_accept_contact_hdr*)NULL);
+  EXPECT_EQ(true, hdr->required_match);
   EXPECT_NE(true, hdr->explicit_match);
-  EXPECT_EQ(0u, pj_list_size(&hdr->feature_set));
+  EXPECT_EQ(1u, pj_list_size(&hdr->feature_set));
 
   pj_pool_release(main_pool);
+}
+
+
+
+TEST_F(SipParserTest, AcceptContactCloning)
+{
+  EXPECT_EQ("Accept-Contact: *;+sip.instance=\"<i:am:a:robot>\";explicit;require",
+          parse_and_print_one("Accept-Contact   :    hello_world ; +sip.instance =  \"<i:am:a:robot>\" ;explicit ;             require\n",
+                              "Accept-Contact",
+                              CloneType::Full));
+
+  EXPECT_EQ("Accept-Contact: *;+sip.instance=\"<i:am:a:robot>\";explicit;require",
+          parse_and_print_one("Accept-Contact   :    hello_world ; +sip.instance =  \"<i:am:a:robot>\" ;explicit ;             require\n",
+                              "Accept-Contact",
+                              CloneType::Shallow));
+}
+
+TEST_F(SipParserTest, DISABLED_AcceptContactQuotedStringEscapedChar)
+{
+  EXPECT_EQ("Accept-Contact: *",
+          parse_and_print_one("Accept-Contact: *;c=\"\\j\"",
+                              "Accept-Contact"));
+}
+
+TEST_F(SipParserTest, DISABLED_AcceptContact_QuotedStringLWS)
+{
+
+      EXPECT_EQ("Accept-Contact: *;a=\"\r\n  \"\n",
+                parse_and_print_one("Accept-Contact: *;a=\"\r\n	 \"\n",
+                                    "Accept-Contact"));
+}
+
+TEST_F(SipParserTest, AcceptContact_VariousABNF_1)
+{
+      std::vector<std::string> expected = { "Accept-Contact: *;explicit", "Accept-Contact: *", "Accept-Contact: *", "Accept-Contact: *", "Accept-Contact: *" };
+      EXPECT_EQ(expected,
+                parse_and_print_multi("a:*;ExpLiciT\n		 		,\n 	*\n	,*,	\n *,  \n  *\n",
+                                "Accept-Contact"));
 }
 
 TEST_F(SipParserTest, RejectContact)
@@ -1124,4 +1261,9 @@ TEST_F(SipParserTest, ResourcePriority)
   EXPECT_STREQ("Resource-Priority: dsn.flash, wps.4", buf);
 
   pj_pool_release(clone_pool);
+  EXPECT_EQ("", parse_and_print_one("rEsOurce-pRioRiTY :     *-.%   , *.''\n", "Resource-Priority"));
 }
+
+
+
+

--- a/src/ut/sip_parser_test.cpp
+++ b/src/ut/sip_parser_test.cpp
@@ -634,7 +634,7 @@ std::vector<std::string> SipParserTest::parse_and_print_multi(std::string header
 
   // If we cloned the message, release the original PJSIP pool so we get
   // valgrind warnings if it was incompletely copied.
-  if (ct != CloneType::None)
+  if (ct == CloneType::Full)
   {
     pj_pool_release(main_pool);
   }
@@ -657,7 +657,7 @@ std::vector<std::string> SipParserTest::parse_and_print_multi(std::string header
 
   pj_pool_release(clone_pool);
 
-  if (ct == CloneType::None)
+  if (ct != CloneType::Full)
   {
     pj_pool_release(main_pool);
   }

--- a/src/ut/sip_parser_test.cpp
+++ b/src/ut/sip_parser_test.cpp
@@ -1372,5 +1372,4 @@ TEST_F(SipParserTest, ResourcePriority)
   EXPECT_STREQ("Resource-Priority: dsn.flash, wps.4", buf);
 
   pj_pool_release(clone_pool);
-  EXPECT_EQ("", parse_and_print_one("rEsOurce-pRioRiTY :     *-.%   , *.''\n", "Resource-Priority"));
 }


### PR DESCRIPTION
Picking you because I think you've done a chunk of Sprout UT work recently and I think the UT changes are the most interesting part of this PR - if I've misremembered or you have too much on your plate, let me know.

L3 raised on Slack (I don't think there's an issue yet) that our Accept-Contact header parsing doesn't accept comma-separated values - `Accept-Contact: *;foo,*;bar` should be equivalent to:

```
Accept-Contact: *;foo
Accept-Contact: *;bar
```

but it fails to parse. Generally I'm a bit worried about this - I think we've hit a few header parsing bugs in our custom headers recently - so I've tried to figure out how to improve the testing here.

This PR:

* adds a specific test for comma-separated values, `AcceptContactMultiple`
* fixes up the Accept-Contact parser to make it work, using the same loop approach as PJSIP's code for Contact headers, which already correctly handles comma-separated values
* adds some helper methods to the tests, like `parse_and_print_multi`, to make them shorter and more readable
* adds several randomly-generated Accept-Contact tests created with abnfgen (http://www.quut.com/abnfgen/) to try and ensure there aren't any further parser bugs lurking - some of these do fail, so they're disabled, and I'll raise issues for those.

If this looks useful I might give a lightning talk on abnfgen.

Tagging @steelyvoid who raised the issue and @metaswitch-ak10 who I think is doing something similar for Reject-Contact, which has a similar bug.