### PR TITLE
[Reviewer: Alex] Retired max_session_expires parameter

### DIFF
--- a/include/cfgoptions.h
+++ b/include/cfgoptions.h
@@ -60,7 +60,6 @@ struct options
   std::string                          external_icscf_uri;
   int                                  record_routing_model;
   int                                  default_session_expires;
-  int                                  max_session_expires;
   int                                  target_latency_us;
   std::string                          local_host;
   std::string                          public_host;

--- a/include/stack.h
+++ b/include/stack.h
@@ -70,7 +70,6 @@ struct stack_data_struct
   bool record_route_on_diversion;
 
   int default_session_expires;
-  int max_session_expires;
   int sip_tcp_connect_timeout;
   int sip_tcp_send_timeout;
   bool enable_orig_sip_to_tel_coerce;
@@ -149,7 +148,6 @@ extern pj_status_t init_stack(const std::string& sas_system_name,
                               SIPResolver* sipresolver,
                               int record_routing_model,
                               const int default_session_expires,
-                              const int max_session_expires,
                               const int sip_tcp_connect_timeout,
                               const int sip_tcp_send_timeout,
                               QuiescingManager *quiescing_mgr,

--- a/sprout-base.root/etc/init.d/sprout
+++ b/sprout-base.root/etc/init.d/sprout
@@ -180,7 +180,6 @@ get_daemon_args()
         [ -z "$sprout_min_token_rate" ] || min_token_rate_arg="--min-token-rate=$sprout_min_token_rate"
         [ -z "$sprout_max_token_rate" ] || max_token_rate_arg="--max-token-rate=$sprout_max_token_rate"
         [ -z "$exception_max_ttl" ] || exception_max_ttl_arg="--exception-max-ttl=$exception_max_ttl"
-        [ -z "$max_session_expires" ] || max_session_expires_arg="--max-session-expires=$max_session_expires"
         [ -z "$local_site_name" ] || local_site_name_arg="--local-site-name=$local_site_name"
         [ -z "$sprout_impi_store" ] || impi_store_arg="--impi-store=$sprout_impi_store"
         [ -z "$chronos_hostname" ] || chronos_hostname_arg="--chronos-hostname=$chronos_hostname"
@@ -212,7 +211,6 @@ get_daemon_args()
                      --http-threads=$num_http_threads
                      --record-routing-model=$sprout_rr_level
                      --default-session-expires=$default_session_expires
-                     $max_session_expires_arg
                      $target_latency_us_arg
                      $max_tokens_arg
                      $init_token_rate_arg

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -102,7 +102,6 @@ enum OptionTypes
   OPT_MIN_TOKEN_RATE,
   OPT_MAX_TOKEN_RATE,
   OPT_EXCEPTION_MAX_TTL,
-  OPT_MAX_SESSION_EXPIRES,
   OPT_SIP_BLACKLIST_DURATION,
   OPT_HTTP_BLACKLIST_DURATION,
   OPT_ASTAIRE_BLACKLIST_DURATION,
@@ -162,7 +161,6 @@ const static struct pj_getopt_option long_opt[] =
   { "hss",                          required_argument, 0, 'H'},
   { "record-routing-model",         required_argument, 0, 'C'},
   { "default-session-expires",      required_argument, 0, OPT_DEFAULT_SESSION_EXPIRES},
-  { "max-session-expires",          required_argument, 0, OPT_MAX_SESSION_EXPIRES},
   { "target-latency-us",            required_argument, 0, OPT_TARGET_LATENCY_US},
   { "xdms",                         required_argument, 0, 'X'},
   { "ralf",                         required_argument, 0, 'G'},
@@ -325,9 +323,6 @@ static void usage(void)
        "                            The maximum allowed subscription period (in seconds)\n"
        "     --default-session-expires <expiry>\n"
        "                            The session expiry period to request\n"
-       "                            (in seconds. Min 90. Defaults to 600)\n"
-       "     --max-session-expires <expiry>\n"
-       "                            The maximum allowed session expiry period.\n"
        "                            (in seconds. Min 90. Defaults to 600)\n"
        "     --target-latency-us <usecs>\n"
        "                            Target latency above which throttling applies (default: 100000)\n"
@@ -951,25 +946,6 @@ static pj_status_t init_options(int argc, char* argv[], struct options* options)
           TRC_WARNING("Invalid value for default session expiry: '%s'. "
                       "The default value of %d will be used.",
                       pj_optarg, options->default_session_expires);
-        }
-      }
-      break;
-
-    case OPT_MAX_SESSION_EXPIRES:
-      {
-        int max_session_expires;
-        bool rc = validated_atoi(pj_optarg, max_session_expires);
-
-        if ((rc) && max_session_expires >= MIN_SESSION_EXPIRES)
-        {
-          options->max_session_expires = max_session_expires;
-          TRC_INFO("Max session expiry time set to %d", max_session_expires);
-        }
-        else
-        {
-          TRC_WARNING("Invalid value for max session expiry: '%s'. "
-                      "The default value of %d will be used.",
-                      pj_optarg, options->max_session_expires);
         }
       }
       break;
@@ -1665,7 +1641,6 @@ int main(int argc, char* argv[])
   opt.sas_server = "0.0.0.0";
   opt.record_routing_model = 1;
   opt.default_session_expires = 10 * 60;
-  opt.max_session_expires = 10 * 60;
   opt.worker_threads = 1;
   opt.analytics_enabled = PJ_FALSE;
   opt.http_address = "127.0.0.1";
@@ -2036,7 +2011,6 @@ int main(int argc, char* argv[])
                       sip_resolver,
                       opt.record_routing_model,
                       opt.default_session_expires,
-                      opt.max_session_expires,
                       opt.sip_tcp_connect_timeout,
                       opt.sip_tcp_send_timeout,
                       quiescing_mgr,

--- a/src/stack.cpp
+++ b/src/stack.cpp
@@ -622,7 +622,6 @@ pj_status_t init_stack(const std::string& system_name,
                        SIPResolver* sipresolver,
                        int record_routing_model,
                        const int default_session_expires,
-                       const int max_session_expires,
                        const int sip_tcp_connect_timeout,
                        const int sip_tcp_send_timeout,
                        QuiescingManager *quiescing_mgr_arg,
@@ -655,7 +654,6 @@ pj_status_t init_stack(const std::string& system_name,
 
   // Copy other functional options to stack data.
   stack_data.default_session_expires = default_session_expires;
-  stack_data.max_session_expires = max_session_expires;
   stack_data.sip_tcp_connect_timeout = sip_tcp_connect_timeout;
   stack_data.sip_tcp_send_timeout = sip_tcp_send_timeout;
   stack_data.enable_orig_sip_to_tel_coerce = enable_orig_sip_to_tel_coerce;

--- a/src/ut/siptest.cpp
+++ b/src/ut/siptest.cpp
@@ -116,7 +116,6 @@ void SipTest::SetUpTestCase()
   stack_data.record_route_on_initiation_of_originating = true;
   stack_data.record_route_on_completion_of_terminating = true;
   stack_data.default_session_expires = 60 * 10;
-  stack_data.max_session_expires = 90 * 10;
   stack_data.addr_family = AF_INET;
   stack_data.sipresolver = new SIPResolver(&_dnsresolver);
   stack_data.sprout_hostname = "sprout.homedomain";


### PR DESCRIPTION
Hi Alex, could you please review this?

This PR removes the `max_session_expires` parameter from the sprout code (this is the only repo that references that parameter). The code that used the parameter was retired already in 2015 (see https://github.com/Metaswitch/sprout/commit/8666b17cc85c64b4b19bb629da86eec4774ccd1e#diff-ec6a7d93b16090d00cb1274ef494ac04).

I have tested the fix by patching a box and restarting sprout with the "max_session_expires" option set in shared_config. Doing "ps -ef | grep sprout" showed that the option wasn't picked up during startup. I also tried putting a test call through the system to see if everything works as it should.
