### PR TITLE
[Reviewer: RKD] Reject-Contact fixes

### DIFF
--- a/include/custom_headers.h
+++ b/include/custom_headers.h
@@ -143,6 +143,9 @@ void* pjsip_accept_contact_hdr_clone(pj_pool_t* pool, const void* o);
 void* pjsip_accept_contact_hdr_shallow_clone(pj_pool_t* pool, const void* o);
 int pjsip_accept_contact_hdr_print_on(void* hdr, char* buf, pj_size_t len);
 
+// Common method for parsing Accept-Contact and Reject-Contact headers
+pjsip_hdr* parse_hdr_accept_or_reject_contact(pjsip_parse_ctx* ctx, bool accept);
+
 // Resource-Priority
 pjsip_hdr* parse_hdr_resource_priority(pjsip_parse_ctx* ctx);
 pjsip_generic_array_hdr* pjsip_resource_priority_hdr_create(pj_pool_t* pool);

--- a/src/custom_headers.cpp
+++ b/src/custom_headers.cpp
@@ -1148,15 +1148,6 @@ int pjsip_p_c_f_a_hdr_print_on(void *h, char* buf, pj_size_t len)
 
 pjsip_hdr* parse_hdr_reject_contact(pjsip_parse_ctx* ctx)
 {
-  // The Reject-Contact header has the following ABNF:
-  //
-  // Reject-Contact  =  ("Reject-Contact" / "j") HCOLON rc-value
-  //                       *(COMMA rc-value)
-  // rc-value        =  "*" *(SEMI rc-params)
-  // rc-params       =  feature-param / generic-param
-  //
-  // But we allow any value for the header (not just *).
-
   return parse_hdr_accept_or_reject_contact(ctx, false);
 }
 
@@ -1238,17 +1229,6 @@ int pjsip_reject_contact_hdr_print_on(void* void_hdr,
 
 pjsip_hdr* parse_hdr_accept_contact(pjsip_parse_ctx* ctx)
 {
-  // The Accept-Contact header has the following ABNF:
-  //
-  // Accept-Contact  =  ("Accept-Contact" / "j") HCOLON ac-value
-  //                       *(COMMA ac-value)
-  // ac-value        =  "*" *(SEMI ac-params)
-  // ac-params       =  feature-param / req-param / explicit-param / generic-param
-  // req-param       =  "require"
-  // explicit-param  =  "explicit"
-  //
-  // But we allow any value for the header (not just *).
-
   return parse_hdr_accept_or_reject_contact(ctx, true);
 }
 
@@ -1346,6 +1326,24 @@ int pjsip_accept_contact_hdr_print_on(void* void_hdr,
 
 pjsip_hdr* parse_hdr_accept_or_reject_contact(pjsip_parse_ctx* ctx, bool accept)
 {
+  // The Accept-Contact header has the following ABNF:
+  //
+  // Accept-Contact  =  ("Accept-Contact" / "j") HCOLON ac-value
+  //                       *(COMMA ac-value)
+  // ac-value        =  "*" *(SEMI ac-params)
+  // ac-params       =  feature-param / req-param / explicit-param / generic-param
+  // req-param       =  "require"
+  // explicit-param  =  "explicit"
+  //
+  // The Reject-Contact header has the following ABNF:
+  //
+  // Reject-Contact  =  ("Reject-Contact" / "j") HCOLON rc-value
+  //                       *(COMMA rc-value)
+  // rc-value        =  "*" *(SEMI rc-params)
+  // rc-params       =  feature-param / generic-param
+  //
+  // But we allow any value for the header (not just *).
+
   pjsip_hdr* first = NULL;
   pjsip_hdr* hdr = NULL;
 

--- a/src/custom_headers.cpp
+++ b/src/custom_headers.cpp
@@ -1157,64 +1157,7 @@ pjsip_hdr* parse_hdr_reject_contact(pjsip_parse_ctx* ctx)
   //
   // But we allow any value for the header (not just *).
 
-  pjsip_reject_contact_hdr* first = NULL;
-  pj_pool_t* pool = ctx->pool;
-  pj_scanner* scanner = ctx->scanner;
-  const pjsip_parser_const_t* pc = pjsip_parser_const();
-  pj_str_t name;
-  pj_str_t value;
-  pjsip_param *param;
-
-  while (true)
-  {
-    pjsip_reject_contact_hdr* hdr = pjsip_reject_contact_hdr_create(pool);
-    if (first == NULL)
-    {
-      first = hdr;
-    }
-    else
-    {
-      pj_list_insert_before(first, hdr);
-    }
-
-    // Read and ignore the value.
-    pj_str_t header_value;
-    pj_scan_get(scanner, &pc->pjsip_TOKEN_SPEC, &header_value);
-
-    // If we're EOF or looking at a newline, we're done.
-    // If we're looking at a "," , we've hit another rc-value. 
-    while (!pj_scan_is_eof(scanner) &&
-           (*scanner->curptr != ',') &&
-           (*scanner->curptr != '\r') &&
-           (*scanner->curptr != '\n'))
-    {
-      // We might need to swallow the ";"
-      if (*scanner->curptr == ';')
-      {
-        pj_scan_get_char(scanner);
-      }
-
-      pjsip_parse_param_imp(scanner, pool, &name, &value, 0);
-      param = PJ_POOL_ALLOC_T(pool, pjsip_param);
-      param->name = name;
-      param->value = value;
-      pj_list_insert_before(&hdr->feature_set, param);
-
-      // Skip any following whitespace (to the end of the line)
-      pj_scan_skip_whitespace(scanner);
-    }
-
-    if (*scanner->curptr != ',')
-    {
-      break;
-    }
-
-    pj_scan_get_char(scanner);
-  }
-
-  // We're done parsing this header.
-  pjsip_parse_end_hdr_imp(scanner);
-  return (pjsip_hdr*)first;
+  return parse_hdr_accept_or_reject_contact(ctx, false);
 }
 
 pjsip_reject_contact_hdr* pjsip_reject_contact_hdr_create(pj_pool_t* pool)
@@ -1293,7 +1236,7 @@ int pjsip_reject_contact_hdr_print_on(void* void_hdr,
   return buf-startbuf;
 }
 
-pjsip_hdr* parse_hdr_accept_contact( pjsip_parse_ctx *ctx )
+pjsip_hdr* parse_hdr_accept_contact(pjsip_parse_ctx* ctx)
 {
   // The Accept-Contact header has the following ABNF:
   //
@@ -1306,76 +1249,7 @@ pjsip_hdr* parse_hdr_accept_contact( pjsip_parse_ctx *ctx )
   //
   // But we allow any value for the header (not just *).
 
-  pjsip_accept_contact_hdr *first = NULL;
-  pj_pool_t* pool = ctx->pool;
-  pj_scanner* scanner = ctx->scanner;
-  const pjsip_parser_const_t* pc = pjsip_parser_const();
-  pj_str_t name;
-  pj_str_t value;
-  pjsip_param *param;
-
-  while (true)
-  {
-    pjsip_accept_contact_hdr *hdr = pjsip_accept_contact_hdr_create(pool);
-    if (first == NULL)
-    {
-      first = hdr;
-    }
-    else
-    {
-      pj_list_insert_before(first, hdr);
-    }
-
-    // Read and ignore the value.
-    pj_str_t header_value;
-    pj_scan_get(scanner, &pc->pjsip_TOKEN_SPEC, &header_value);
-
-    // If we're EOF or looking at a newline, we're done.
-    while (!pj_scan_is_eof(scanner) &&
-           (*scanner->curptr != ',') &&
-           (*scanner->curptr != '\r') &&
-           (*scanner->curptr != '\n'))
-    {
-      // We might need to swallow the ';'.
-      if (!pj_scan_is_eof(scanner) && *scanner->curptr == ';')
-      {
-        pj_scan_get_char(scanner);
-      }
-
-      pjsip_parse_param_imp(scanner, pool, &name, &value, 0);
-      param = PJ_POOL_ALLOC_T(pool, pjsip_param);
-      param->name = name;
-      param->value = value;
-
-      if (!pj_stricmp2(&name, "require"))
-      {
-        hdr->required_match = true;
-      }
-      else if (!pj_stricmp2(&name, "explicit"))
-      {
-        hdr->explicit_match = true;
-      }
-      else
-      {
-        pj_list_insert_before(&hdr->feature_set, param);
-      }
-
-      // Skip any following whitespace (to the end of the line)
-      pj_scan_skip_whitespace(scanner);
-    }
-
-    if (*scanner->curptr != ',')
-    {
-      break;
-    }
-
-    pj_scan_get_char(scanner);
-
-  }
-
-  // We're done parsing this header.
-  pjsip_parse_end_hdr_imp(scanner);
-  return (pjsip_hdr*)first;
+  return parse_hdr_accept_or_reject_contact(ctx, true);
 }
 
 pjsip_accept_contact_hdr* pjsip_accept_contact_hdr_create(pj_pool_t* pool)
@@ -1468,6 +1342,89 @@ int pjsip_accept_contact_hdr_print_on(void* void_hdr,
   }
 
   return buf-startbuf;
+}
+
+pjsip_hdr* parse_hdr_accept_or_reject_contact(pjsip_parse_ctx* ctx, bool accept)
+{
+  pjsip_hdr* first = NULL;
+  pjsip_hdr* hdr = NULL;
+
+  pj_pool_t* pool = ctx->pool;
+  pj_scanner* scanner = ctx->scanner;
+  const pjsip_parser_const_t* pc = pjsip_parser_const();
+  pj_str_t name;
+  pj_str_t value;
+  pjsip_param *param;
+
+  while (true)
+  {
+    hdr = accept ? (pjsip_hdr*)pjsip_accept_contact_hdr_create(pool) : (pjsip_hdr*)pjsip_reject_contact_hdr_create(pool);
+    if (first == NULL)
+    {
+      first = hdr;
+    }
+    else
+    {
+      pj_list_insert_before(first, hdr);
+    }
+
+    // Read and ignore the value.
+    pj_str_t header_value;
+    pj_scan_get(scanner, &pc->pjsip_TOKEN_SPEC, &header_value);
+
+    // If we're EOF or looking at a newline, we're done.
+    while (!pj_scan_is_eof(scanner) &&
+           (*scanner->curptr != ',') &&
+           (*scanner->curptr != '\r') &&
+           (*scanner->curptr != '\n'))
+    {
+      // We might need to swallow the ';'.
+      if (!pj_scan_is_eof(scanner) && *scanner->curptr == ';')
+      {
+        pj_scan_get_char(scanner);
+      }
+
+      pjsip_parse_param_imp(scanner, pool, &name, &value, 0);
+      param = PJ_POOL_ALLOC_T(pool, pjsip_param);
+      param->name = name;
+      param->value = value;
+
+      if (accept)
+      {
+        pjsip_accept_contact_hdr* achdr = (pjsip_accept_contact_hdr*)hdr;
+        if (!pj_stricmp2(&name, "require"))
+        {
+          achdr->required_match = true;
+        }
+        else if (!pj_stricmp2(&name, "explicit"))
+        {
+          achdr->explicit_match = true;
+        }
+        else
+        {
+          pj_list_insert_before(&achdr->feature_set, param);
+        }
+      }
+      else
+      {
+        pj_list_insert_before(&((pjsip_reject_contact_hdr*)hdr)->feature_set, param);
+      }
+
+      // Skip any following whitespace (to the end of the line)
+      pj_scan_skip_whitespace(scanner);
+    }
+
+    if (*scanner->curptr != ',')
+    {
+      break;
+    }
+
+    pj_scan_get_char(scanner);
+  }
+
+  // We're done parsing this header.
+  pjsip_parse_end_hdr_imp(scanner);
+  return (pjsip_hdr*)first;
 }
 
 static pjsip_hdr_vptr pjsip_resource_priority_vptr = {

--- a/src/custom_headers.cpp
+++ b/src/custom_headers.cpp
@@ -1214,7 +1214,7 @@ pjsip_hdr* parse_hdr_reject_contact(pjsip_parse_ctx* ctx)
 
   // We're done parsing this header.
   pjsip_parse_end_hdr_imp(scanner);
-  return (pjsip_hdr*)hdr;
+  return (pjsip_hdr*)first;
 }
 
 pjsip_reject_contact_hdr* pjsip_reject_contact_hdr_create(pj_pool_t* pool)

--- a/src/ut/sip_parser_test.cpp
+++ b/src/ut/sip_parser_test.cpp
@@ -962,17 +962,17 @@ TEST_F(SipParserTest, RejectContactMultiple)
   parse_rxdata(rdata);
 
   pj_str_t header_name = pj_str("Reject-Contact");
-  pjsip_accept_contact_hdr* hdr =
-      (pjsip_accept_contact_hdr*)pjsip_msg_find_hdr_by_name(rdata->msg_info.msg,
+  pjsip_reject_contact_hdr* hdr =
+      (pjsip_reject_contact_hdr*)pjsip_msg_find_hdr_by_name(rdata->msg_info.msg,
                                                             &header_name,
                                                             NULL);
-  EXPECT_NE(hdr, (pjsip_accept_contact_hdr*)NULL);
+  EXPECT_NE(hdr, (pjsip_reject_contact_hdr*)NULL);
   EXPECT_EQ(2u, pj_list_size(&hdr->feature_set));
 
-  hdr = (pjsip_accept_contact_hdr*)pjsip_msg_find_hdr_by_name(rdata->msg_info.msg,
+  hdr = (pjsip_reject_contact_hdr*)pjsip_msg_find_hdr_by_name(rdata->msg_info.msg,
                                                               &header_name,
                                                               hdr->next);
-  EXPECT_NE(hdr, (pjsip_accept_contact_hdr*)NULL);
+  EXPECT_NE(hdr, (pjsip_reject_contact_hdr*)NULL);
   EXPECT_EQ(1u, pj_list_size(&hdr->feature_set));
 
   pj_pool_release(main_pool);

--- a/src/ut/sip_parser_test.cpp
+++ b/src/ut/sip_parser_test.cpp
@@ -955,7 +955,7 @@ TEST_F(SipParserTest, RejectContactMultiple)
              "Contact: <sip:6505551234@10.0.0.1:5060;transport=TCP;ob>\n"
              "Call-ID: 1-13919@10.151.20.48\n"
              "CSeq: 1 INVITE\n"
-             "Reject-Contact: *;+sip.instance=\"<i:am:a:robot>\";+xyz,*;+abcd\n"
+             "Reject-Contact: *;+sip.instance=\"<i:am:a:robot>\";explicit;+xyz,*;require;+abcd\n"
              "Content-Length: 0\n\n");
 
   pjsip_rx_data* rdata = build_rxdata(str, _tp_default, main_pool);
@@ -967,13 +967,13 @@ TEST_F(SipParserTest, RejectContactMultiple)
                                                             &header_name,
                                                             NULL);
   EXPECT_NE(hdr, (pjsip_reject_contact_hdr*)NULL);
-  EXPECT_EQ(2u, pj_list_size(&hdr->feature_set));
+  EXPECT_EQ(3u, pj_list_size(&hdr->feature_set));
 
   hdr = (pjsip_reject_contact_hdr*)pjsip_msg_find_hdr_by_name(rdata->msg_info.msg,
                                                               &header_name,
                                                               hdr->next);
   EXPECT_NE(hdr, (pjsip_reject_contact_hdr*)NULL);
-  EXPECT_EQ(1u, pj_list_size(&hdr->feature_set));
+  EXPECT_EQ(2u, pj_list_size(&hdr->feature_set));
 
   pj_pool_release(main_pool);
 }

--- a/src/ut/sip_parser_test.cpp
+++ b/src/ut/sip_parser_test.cpp
@@ -941,6 +941,43 @@ TEST_F(SipParserTest, RejectContact)
   pj_pool_release(clone_pool);
 }
 
+TEST_F(SipParserTest, RejectContactMultiple)
+{
+  pj_pool_t *main_pool = pjsip_endpt_create_pool(stack_data.endpt, "rtd%p",
+                                                 PJSIP_POOL_RDATA_LEN,
+                                                 PJSIP_POOL_RDATA_INC);
+
+  string str("INVITE sip:6505554321@homedomain SIP/2.0\n"
+             "Via: SIP/2.0/TCP 10.0.0.1:5060;rport;branch=z9hG4bKPjPtVFjqo;alias\n"
+             "Max-Forwards: 63\n"
+             "From: <sip:6505551234@homedomain>;tag=1234\n"
+             "To: <sip:6505554321@homedomain>\n"
+             "Contact: <sip:6505551234@10.0.0.1:5060;transport=TCP;ob>\n"
+             "Call-ID: 1-13919@10.151.20.48\n"
+             "CSeq: 1 INVITE\n"
+             "Reject-Contact: *;+sip.instance=\"<i:am:a:robot>\";+xyz,*;+abcd\n"
+             "Content-Length: 0\n\n");
+
+  pjsip_rx_data* rdata = build_rxdata(str, _tp_default, main_pool);
+  parse_rxdata(rdata);
+
+  pj_str_t header_name = pj_str("Reject-Contact");
+  pjsip_accept_contact_hdr* hdr =
+      (pjsip_accept_contact_hdr*)pjsip_msg_find_hdr_by_name(rdata->msg_info.msg,
+                                                            &header_name,
+                                                            NULL);
+  EXPECT_NE(hdr, (pjsip_accept_contact_hdr*)NULL);
+  EXPECT_EQ(2u, pj_list_size(&hdr->feature_set));
+
+  hdr = (pjsip_accept_contact_hdr*)pjsip_msg_find_hdr_by_name(rdata->msg_info.msg,
+                                                              &header_name,
+                                                              hdr->next);
+  EXPECT_NE(hdr, (pjsip_accept_contact_hdr*)NULL);
+  EXPECT_EQ(1u, pj_list_size(&hdr->feature_set));
+
+  pj_pool_release(main_pool);
+}
+
 TEST_F(SipParserTest, PAssociatedURI)
 {
   pj_pool_t *main_pool = pjsip_endpt_create_pool(stack_data.endpt, "rtd%p",


### PR DESCRIPTION
Hi Rob,

This PR complements your Accept-Contact PR #2064. Consequently, I believe you are the best person to review this.

In this fix, I have:

- Fixed the Reject-Contact header parser to allow parsing of headers with multiple rc-values.

- Merged the routines for parsing Accept-Contact and Reject-Contact headers into one common routine.  I think this makes sense since the routines are virtually the same with only minor differences. having a common routine also reduces the possibility of an error when the parser get updated in the future.

- Added a UT for parsing Reject-Contact header with multiple rc-values. Note that by combining the two routines, the extensive UTs that you have added as part of your fix test the Reject-Contact code as well.

I have tested the fix by running make full_test;