### PR TITLE
Process timer pop callbacks on the PJSIP worker threads

### DIFF
--- a/include/subscriber_manager.h
+++ b/include/subscriber_manager.h
@@ -301,6 +301,9 @@ private:
                                HSSConnection::irs_info& irs_info,
                                SAS::TrailId trail);
 
+  void handle_timer_pop_internal(const std::string& aor_id,
+                                 SAS::TrailId trail);
+
 };
 
 #endif

--- a/src/subscriber_manager.cpp
+++ b/src/subscriber_manager.cpp
@@ -567,6 +567,14 @@ HTTPCode SubscriberManager::update_associated_uris(const std::string& aor_id,
 void SubscriberManager::handle_timer_pop(const std::string& aor_id,
                                          SAS::TrailId trail)
 {
+  PJUtils::run_callback_on_worker_thread([this, aor_id, trail]() {
+    return handle_timer_pop_internal(aor_id, trail);
+  });
+}
+
+void SubscriberManager::handle_timer_pop_internal(const std::string& aor_id,
+                                                  SAS::TrailId trail)
+{
   TRC_DEBUG("Handling a timer pop for AoR %s", aor_id.c_str());
 
   // Get the original AoR from S4.


### PR DESCRIPTION
Well that was easy (and I wasted a depressing amount of time failing to do something more complicated).

UTs pass. I can't easily test that the code is actually transferring to a new thread (since the PJUtils function detects when it is in Unit test and if it is, runs the callback on the current thread). 