### PR TITLE
[Reviewer: Seb] Route off-net calls to the BGCF when not doing ENUM

### DIFF
--- a/include/scscfsproutlet.h
+++ b/include/scscfsproutlet.h
@@ -349,7 +349,10 @@ private:
   void route_to_icscf(pjsip_msg* req);
 
   /// Route the request to the BGCF.
-  void route_to_bgcf(pjsip_msg* req);
+  ///
+  /// @param req      - The request to route
+  /// @param reason   - The SAS Event ID to log as the reason
+  void route_to_bgcf(pjsip_msg* req, int reason);
 
   /// Route the request to the terminating side S-CSCF.
   void route_to_term_scscf(pjsip_msg* req);
@@ -605,8 +608,7 @@ private:
   /// 400 Bad Request error (which also frees the request).
   ///
   /// @param req      - The request to reject
-  /// @param uri_str  - The URI string to add to the SAS log
-  void reject_invalid_uri(pjsip_msg* req, const std::string& uri_str);
+  void reject_invalid_uri(pjsip_msg* req);
 
   /// The S-CSCF URI for this transaction. This is used in the SAR sent to the
   /// HSS. This field should not be changed once it has been set by the

--- a/include/scscfsproutlet.h
+++ b/include/scscfsproutlet.h
@@ -604,11 +604,18 @@ private:
   /// Get the base request that the S-CSCF should use when retrying a request.
   pjsip_msg* get_base_request();
 
-  /// SAS logs that the next hop URI is invalid and rejects the request with a
+  /// SAS logs that the request URI is invalid and rejects the request with a
   /// 400 Bad Request error (which also frees the request).
   ///
   /// @param req      - The request to reject
   void reject_invalid_uri(pjsip_msg* req);
+
+  /// SAS logs that the next hop URI is invalid and rejects the request with a
+  /// 400 Bad Request error (which also frees the request).
+  ///
+  /// @param req         - The request to reject
+  /// @param invalid_uri - The URI which caused it to be rejected
+  void reject_invalid_uri(pjsip_msg* req, const std::string& invalid_uri);
 
   /// The S-CSCF URI for this transaction. This is used in the SAR sent to the
   /// HSS. This field should not be changed once it has been set by the

--- a/src/scscfsproutlet.cpp
+++ b/src/scscfsproutlet.cpp
@@ -630,7 +630,8 @@ void SCSCFSproutletTsx::on_rx_initial_request(pjsip_msg* req)
       else
       {
         // Invalid URI, so just reject the request
-        reject_invalid_uri(req);
+        std::string uri_str = PJUtils::uri_to_string(context, next_uri);
+        reject_invalid_uri(req, uri_str);
       }
     }
   }
@@ -2373,10 +2374,14 @@ pjsip_msg* SCSCFSproutletTsx::get_base_request()
 void SCSCFSproutletTsx::reject_invalid_uri(pjsip_msg* req)
 {
   std::string uri_str = PJUtils::uri_to_string(PJSIP_URI_IN_REQ_URI, req->line.req.uri);
+  reject_invalid_uri(req, uri_str);
+}
 
-  TRC_DEBUG("Rejecting request to invalid URI %s", uri_str.c_str());
+void SCSCFSproutletTsx::reject_invalid_uri(pjsip_msg* req, const std::string& invalid_uri)
+{
+  TRC_DEBUG("Rejecting request to invalid URI %s", invalid_uri.c_str());
   SAS::Event event(trail(), SASEvent::SCSCF_INVALID_URI, 0);
-  event.add_var_param(uri_str);
+  event.add_var_param(invalid_uri);
   SAS::report_event(event);
   pjsip_msg* rsp = create_response(req, PJSIP_SC_BAD_REQUEST);
   send_response(rsp);

--- a/src/ut/fakehssconnection.hpp
+++ b/src/ut/fakehssconnection.hpp
@@ -41,17 +41,22 @@ public:
                        std::string,
                        std::string = "",
                        std::string chargingaddrsxml = "");
-void set_impu_result_with_prev(const std::string&,
-                               const std::string&,
-                               const std::string&,
-                               const std::string&,
-                               std::string,
-                               std::string = "",
-                               std::string chargingaddrsxml = "");
-void delete_result(const std::string& url);
+  void set_impu_result_with_prev(const std::string&,
+                                 const std::string&,
+                                 const std::string&,
+                                 const std::string&,
+                                 std::string,
+                                 std::string = "",
+                                 std::string chargingaddrsxml = "");
+  void delete_result(const std::string& url);
   void set_rc(const std::string& url, long rc);
   void delete_rc(const std::string& url);
   bool url_was_requested(const std::string& url, const std::string& body);
+
+  int request_count()
+  {
+    return _calls.size();
+  }
 
   HTTPCode update_registration_state(const HSSConnection::irs_query& irs_query,
                                      HSSConnection::irs_info& irs_info,

--- a/src/ut/scscf_test.cpp
+++ b/src/ut/scscf_test.cpp
@@ -2263,7 +2263,7 @@ TEST_F(SCSCFTest, TestWithoutEnumUserPhone)
 
   // We only do ENUM on originating calls
   msg._route = "Route: <sip:sprout.homedomain;orig>";
-  msg._extra = "Record-Route: <sip:homedomain>\nP-Asserted-Identity: <sip:+16505551000@homedomain>";
+  msg._extra = "P-Asserted-Identity: <sip:+16505551000@homedomain>";
   add_host_mapping("ut.cw-ngv.com", "10.9.8.7");
   list<HeaderMatcher> hdrs;
 
@@ -2288,7 +2288,7 @@ TEST_F(SCSCFTest, TestWithoutEnumOffnet)
 
   // We only do ENUM on originating calls
   msg._route = "Route: <sip:sprout.homedomain;orig>";
-  msg._extra = "Record-Route: <sip:homedomain>\nP-Asserted-Identity: <sip:+16505551000@homedomain>";
+  msg._extra = "P-Asserted-Identity: <sip:+16505551000@homedomain>";
   add_host_mapping("ut.cw-ngv.com", "10.9.8.7");
   list<HeaderMatcher> hdrs;
 

--- a/src/ut/scscf_test.cpp
+++ b/src/ut/scscf_test.cpp
@@ -2233,7 +2233,7 @@ TEST_F(SCSCFTest, TestEnumNPBGCFTel)
 // We can run with no ENUM service - in this case we expect the Request-URI to
 // be unchanged (as there's no lookup which can change it) and for it to just
 // be routed normally to the I-CSCF.
-TEST_F(SCSCFTest, TestWithoutEnum)
+TEST_F(SCSCFTest, TestWithoutEnumUserPhone)
 {
   SCOPED_TRACE("");
 
@@ -2267,9 +2267,35 @@ TEST_F(SCSCFTest, TestWithoutEnum)
   add_host_mapping("ut.cw-ngv.com", "10.9.8.7");
   list<HeaderMatcher> hdrs;
 
-  // Skip the ACK and BYE on this request by setting the last
-  // parameter to false, as we're only testing Sprout functionality
   doSuccessfulFlow(msg, testing::MatchesRegex(".*+15108580271@10.114.61.213:5061;transport=tcp;.*"), hdrs);
+}
+
+TEST_F(SCSCFTest, TestWithoutEnumOffnet)
+{
+  SCOPED_TRACE("");
+
+  // Disable ENUM.
+  _scscf_sproutlet->_enum_service = NULL;
+
+  SCSCFMessage msg;
+  msg._to = "+15108580271";
+  msg._todomain = "ut.cw-ngv.com";
+
+  // IFCs for originating call
+  HSSConnection::irs_info irs_info_1;
+  setup_irs_info(irs_info_1, "+16505551000", "homedomain");
+  expect_get_subscriber_state(irs_info_1, "sip:+16505551000@homedomain");
+
+  // We only do ENUM on originating calls
+  msg._route = "Route: <sip:sprout.homedomain;orig>";
+  msg._extra = "Record-Route: <sip:homedomain>\nP-Asserted-Identity: <sip:+16505551000@homedomain>";
+  add_host_mapping("ut.cw-ngv.com", "10.9.8.7");
+  list<HeaderMatcher> hdrs;
+
+  doSuccessfulFlow(msg, testing::MatchesRegex(".*+15108580271@ut.cw-ngv.com.*"), hdrs);
+
+  // Check that we didn't send an LIR
+  ASSERT_EQ(_hss_connection->request_count(), 0);
 }
 
 /// Test a forked flow - setup phase.


### PR DESCRIPTION
If we aren't doing ENUM, and we have a URI which is already known to be
off-net, don't bother routing it to the I-CSCF which will need to perform an
LIR.