### PR TITLE
Split the SM callback interfaces into separate classes

### DIFF
--- a/include/subscriber_manager.h
+++ b/include/subscriber_manager.h
@@ -30,13 +30,13 @@ extern "C" {
 #include "ifchandler.h"
 #include "aor.h"
 #include "s4.h"
-#include "base_subscriber_manager.h"
 #include "notify_sender.h"
 #include "registration_sender.h"
 #include "subscriber_data_utils.h"
 
 // SDM-REFACTOR-TODO: Add Doxygen comments.
-class SubscriberManager : public BaseSubscriberManager
+class SubscriberManager : public S4::TimerPopConsumer,
+                          public RegistrationSender::DeregistrationEventConsumer
 {
 public:
   /// SubscriberManager constructor. It calls the S4 to store a reference to

--- a/src/registration_sender.cpp
+++ b/src/registration_sender.cpp
@@ -32,10 +32,10 @@ RegistrationSender::~RegistrationSender()
 {
 }
 
-void RegistrationSender::initialize(BaseSubscriberManager* subscriber_manager)
+void RegistrationSender::register_dereg_event_consumer(DeregistrationEventConsumer* dereg_event_consumer)
 {
   TRC_DEBUG("Initializing RegistrationSender with reference to this subscriber manager");
-  _subscriber_manager = subscriber_manager;
+  _dereg_event_consumer = dereg_event_consumer;
 }
 
 void RegistrationSender::register_with_application_servers(pjsip_msg* received_register_message,
@@ -440,7 +440,7 @@ void RegistrationSender::send_register_to_as(pjsip_msg* received_register_msg,
   // register callback is triggered.
   ThirdPartyRegData* tsxdata = new ThirdPartyRegData;
   tsxdata->registration_sender = this;
-  tsxdata->subscriber_manager = _subscriber_manager;
+  tsxdata->dereg_event_consumer = _dereg_event_consumer;
   tsxdata->default_handling = as.default_handling;
   tsxdata->trail = trail;
   tsxdata->served_user = served_user;
@@ -498,9 +498,9 @@ void RegistrationSender::RegisterCallback::run()
     // currently registered public user identity" - i.e. all bindings
     if (_reg_data->expires > 0)
     {
-      _reg_data->subscriber_manager->deregister_subscriber(_reg_data->served_user,
-                                                           SubscriberDataUtils::EventTrigger::ADMIN,
-                                                           _reg_data->trail);
+      _reg_data->dereg_event_consumer->deregister_subscriber(_reg_data->served_user,
+                                                             SubscriberDataUtils::EventTrigger::ADMIN,
+                                                             _reg_data->trail);
     }
   }
 

--- a/src/subscriber_manager.cpp
+++ b/src/subscriber_manager.cpp
@@ -9,7 +9,6 @@
  * Metaswitch Networks in a separate written agreement.
  */
 
-#include "base_subscriber_manager.h"
 #include "subscriber_manager.h"
 #include "aor_utils.h"
 #include "pjutils.h"
@@ -27,12 +26,12 @@ SubscriberManager::SubscriberManager(S4* s4,
 {
   if (_s4 != NULL)
   {
-    _s4->initialize(this);
+    _s4->register_timer_pop_consumer(this);
   }
 
   if (_registration_sender != NULL)
   {
-    _registration_sender->initialize(this);
+    _registration_sender->register_dereg_event_consumer(this);
   }
 }
 

--- a/src/ut/registration_sender_test.cpp
+++ b/src/ut/registration_sender_test.cpp
@@ -36,7 +36,7 @@ public:
                                                   _fifc_service,
                                                   &SNMP::FAKE_THIRD_PARTY_REGISTRATION_STATS_TABLES,
                                                   true);
-    _registration_sender->initialize(_subscriber_manager);
+    _registration_sender->register_dereg_event_consumer(_subscriber_manager);
   }
 
   virtual ~RegistrationSenderTest()

--- a/src/ut/s4_test.cpp
+++ b/src/ut/s4_test.cpp
@@ -77,7 +77,7 @@ class BasicS4Test : public ::testing::Test
                  _aor_store,
                  {_remote_s4_1, _remote_s4_2});
     _mock_sm = new MockSubscriberManager();
-    _s4->initialize(_mock_sm);
+    _s4->register_timer_pop_consumer(_mock_sm);
 
     cwtest_completely_control_time();
   }


### PR DESCRIPTION
Sathiyan, please can you review this change to split the SM callback interfaces into two classes (and some associated renaming)? 

Tested in UTs, which all pass (barring the valgrind errors I just messaged you about). 