### PR TITLE
[Review KH1]: No 3rd part register for fetch binding

### DIFF
--- a/src/registrarsproutlet.cpp
+++ b/src/registrarsproutlet.cpp
@@ -865,9 +865,11 @@ void RegistrarSproutletTsx::process_register_request(pjsip_msg *req)
   // ID). hss->get_subscription_data should be enhanced to provide an
   // appropriate data structure (representing the ServiceProfile
   // nodes) and we should loop through that. Don't send any register that
-  // contained emergency registrations to the application servers.
+  // contained emergency registrations to the application servers, or that
+  // is a 'fetch binding' REGISTER (i.e. a query for the current bindings,
+  // not an attempt to change registration state).
 
-  if (num_emergency_bindings == 0)
+  if ((num_emergency_bindings == 0) && (num_contacts > 0))
   {
     // If the public ID is unbarred, we use that for third party registers. If
     // it is barred, we use the default URI.

--- a/src/ut/registrar_test.cpp
+++ b/src/ut/registrar_test.cpp
@@ -1250,6 +1250,32 @@ TEST_F(RegistrarTest, AppServersWithMultipartBody)
   EXPECT_EQ("Service-Route: <sip:scscf.sprout.homedomain:5058;transport=TCP;lr;orig>", get_headers(out, "Service-Route"));
   EXPECT_EQ(1,((SNMP::FakeSuccessFailCountTable*)SNMP::FAKE_REGISTRATION_STATS_TABLES.init_reg_tbl)->_attempts);
   EXPECT_EQ(1,((SNMP::FakeSuccessFailCountTable*)SNMP::FAKE_REGISTRATION_STATS_TABLES.init_reg_tbl)->_successes);
+
+  free_txdata();
+
+  // Repeat the test for a 'fetch bindings' REGISTER (i.e. one with no Contact header).  Verify that no
+  // 3rd party REGISTER is sent in this case.
+  SCOPED_TRACE("REGISTER (2)");
+  Message msg2;
+  msg2._contact = "";
+  SCOPED_TRACE("REGISTER (about to inject)");
+  inject_msg(msg2.get());
+  SCOPED_TRACE("REGISTER (injected)");
+  ASSERT_EQ(1, txdata_count());
+  
+  SCOPED_TRACE("REGISTER (200 OK)");
+  out = current_txdata()->msg;
+  EXPECT_EQ(200, out->line.status.code);
+  EXPECT_EQ("OK", str_pj(out->line.status.reason));
+  EXPECT_EQ("Supported: outbound", get_headers(out, "Supported"));
+  EXPECT_EQ("Require: outbound", get_headers(out, "Require")); // because we have path
+  EXPECT_EQ(msg._path, get_headers(out, "Path"));
+  EXPECT_EQ("P-Associated-URI: <sip:6505550231@homedomain>", get_headers(out, "P-Associated-URI"));
+  EXPECT_EQ("Service-Route: <sip:scscf.sprout.homedomain:5058;transport=TCP;lr;orig>", get_headers(out, "Service-Route"));
+
+  EXPECT_EQ(1,((SNMP::FakeSuccessFailCountTable*)SNMP::FAKE_THIRD_PARTY_REGISTRATION_STATS_TABLES.init_reg_tbl)->_attempts);
+  EXPECT_EQ(1,((SNMP::FakeSuccessFailCountTable*)SNMP::FAKE_THIRD_PARTY_REGISTRATION_STATS_TABLES.init_reg_tbl)->_successes);
+
   free_txdata();
 }
 


### PR DESCRIPTION
Hi Krista

Can you sign off on this fix for me?  The problem here is that, if a "fetch bindings" REGISTER (one with no Contact headers) is received for an IMPU that has ASes that need 3rd party registration, Sprout forwards the REGISTER to the AS with an expires value of 0 (because the incoming REGISTER didn't include an Expires), which results in, e.g., call drops because the AS thinks its being told to deregister the sub.  

My view is that we should suppress forwarding of 3rd party REGISTERs if the REGISTER is a "fetch bindings" REGISTER, because these REGISTERs are just querying the bindings - they aren't intended to change state - so there's no need to forward them to the AS.

Tested live and via the UT.  Note that I deliberately amended an existing UT (rather than write a new one).  My concern was that a UT that said "check that we don't forward to ASes under this situation" is more likely to decay than a UT that says "having issued a regular REGISTER that prompted a 3rd party REGISTER, send in a 'fetch bindings' REGISTER that _doesn't_ result in a 3rd party REGISTER", because we know that the test setup in that case should normally cause the 3rd part register to be emitted.  

Actually, I initially implemented a separate UT, saw that a 3rd party REGISTER wasn't generated and only at the last minute double checked, discovering that the initial setup was bugged, so the suppression wasn't down to my change.