### PR TITLE
[Reviewer Krista] Correctly quote PCV header contents

### DIFF
--- a/include/pjutils.h
+++ b/include/pjutils.h
@@ -309,6 +309,9 @@ void add_pcfa_header(pjsip_msg* msg,
                      const std::deque<std::string>& ecfs,
                      const bool replace);
 
+bool needs_quoting(const char* inbuf,
+                   size_t length);
+
 void add_pcfa_param(pj_list_type *cf_list,
                     pj_pool_t* pool,
                     const pj_str_t name,

--- a/src/pjutils.cpp
+++ b/src/pjutils.cpp
@@ -2300,7 +2300,7 @@ bool PJUtils::needs_quoting(const char *inbuf,
   // Note that we assume for simplicity that if the value starts with '[',
   // its an ipv6 address (int_parse_host in sip_parser.c makes the same
   // assumption and the pjsip_HOST_SPEC doesn't cover IPv6 parsing).
-  bool quote = false;
+  bool needs_quoting = false;
 
   // Check whether the value already quoted, or an IPv6 address
   if ((inbuf[0] != '"') && (inbuf[0] != '['))
@@ -2308,12 +2308,13 @@ bool PJUtils::needs_quoting(const char *inbuf,
     const pjsip_parser_const_t *pc = pjsip_parser_const();
     for (size_t index = 0; index < length; index++)
     {
-      quote = quote || (!pj_cis_match(&pc->pjsip_TOKEN_SPEC, inbuf[index]) &&
+      needs_quoting = needs_quoting ||
+                       (!pj_cis_match(&pc->pjsip_TOKEN_SPEC, inbuf[index]) &&
                         !pj_cis_match(&pc->pjsip_HOST_SPEC, inbuf[index]));
     }
   }
 
-  return quote;
+  return needs_quoting;
 }
 
 // Add Changing Function param to the list for a PCFA header

--- a/src/ut/sip_parser_test.cpp
+++ b/src/ut/sip_parser_test.cpp
@@ -54,7 +54,7 @@ TEST_F(SipParserTest, PChargingVector)
              "Max-Forwards: 63\n"
              "From: <sip:6505551234@homedomain>;tag=1234\n"
              "To: <sip:6505554321@homedomain>\n"
-             "P-Charging-Vector: icid-value=4815162542; orig-ioi=homedomain; term-ioi=remotedomain; icid-generated-at=edge.proxy.net; other-param=test-value\n"
+             "P-Charging-Vector: icid-value=4815162542; orig-ioi=\"home;domain\"; term-ioi=\"remote;domain\"; icid-generated-at=edge.proxy.net; eps-info=\"eps-item=1;eps-sig=yes;ecid=32333631313536313937,eps-item=2;eps-sig=yes;ecid=432100AB00;flow-id=({0,0})\"\n"
              "Contact: <sip:6505551234@10.0.0.1:5060;transport=TCP;ob>\n"
              "Call-ID: 1-13919@10.151.20.48\n"
              "CSeq: 1 INVITE\n"
@@ -73,8 +73,8 @@ TEST_F(SipParserTest, PChargingVector)
   pjsip_p_c_v_hdr* pcv = (pjsip_p_c_v_hdr*)hdr;
 
   EXPECT_PJEQ(pcv->icid, "4815162542");
-  EXPECT_PJEQ(pcv->orig_ioi, "homedomain");
-  EXPECT_PJEQ(pcv->term_ioi, "remotedomain");
+  EXPECT_PJEQ(pcv->orig_ioi, "home;domain");
+  EXPECT_PJEQ(pcv->term_ioi, "remote;domain");
   EXPECT_PJEQ(pcv->icid_gen_addr, "edge.proxy.net");
   EXPECT_EQ(1u, pj_list_size(&pcv->other_param));
 
@@ -82,16 +82,16 @@ TEST_F(SipParserTest, PChargingVector)
   pjsip_p_c_v_hdr* pcv_clone = (pjsip_p_c_v_hdr*)hdr->vptr->clone(stack_data.pool, (void*)hdr);
 
   EXPECT_PJEQ(pcv_clone->icid, "4815162542");
-  EXPECT_PJEQ(pcv_clone->orig_ioi, "homedomain");
-  EXPECT_PJEQ(pcv_clone->term_ioi, "remotedomain");
+  EXPECT_PJEQ(pcv_clone->orig_ioi, "home;domain");
+  EXPECT_PJEQ(pcv_clone->term_ioi, "remote;domain");
   EXPECT_PJEQ(pcv_clone->icid_gen_addr, "edge.proxy.net");
   EXPECT_EQ(1u, pj_list_size(&pcv_clone->other_param));
 
   pjsip_p_c_v_hdr* pcv_sclone = (pjsip_p_c_v_hdr*)hdr->vptr->shallow_clone(stack_data.pool, (void*)hdr);
 
   EXPECT_PJEQ(pcv_sclone->icid, "4815162542");
-  EXPECT_PJEQ(pcv_sclone->orig_ioi, "homedomain");
-  EXPECT_PJEQ(pcv_sclone->term_ioi, "remotedomain");
+  EXPECT_PJEQ(pcv_sclone->orig_ioi, "home;domain");
+  EXPECT_PJEQ(pcv_sclone->term_ioi, "remote;domain");
   EXPECT_PJEQ(pcv_sclone->icid_gen_addr, "edge.proxy.net");
   EXPECT_EQ(1u, pj_list_size(&pcv_sclone->other_param));
 
@@ -104,8 +104,8 @@ TEST_F(SipParserTest, PChargingVector)
     written = hdr->vptr->print_on(hdr, buf, i);
     i++;
   }
-  EXPECT_EQ(written, 140);
-  EXPECT_STREQ("P-Charging-Vector: icid-value=\"4815162542\";orig-ioi=homedomain;term-ioi=remotedomain;icid-generated-at=edge.proxy.net;other-param=test-value", buf);
+  EXPECT_EQ(written, 238);
+  EXPECT_STREQ("P-Charging-Vector: icid-value=\"4815162542\";orig-ioi=\"home;domain\";term-ioi=\"remote;domain\";icid-generated-at=edge.proxy.net;eps-info=\"eps-item=1;eps-sig=yes;ecid=32333631313536313937,eps-item=2;eps-sig=yes;ecid=432100AB00;flow-id=({0,0})\"", buf);
 }
 
 TEST_F(SipParserTest, PChargingVectorQuotedIcidValue)

--- a/src/ut/sip_parser_test.cpp
+++ b/src/ut/sip_parser_test.cpp
@@ -47,6 +47,7 @@ public:
   std::string parse_and_print_one(std::string header, std::string hname, CloneType ct = CloneType::None);
 };
 
+// Verify the function of the P-Charging-Vector parse and print functions
 TEST_F(SipParserTest, PChargingVector)
 {
   string str("INVITE sip:6505554321@homedomain SIP/2.0\n"


### PR DESCRIPTION
Hi Krista

Can you review this fix for me this week (before the code slush)? Its a fix to Sprint-critical issue https://github.com/Metaswitch/clearwater-issues/issues/3646.

Fix here is to refactor the PCFA print code (which has the same quoting requirement) and use this code to correctly quote the parameters for the PCV, with a couple of exceptions

-  I've left the icid-value as "always quote", for two reasons:  Its what the code explicitly did already (possibly for interworking reasons) and we want to cope with the "icid-value is zero-length" case (icid-value is mandatory in the PCV, and I expect 'icid-value=;....' to be rejected by the downstream node as unparseable, whereas 'icid-value="";...' is less likely to cause problems)
-  the icid-generated-at parameter only takes "host" parameters, so I'm just reported what is already in the parameter unquoted.

Tested using the updated UT test script and also live (I fired in a test INVITE with the PCV header from the issue and checked that the header in the response was correctly quoted)