### PR TITLE
Chronos threading

### DIFF
--- a/src/chronoshandlers.cpp
+++ b/src/chronoshandlers.cpp
@@ -17,69 +17,6 @@
 #include "log.h"
 #include "pjutils.h"
 
-void ChronosAoRTimeoutTask::run()
-{
-  if (_req.method() != htp_method_POST)
-  {
-    send_http_reply(HTTP_BADMETHOD);
-    delete this;
-    return;
-  }
-
-  HTTPCode rc = parse_response(_req.get_rx_body());
-
-  if (rc != HTTP_OK)
-  {
-    TRC_DEBUG("Unable to parse response from Chronos");
-    send_http_reply(rc);
-    delete this;
-    return;
-  }
-
-  send_http_reply(HTTP_OK);
-
-  handle_response();
-}
-
-HTTPCode ChronosAoRTimeoutTask::parse_response(std::string body)
-{
-  rapidjson::Document doc;
-  std::string json_str = body;
-  doc.Parse<0>(json_str.c_str());
-
-  if (doc.HasParseError())
-  {
-    TRC_DEBUG("Failed to parse opaque data as JSON: %s\nError: %s",
-              json_str.c_str(),
-              rapidjson::GetParseError_En(doc.GetParseError()));
-    return HTTP_BAD_REQUEST;
-  }
-
-  try
-  {
-    JSON_GET_STRING_MEMBER(doc, "aor_id", _aor_id);
-  }
-  catch (JsonFormatError err)
-  {
-    TRC_DEBUG("Badly formed opaque data (missing aor_id)");
-    return HTTP_BAD_REQUEST;
-  }
-
-
-  return HTTP_OK;
-}
-
-void ChronosAoRTimeoutTask::handle_response()
-{
-  SAS::Marker start_marker(trail(), MARKER_ID_START, 1u);
-  SAS::report_marker(start_marker);
-
-  process_aor_timeout(_aor_id);
-
-  SAS::Marker end_marker(trail(), MARKER_ID_END, 1u);
-  SAS::report_marker(end_marker);
-}
-
 void ChronosAuthTimeoutTask::run()
 {
   if (_req.method() != htp_method_POST)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -90,7 +90,6 @@ extern "C" {
 #include "sproutlet_options.h"
 #include "astaire_impistore.h"
 
-
 enum OptionTypes
 {
   OPT_DEFAULT_SESSION_EXPIRES=256+1,
@@ -1386,45 +1385,6 @@ void reg_httpthread_with_pjsip(evhtp_t * htp, evthr_t * httpthread, void * arg)
   }
 }
 
-
-/// @brief An HTTP handler that runs all work received on a PJSIP worker thread.
-///
-/// This works by wrapping another handler. The wrapper ensures that the wrapped
-/// handler is executed on the thread pool.
-class RunOnPJSIPThreadPoolHandler : public HttpStack::HandlerInterface
-{
-public:
-  /// Constructor.
-  ///
-  /// @param [in] handler - The handler to execute on the thread pool.
-  RunOnPJSIPThreadPoolHandler(HttpStack::HandlerInterface* handler) : _handler(handler) {}
-
-  /// Process a single HTTP request by running it on the thread pool.
-  ///
-  /// @param [in] req   - The received request.
-  /// @param [in] trail - The SAS trail ID.
-  void process_request(HttpStack::Request& req, SAS::TrailId trail)
-  {
-    PJUtils::run_callback_on_worker_thread(
-      [this, req, trail] () mutable {
-        _handler->process_request(req, trail);
-      },
-      false);
-  }
-
-  /// Get the SAS logger for this request. This is just passed through to the
-  /// underlying handler.
-  HttpStack::SasLogger* sas_logger(HttpStack::Request& req)
-  {
-    return _handler->sas_logger(req);
-  }
-
-private:
-  /// The underlying handler that this handler wraps.
-  HttpStack::HandlerInterface* _handler;
-};
-
-
 // Objects that must be shared with dynamically linked sproutlets must be
 // globally scoped.
 LoadMonitor* load_monitor = NULL;
@@ -2406,7 +2366,6 @@ int main(int argc, char* argv[])
   GetSubscriptionsTask::Config get_subscriptions_config(subscriber_manager);
 
   HttpStackUtils::TimerHandler<ChronosAoRTimeoutTask, AoRTimeoutTask::Config> aor_timeout_handler(&aor_timeout_config);
-  RunOnPJSIPThreadPoolHandler aor_timeout_handler_with_thread_pool(&aor_timeout_handler);
   HttpStackUtils::TimerHandler<ChronosAuthTimeoutTask, AuthTimeoutTask::Config> auth_timeout_handler(&auth_timeout_config);
   HttpStackUtils::SpawningHandler<DeregistrationTask, DeregistrationTask::Config> deregistration_handler(&deregistration_config);
   HttpStackUtils::SpawningHandler<PushProfileTask, PushProfileTask::Config> push_profile_handler(&push_profile_config);
@@ -2424,7 +2383,7 @@ int main(int argc, char* argv[])
       http_stack_sig->register_handler("^/ping$",
                                        &ping_handler);
       http_stack_sig->register_handler("^/timers$",
-                                       &aor_timeout_handler_with_thread_pool);
+                                       &aor_timeout_handler);
       http_stack_sig->register_handler("^/authentication-timeout$",
                                        &auth_timeout_handler);
       http_stack_sig->register_handler("^/registrations?*$",

--- a/src/ut/subscriber_manager_test.cpp
+++ b/src/ut/subscriber_manager_test.cpp
@@ -1211,7 +1211,7 @@ TEST_F(SubscriberManagerTest, TestHandleTimerPop)
   EXPECT_CALL(*_notify_sender, send_notifys(DEFAULT_ID,
                                             AoRsMatch(*get_aor),
                                             AoRsMatch(*empty_aor),
-                                            SubscriberDataUtils::EventTrigger::USER,
+                                            SubscriberDataUtils::EventTrigger::TIMEOUT,
                                             _,
                                             _));
   // Call handle timer pops on SM.


### PR DESCRIPTION
Avoid using PJSIP callback in S4, by creating a Callback class. Not live-tested but full_test passed.

Together with https://github.com/Metaswitch/clearwater-s4/pull/21