### PR TITLE
[Reviewer: RND] Load records from /etc/clearwater/dns.json

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -9,6 +9,7 @@ SPROUT_COMMON_SOURCES := logger.cpp \
                          stack.cpp \
                          dnsparser.cpp \
                          dnscachedresolver.cpp \
+                         static_dns_cache.cpp \
                          baseresolver.cpp \
                          sipresolver.cpp \
                          bono.cpp \


### PR DESCRIPTION
I need to make similar changes in:

- [ ] homestead
- [ ] ralf

I don't think it's valuable to add this functionality to:

- [ ] bifrost
- [ ] cedar
- [ ] clearwater-fv-test
- [ ] mellon
- [ ] memento
- [ ] MVSE