### PR TITLE
[Reviewer: Seb] Don't leak PJSIP transactions sending SIP messages

### DIFF
--- a/src/pjutils.cpp
+++ b/src/pjutils.cpp
@@ -1648,6 +1648,18 @@ pj_status_t PJUtils::respond_stateful(pjsip_endpoint* endpt,
 
   status = pjsip_tsx_send_msg(uas_tsx, tdata);
 
+  if (status != PJ_SUCCESS)
+  {
+    // The message is owned by the transaction, which will get a on_tsx_state
+    // callback. However, we still have a reference count if tsx_send_msg
+    // fails, which we should decrement, to prevent a leak.
+    pjsip_tx_data_dec_ref(tdata);
+
+    // Even if we failed to send, we should treat it as a success, as the
+    // message may be resent by the transaction owner.
+    status = PJ_SUCCESS;
+  }
+
   return status;
 }
 

--- a/src/pjutils.cpp
+++ b/src/pjutils.cpp
@@ -1173,6 +1173,7 @@ static void on_tsx_state(pjsip_transaction* tsx, pjsip_event* event)
 
             // We no longer care about the old tdata.
             pjsip_tx_data_dec_ref(old_tdata);
+            sss->tdata = tdata;
           }
           // LCOV_EXCL_STOP
 


### PR DESCRIPTION
Seb,

If we send a SIP request to another SIP node using `PJUtils::send_request`, e.g. Third Party Registrations, if `pjsip_tsx_send_msg` fails, we can leak the `pjsip_tx_data`'s pool, which leaks a bunch of memory.

This is because we `pjsip_tsx_send_msg` will not decrement the reference count isn't decremented if pjsip_tsx_send_msg fails.

I've written further detail on exactly what semantics are of the memory management, and why this is the right thing to do inline. There's no current UTs for pjutils.

This is conceptually a follow on to https://github.com/Metaswitch/sprout/pull/2001

I've tested with a long low load, under massif, and I'm now running a longer stress test with a higher load to test this further.