### PR TITLE
[Reviewer: Alex] Log IMS Charging IDs to SAS from the I-CSCF

### DIFF
--- a/include/pjutils.h
+++ b/include/pjutils.h
@@ -247,6 +247,8 @@ void create_random_token(size_t length, std::string& token);
 
 std::string get_header_value(pjsip_hdr*);
 
+void mark_icid(const SAS::TrailId trail, pjsip_msg* msg);
+
 void mark_sas_call_branch_ids(const SAS::TrailId trail,
                               pjsip_msg* msg,
                               const std::vector<std::string>& cids = std::vector<std::string>());

--- a/src/icscfsproutlet.cpp
+++ b/src/icscfsproutlet.cpp
@@ -754,6 +754,11 @@ void ICSCFSproutletTsx::on_rx_initial_request(pjsip_msg* req)
     }
 
     PJUtils::add_route_header(req, scscf_sip_uri, get_pool(req));
+
+    // We might be invoking a directly attached AS here, so we should log the
+    // ICID if it exists
+    PJUtils::mark_icid(trail(), req);
+
     send_request(req);
   }
   else if ((uri_class == OFFNET_SIP_URI) ||

--- a/src/pjutils.cpp
+++ b/src/pjutils.cpp
@@ -1743,6 +1743,27 @@ std::string PJUtils::get_header_value(pjsip_hdr* header)
   return std::string(buf2, len);
 }
 
+// Add SAS marker for the specified message's P-Charging-Vector IMS Charging ID
+// for B2BUA AS correlation.
+void PJUtils::mark_icid(const SAS::TrailId trail, pjsip_msg* msg)
+{
+  pjsip_p_c_v_hdr* pcv = (pjsip_p_c_v_hdr*)pjsip_msg_find_hdr_by_name(msg,
+                                                                      &STR_P_C_V,
+                                                                      NULL);
+
+  if (pcv)
+  {
+    TRC_DEBUG("Logging ICID marker %.*s for B2BUA AS correlation", pcv->icid.slen, pcv->icid.ptr);
+    SAS::Marker icid_marker(trail, MARKER_ID_IMS_CHARGING_ID, 1u);
+    icid_marker.add_var_param(pcv->icid.slen, pcv->icid.ptr);
+    SAS::report_marker(icid_marker, SAS::Marker::Scope::Trace);
+  }
+  else
+  {
+    TRC_DEBUG("No P-Charging-Vector header (so can't log ICID for B2BUA correlation)");
+  }
+}
+
 /// Add SAS markers for the specified call IDs and branch IDs on the message
 // (msg must not be NULL).
 void PJUtils::mark_sas_call_branch_ids(const SAS::TrailId trail, pjsip_msg* msg, const std::vector<std::string>& cids)

--- a/src/scscfsproutlet.cpp
+++ b/src/scscfsproutlet.cpp
@@ -989,20 +989,8 @@ void SCSCFSproutletTsx::retrieve_odi_and_sesscase(pjsip_msg* req)
     // we'll log an ICID marker to correlate the trails.
     if (!_as_chain_link.is_set())
     {
-      pjsip_p_c_v_hdr* pcv = (pjsip_p_c_v_hdr*)pjsip_msg_find_hdr_by_name(req,
-                                                                          &STR_P_C_V,
-                                                                          NULL);
-      if (pcv)
-      {
-        TRC_DEBUG("No ODI token, or invalid ODI token, on request - logging ICID marker %.*s for B2BUA AS correlation", pcv->icid.slen, pcv->icid.ptr);
-        SAS::Marker icid_marker(trail(), MARKER_ID_IMS_CHARGING_ID, 1u);
-        icid_marker.add_var_param(pcv->icid.slen, pcv->icid.ptr);
-        SAS::report_marker(icid_marker, SAS::Marker::Scope::Trace);
-      }
-      else
-      {
-        TRC_DEBUG("No ODI token, or invalid ODI token, on request, and no P-Charging-Vector header (so can't log ICID for correlation)");
-      }
+      TRC_DEBUG("No ODI token, or invalid ODI token, on request");
+      PJUtils::mark_icid(trail(), req);
     }
 
     TRC_DEBUG("Got our Route header, session case %s, OD=%s",

--- a/src/ut/icscfsproutlet_test.cpp
+++ b/src/ut/icscfsproutlet_test.cpp
@@ -20,6 +20,7 @@
 #include "utils.h"
 #include "test_utils.hpp"
 #include "icscfsproutlet.h"
+#include "mock_sas.h"
 #include "fakehssconnection.hpp"
 #include "test_interposer.hpp"
 #include "sproutletproxy.h"
@@ -121,6 +122,23 @@ public:
 
     delete _icscf_proxy; _icscf_proxy = NULL;
     delete _icscf_sproutlet; _icscf_sproutlet = NULL;
+  }
+
+  /// Check that we logged an ICID to SAS.
+  void check_sas_correlator_icid(std::string value, bool present=true)
+  {
+    bool found_value = false;
+    std::vector<MockSASMessage*> markers = mock_sas_find_marker_multiple(MARKER_ID_IMS_CHARGING_ID);
+    for (MockSASMessage* marker : markers)
+    {
+      EXPECT_EQ(marker->var_params.size(), 1u);
+      if (marker->var_params[0] == value)
+      {
+        found_value = true;
+        break;
+      }
+    }
+    EXPECT_EQ(found_value, present);
   }
 
 protected:
@@ -1591,8 +1609,10 @@ TEST_F(ICSCFSproutletTest, RouteOrigInviteHSSServerName)
                               "{\"result-code\": 2001,"
                               " \"scscf\": \"sip:scscf1.homedomain:5058;transport=TCP\"}");
 
-  // Inject a INVITE request with orig in the Route header and a P-Served-User
-  // header.
+  // Inject a INVITE request with orig in the Route header, a P-Served-User
+  // header and a P-Charging-Vector header. Check the ICID from the PCV is
+  // logged to SAS.
+  mock_sas_collect_messages(true);
   Message msg1;
   msg1._first_hop = true;
   msg1._method = "INVITE";
@@ -1600,9 +1620,13 @@ TEST_F(ICSCFSproutletTest, RouteOrigInviteHSSServerName)
   msg1._extra = "Contact: sip:6505551000@" +
                 tp->to_string(true) +
                 ";ob;expires=300;+sip.ice;reg-id=1;+sip.instance=\"<urn:uuid:00000000-0000-0000-0000-b665231f1213>\"\r\n";
-  msg1._extra += "P-Served-User: <sip:6505551000@homedomain>";
+  msg1._extra += "P-Served-User: <sip:6505551000@homedomain>\r\n";
+  msg1._extra += "P-Charging-Vector: icid-value=4815152542";
   msg1._route = "Route: <sip:homedomain;orig>";
   inject_msg(msg1.get_request(), tp);
+  check_sas_correlator_icid("4815152542");
+  mock_sas_discard_messages();
+  mock_sas_collect_messages(false);
 
   // Expecting 100 Trying and forwarded INVITE
   ASSERT_EQ(2, txdata_count());


### PR DESCRIPTION
Alex,

I think you are best placed to review this given we discussed the fix?

If we are invoking a server to handle a non REGISTER event, it's useful to log
the IMS Charging Identifier in the P-Charging-Vector as this allows us to link
up calls across B2BUAs via directly attached AS.

This should then correlate with the same marker raised by an S-CSCF when it receives a new request.

I haven't live tested this, but I have updated the UT to check the correct marker is raised.