### PR TITLE
[Reviewer RJW2] Ensure PJSIP timers that are cancelled after they've popped do not make it into the sproutlets

### DIFF
--- a/include/sproutletproxy.h
+++ b/include/sproutletproxy.h
@@ -302,7 +302,8 @@ protected:
     virtual void on_tsx_state(pjsip_event* event);
 
     // A count of the number of pending Callbacks that are queued for this
-    // UASTsx. A non-zero count prevents the UASTsx from being destroyed
+    // UASTsx plus the number of outstanding PJSIP timers.
+    // A non-zero count prevents the UASTsx from being destroyed
     int _pending_callbacks = 0;
 
   private:

--- a/include/sproutletproxy.h
+++ b/include/sproutletproxy.h
@@ -302,7 +302,10 @@ protected:
     virtual void on_tsx_state(pjsip_event* event);
 
     // A count of the number of pending Callbacks that are queued for this
-    // UASTsx plus the number of outstanding PJSIP timers.
+    // UASTsx plus the number of outstanding timer callbacks, where this
+    // includes timer callbacks outstanding in PJSIP, and timer callbacks
+    // which have been popped by PJSIP, but whose callback is awaiting 
+    // scheduling on a worker thread.
     // A non-zero count prevents the UASTsx from being destroyed
     int _pending_callbacks = 0;
 

--- a/src/scscfsproutlet.cpp
+++ b/src/scscfsproutlet.cpp
@@ -791,18 +791,34 @@ void SCSCFSproutletTsx::on_rx_response(pjsip_msg* rsp, int fork_id)
           bypass_As.add_var_param(st_code == PJSIP_SC_REQUEST_TIMEOUT ?
                                   "Timed out waiting for response to INVITE request from AS" :
                                   "AS returned 5xx response");
+          bypass_As.add_static_param(_as_chain_link.complete());
           SAS::report_event(bypass_As);
 
-          _as_chain_link = _as_chain_link.next();
-          pjsip_msg* req = get_base_request();
-          _record_routed = false;
-          if (_session_case->is_originating())
+          // Check that we aren't about to iterate through the AS chain if we're
+          // already complete (which would cause "index out of range" crashes).  
+          // This shouldn't happen in normal operation, but there have 
+          // historically been problems when AS timers couldn't be cancelled because
+          // they'd already popped, with the result that we get too many callbacks
+          // changing the state of the AS chain.
+          if (_as_chain_link.complete())
           {
-            apply_originating_services(req);
+            // LCOV_EXCL_START
+            TRC_ERROR("Unexpected response for complete AS Chain. SAS TrailID: %lu", trail());
+            // LCOV_EXCL_STOP
           }
           else
           {
-            apply_terminating_services(req);
+            _as_chain_link = _as_chain_link.next();
+            pjsip_msg* req = get_base_request();
+            _record_routed = false;
+            if (_session_case->is_originating())
+            {
+              apply_originating_services(req);
+            }
+            else
+            {
+              apply_terminating_services(req);
+            }
           }
 
           // Free off the response as we no longer need it.
@@ -2162,18 +2178,34 @@ void SCSCFSproutletTsx::on_timer_expiry(void* context)
       TRC_DEBUG("Trigger default_handling=CONTINUED processing");
       SAS::Event bypass_as(trail(), SASEvent::BYPASS_AS, 0);
       bypass_as.add_var_param("AS liveness timer expired");
+      bypass_as.add_static_param(_as_chain_link.complete());
       SAS::report_event(bypass_as);
 
-      _as_chain_link = _as_chain_link.next();
-      pjsip_msg* req = get_base_request();
-      _record_routed = false;
-      if (_session_case->is_originating())
+      // Check that we aren't about to iterate through the AS chain if we're
+      // already complete (which would cause "index out of range" crashes).  
+      // If this happens, it means there's a bug elsewhere, but there have 
+      // historically been problems when AS timers couldn't be cancelled because
+      // they'd already popped, with the result that we get too many callbacks
+      // changing the state of the AS chain.
+      if (_as_chain_link.complete())
       {
-        apply_originating_services(req);
+        // LCOV_EXCL_START
+        TRC_ERROR("Unexpected timeout for complete AS Chain. SAS TrailID: %lu", trail());
+        // LCOV_EXCL_STOP
       }
       else
       {
-        apply_terminating_services(req);
+        _as_chain_link = _as_chain_link.next();
+        pjsip_msg* req = get_base_request();
+        _record_routed = false;
+        if (_session_case->is_originating())
+        {
+          apply_originating_services(req);
+        }
+        else
+        {
+          apply_terminating_services(req);
+        }
       }
     }
     else

--- a/src/sproutletproxy.cpp
+++ b/src/sproutletproxy.cpp
@@ -672,7 +672,7 @@ SproutletProxy::UASTsx::Callback::Callback(UASTsx* tsx, std::function<void()> ru
   // Whenever we create a Callback we expect it to be run, so increase the count
   // of _pending_callbacks on the UASTsx
   _tsx->_pending_callbacks++;
-  TRC_DEBUG("Increment pending callbacks to: %d", _tsx->_pending_callbacks);
+  TRC_DEBUG("Incremented pending callbacks to: %d", _tsx->_pending_callbacks);
 }
 
 void SproutletProxy::UASTsx::Callback::run()
@@ -682,7 +682,7 @@ void SproutletProxy::UASTsx::Callback::run()
   // Now that we are running a Callback, we can decrement the count of pending
   // callbacks
   _tsx->_pending_callbacks--;
-  TRC_DEBUG("Decrement pending callbacks to: %d", _tsx->_pending_callbacks);
+  TRC_DEBUG("Decremented pending callbacks to: %d", _tsx->_pending_callbacks);
 
   // _run_fn() contains that actual work that we need to do for this Callback
   _run_fn();
@@ -1175,7 +1175,7 @@ bool SproutletProxy::UASTsx::schedule_timer(SproutletWrapper* tsx,
     // but before its had a chance to run, in which case we'd end up
     // threading a destroyed object.
     _pending_callbacks++;
-    TRC_DEBUG("Increment pending callbacks to: %d", _pending_callbacks);
+    TRC_DEBUG("Incremented pending callbacks to: %d", _pending_callbacks);
   }
   return scheduled;
 }
@@ -1192,7 +1192,7 @@ bool SproutletProxy::UASTsx::cancel_timer(TimerID id)
     // if the cancel failed, it will be because the timer has popped, in which
     // case _pending_callbacks will be decremented by process_timer_pop below
     _pending_callbacks--;
-    TRC_DEBUG("Decrement pending callbacks to: %d", _pending_callbacks);
+    TRC_DEBUG("Decremented pending callbacks to: %d", _pending_callbacks);
   }
 
   // Always attempt to remove the timer entry from the _pending_timers
@@ -1238,7 +1238,7 @@ void SproutletProxy::UASTsx::process_timer_pop(pj_timer_entry* tentry)
   // cancel call did not fail (if it failed, then the timer will have popped,
   // in which case this routine will eventually get called).
   _pending_callbacks--;
-  TRC_DEBUG("Decrement pending callbacks to: %d", _pending_callbacks);
+  TRC_DEBUG("Decremented pending callbacks to: %d", _pending_callbacks);
 
   if (_pending_timers.erase(tentry) != 0)
   {


### PR DESCRIPTION
Hi Richard

Are you OK to review this two-pronged timer cancel fix?  

No UTs, but I managed to test first the timer handling code in scscfsproutlet with this "slow DNS" repro scenario (which stopped the crash, but a random leg got CANCELled and the call failed) and then the "cancel timer even if popped" code in sproutletproxy with the same slow repro (this time the call completed fine, with the slow timer being properly cancelled) altogether.

I haven't been able to come up with a repro scenario for the "extra response" case in scscfsproutlet, but I'm going to claim that the backstop code is good by inspection (and "make full_test" passes).

I'll reference the associated SAS resource bundle fix shortly