### PR TITLE
[Reviewer: CJR] Fixed marker ID typo

### DIFF
--- a/src/authenticationsproutlet.cpp
+++ b/src/authenticationsproutlet.cpp
@@ -685,7 +685,7 @@ void AuthenticationSproutletTsx::create_challenge(pjsip_digest_credential* crede
     std::string opaque;
     opaque.assign(buf, sizeof(buf));
     TRC_DEBUG("Log opaque value %s to SAS as a generic correlator", opaque.c_str());
-    SAS::Marker opaque_marker(trail(), MARKED_ID_GENERIC_CORRELATOR, 1u);
+    SAS::Marker opaque_marker(trail(), MARKER_ID_GENERIC_CORRELATOR, 1u);
     opaque_marker.add_static_param((uint32_t)UniquenessScopes::DIGEST_OPAQUE);
     opaque_marker.add_var_param(opaque);
     SAS::report_marker(opaque_marker, SAS::Marker::Scope::Trace);
@@ -1051,7 +1051,7 @@ void AuthenticationSproutletTsx::on_rx_initial_request(pjsip_msg* req)
     {
       std::string opaque = PJUtils::pj_str_to_string(&credentials->opaque);
       TRC_DEBUG("Log opaque value %s to SAS as a generic correlator", opaque.c_str());
-      SAS::Marker opaque_marker(trail(), MARKED_ID_GENERIC_CORRELATOR, 2u);
+      SAS::Marker opaque_marker(trail(), MARKER_ID_GENERIC_CORRELATOR, 2u);
       opaque_marker.add_static_param((uint32_t)UniquenessScopes::DIGEST_OPAQUE);
       opaque_marker.add_var_param(opaque);
       SAS::report_marker(opaque_marker, SAS::Marker::Scope::Trace);

--- a/src/bono.cpp
+++ b/src/bono.cpp
@@ -216,7 +216,7 @@ public:
   {
     if (_flush_required)
     {
-      SAS::Marker flush_marker(_trail, MARKED_ID_FLUSH);
+      SAS::Marker flush_marker(_trail, MARKER_ID_FLUSH);
       SAS::report_marker(flush_marker);
     }
   }

--- a/src/impistore.cpp
+++ b/src/impistore.cpp
@@ -296,7 +296,7 @@ void correlate_trail_to_challenge(ImpiStore::AuthChallenge* auth_challenge,
   // Report the correlator as a SAS marker, if it exists.
   if (auth_challenge->get_correlator() != "")
   {
-    SAS::Marker marker(trail, MARKED_ID_GENERIC_CORRELATOR, 3u);
+    SAS::Marker marker(trail, MARKER_ID_GENERIC_CORRELATOR, 3u);
     marker.add_static_param((uint32_t)UniquenessScopes::DIGEST_OPAQUE);
     marker.add_var_param(auth_challenge->get_correlator());
     SAS::report_marker(marker, SAS::Marker::Scope::Trace);

--- a/src/sproutletproxy.cpp
+++ b/src/sproutletproxy.cpp
@@ -729,7 +729,7 @@ SproutletProxy::UASTsx::~UASTsx()
     //
     // For non-ACK transactions, there isn't any harm in logging an extra flush
     // marker after the end marker.
-    SAS::Marker flush(_trail, MARKED_ID_FLUSH);
+    SAS::Marker flush(_trail, MARKER_ID_FLUSH);
     SAS::report_marker(flush);
   }
 
@@ -1355,7 +1355,7 @@ bool SproutletProxy::UASTsx::accept_sproutlet_match(SproutletMatch match,
     // boundary. If it is matched on another alias, we are attempting to route
     // to a specific Sproutlet, in which case we are not crossing such a
     // boundary.
-    if (!serve_remote_aliases && 
+    if (!serve_remote_aliases &&
         (alias == match.sproutlet->network_function()))
     {
       // If the Sproutlet was matched on its network function, and we are not


### PR DESCRIPTION
Update to be in line with typo fix in the sas-client. PR [here](https://github.com/Metaswitch/sas-client/pull/82).

Typo in commit message is intentionally ironic. 