### PR TITLE
[Reviewer: Sathiyan] Reject INVITEs statefully when overloaded

### DIFF
--- a/src/ut/scscf_test.cpp
+++ b/src/ut/scscf_test.cpp
@@ -1152,10 +1152,16 @@ void SCSCFTestBase::doSlowFailureFlow(SCSCFMessage& msg,
   RespMatcher(100).matches(out);
   free_txdata();
 
-  // error goes back
+  // Error goes back
   out = current_txdata()->msg;
   RespMatcher(st_code, body, reason).matches(out);
   free_txdata();
+
+  // Send ACK to finish transaction.
+  msg._method = "ACK";
+  msg._in_dialog = true;
+  inject_msg(msg.get_request());
+  poll();
 }
 
 // Fill in the irs info object to be returned by the mock subscriber manager.

--- a/src/ut/thread_dispatcher_test.cpp
+++ b/src/ut/thread_dispatcher_test.cpp
@@ -175,6 +175,19 @@ TEST_F(ThreadDispatcherTest, OverloadedInviteTest)
   inject_msg_thread(msg.get_request());
 }
 
+// Messages should be rejected with a 503 if the load monitor returns false.
+TEST_F(ThreadDispatcherTest, OverloadedMessageTest)
+{
+  TestingCommon::Message msg;
+  msg._method = "MESSAGE";
+
+  EXPECT_CALL(load_monitor, admit_request(_, false)).WillOnce(Return(false));
+  EXPECT_CALL(load_monitor, get_target_latency_us()).WillOnce(Return(100000));
+  EXPECT_CALL(*mod_mock, on_tx_response(ResultOf(get_tx_status_code, 503)));
+
+  inject_msg_thread(msg.get_request());
+}
+
 // Invites older than the specified request_on_queue_timeout parameter should
 // be rejected with a 503.
 TEST_F(ThreadDispatcherTest, RejectOldInviteTest)


### PR DESCRIPTION
Sathiyan, can you review this change to reject INVITEs statefully when overloaded?

It's been tested live at 3x overload. I've not really tested this in the UTs. I've got coverage, but if you can think of a better UT please let me know.