### PR TITLE
Remove TimerHandler

### DIFF
--- a/include/handlers.h
+++ b/include/handlers.h
@@ -21,27 +21,6 @@
 #include "impistore.h"
 #include "fifcservice.h"
 
-/// Common factory for all handlers that deal with timer pops. This is
-/// a subclass of SpawningHandler that requests HTTP flows to be
-/// logged at detail level.
-template<class H, class C>
-class TimerHandler : public HttpStackUtils::SpawningHandler<H, C>
-{
-public:
-  TimerHandler(C* cfg) : HttpStackUtils::SpawningHandler<H, C>(cfg)
-  {}
-
-  virtual ~TimerHandler() {}
-
-  HttpStack::SasLogger* sas_logger(HttpStack::Request& req)
-  {
-    // Note that we use a Chronos SAS Logger here even though this TimerHandler
-    // isn't specific to Chronos.  In reality there isn't anything Chronos
-    // specific about the logger, but we should fix up the naming in future
-    // when we actually support multiple timer services.
-    return &HttpStackUtils::CHRONOS_SAS_LOGGER;
-  }
-};
 
 /// Base AoRTimeoutTask class for tasks that implement AoR timeout callbacks
 /// from specific timer services.


### PR DESCRIPTION
Moved TimerHandler into cpp-common during develpment of sdm-refactor, which isn't merged yet.