### PR TITLE
Build IO trap library for sprout

### DIFF
--- a/debian/sprout-libs.install
+++ b/debian/sprout-libs.install
@@ -1,2 +1,3 @@
 usr/lib/*.so usr/share/clearwater/sprout/lib
 usr/lib/*.so.* usr/share/clearwater/sprout/lib
+build/bin/sprout_io_trap.so usr/share/clearwater/sprout/lib

--- a/docs/IOTraps.md
+++ b/docs/IOTraps.md
@@ -1,0 +1,19 @@
+# Trapping disallowed IO patterns
+
+Sprout's overload controls use message latency to spot when sprout is under too much load. However these controls exclude the latency of any IO that sprout does when processing a message, so as to accurately measure the load on the sprout node and not other devices in the network. For this to work correctly, it is important that any IO done on a sprout worker thread is wrapped in calls to `CW_IO_STARTS` and `CW_IO_COMPLETES`, as this ensures that any latency incurred from the IO is deducted from the overall latency of the message.
+
+In order to spot if sprout does any IO with making the above calls, sprout comes with an "IO trap". This is a shared object that can be installed into sprout using the `LD_PRELOAD` environment variable. With the trap installed, ff sprout's worker threads do any IO without making these calls, the process will abort and produce a stack trace and a core file.
+
+To run sprout with the IO trap, do the following.
+
+1.  Find the command line you are using to run sprout (`ps -eaf | grep sprout`)
+1.  Make sure you have the appropriate debug packages installed (`sudo apt-get install sprout-node-dbg`)
+1.  Disable monitoring of sprout (`sudo monit unmonitor -g sprout`)
+1.  Stop sprout (`sudo service sprout stop`)
+1.  Set user limits and become the sprout user (`sudo -i; ulimit -Hn 1000000; ulimit -Sn 1000000; ulimit -r 1; ulimit -c unlimited; sudo -s -u sprout bash`)
+1.  Change to the `/etc/clearwater` directory
+1.  Run the following command, replacing args with the arguments sprout was run with in step 1.
+
+```
+LD_PRELOAD=/usr/share/clearwater/sprout/lib/sprout_io_trap.so LD_LIBRARY_PATH=/usr/share/clearwater/sprout/lib /usr/share/clearwater/bin/sprout <args>
+```

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,4 @@
-TARGETS := sprout call-diversion-as.so gemini-as.so sprout_bgcf.so sprout_icscf.so sprout_mmtel_as.so sprout_scscf.so mangelwurzel-as.so
+TARGETS := sprout call-diversion-as.so gemini-as.so sprout_bgcf.so sprout_icscf.so sprout_mmtel_as.so sprout_scscf.so mangelwurzel-as.so sprout_io_trap.so
 
 TEST_TARGETS := sprout_test
 
@@ -312,6 +312,10 @@ sprout_scscf.so_LDFLAGS := ${PLUGIN_COMMON_LDFLAGS}
 mangelwurzel-as.so_SOURCES := mangelwurzel.cpp mangelwurzelplugin.cpp
 mangelwurzel-as.so_CPPFLAGS := ${PLUGIN_COMMON_CPPFLAGS} -I../include/mangelwurzel
 mangelwurzel-as.so_LDFLAGS := ${PLUGIN_COMMON_LDFLAGS}
+
+sprout_io_trap.so_SOURCES := io_trap.cpp
+sprout_io_trap.so_CPPFLAGS := -fPIC -I../modules/cpp-common/include
+sprout_io_trap.so_LDFLAGS := -shared
 
 VPATH = ../modules/cpp-common/src ../modules/clearwater-s4/src ../modules/clearwater-s4/src/ut ../modules/cpp-common/test_utils ../modules/app-servers/test ../modules/gemini/src ../modules/gemini/src/ut mangelwurzel mangelwurzel/ut ut
 

--- a/src/thread_dispatcher.cpp
+++ b/src/thread_dispatcher.cpp
@@ -356,6 +356,11 @@ int worker_thread(void* p)
 {
   TRC_DEBUG("Worker thread started");
 
+  // This thread is not allowed to do IO without using the CW_IO_START and
+  // CW_IO_COMPLETES macros. Doing so means that sprout's overload algorithms
+  // will not work properly.
+  CW_IO_CALLS_REQUIRED();
+
   bool rc = true;
 
   while (rc) {


### PR DESCRIPTION
This PR builds an IO trap library that can be used to check if sprout worker threads are doing IO without first calling `CW_IO_*`. 

This PR is not quite complete as I haven't decided how to run this going forwards. There are two options:

* Run sprout from the command line, and explicitly load the IO trap as described in https://github.com/Metaswitch/cpp-common/pull/779. In this case all that's needed is some documentation. 
* Add a shared config option that can be used to automatically load the IO trap when sprout starts. That needs more code and I'm not quite sure how to do it yet. 

However I still think it's worth gettting the code reviewed as it stands. I'll do one of the above either as a separate commit or a separate PR. 