### PR TITLE
[Reviewer: RND] Allow searching for SIP errors in SAS 

### DIFF
--- a/src/common_sip_processing.cpp
+++ b/src/common_sip_processing.cpp
@@ -285,6 +285,15 @@ static void sas_log_tx_msg(pjsip_tx_data *tdata)
       PJUtils::mark_sas_call_branch_ids(trail, tdata->msg);
     }
 
+    if (tdata->msg->type == PJSIP_RESPONSE_MSG && (tdata->msg->line.status.code > 199))
+    {
+      SAS::Marker error_marker(trail, MARKER_ID_PROTOCOL_ERROR, 1u);
+      error_marker.add_static_param(5); // SIP protocol
+      error_marker.add_static_param(503);
+      error_marker.add_var_param("Bad thing");
+      SAS::report_marker(error_marker);
+    }
+
     // Log the message event.
     SAS::Event event(trail, SASEvent::TX_SIP_MSG, 0);
     event.add_static_param(pjsip_transport_get_type_from_flag(tdata->tp_info.transport->flag));

--- a/src/common_sip_processing.cpp
+++ b/src/common_sip_processing.cpp
@@ -285,12 +285,15 @@ static void sas_log_tx_msg(pjsip_tx_data *tdata)
       PJUtils::mark_sas_call_branch_ids(trail, tdata->msg);
     }
 
-    if (tdata->msg->type == PJSIP_RESPONSE_MSG && (tdata->msg->line.status.code > 199))
+    // Log a SIP protocol error marker for 4xx, 5xx or 6xx responses, so we can
+    // search by error code.
+    if (tdata->msg->type == PJSIP_RESPONSE_MSG && (tdata->msg->line.status.code > 399))
     {
       SAS::Marker error_marker(trail, MARKER_ID_PROTOCOL_ERROR, 1u);
       error_marker.add_static_param(5); // SIP protocol
-      error_marker.add_static_param(503);
-      error_marker.add_var_param("Bad thing");
+      error_marker.add_static_param(tdata->msg->line.status.code);
+      // We can't give a more specific error string here - it would be a waste of bandwidth.
+      error_marker.add_var_param("");
       SAS::report_marker(error_marker);
     }
 


### PR DESCRIPTION
Turns out you were right, it wasn't that hard! Tested by building and deploying https://github.com/Metaswitch/sprout/commit/93c2babe56687bd4aea4bc7f2c49abd409740b6d, sending a REGISTER, and checking it came up in SAS when I searched for a SIP 503 but not when I searched for a SIP 423.