### PR TITLE
Cope with RamRecoder interface change

### DIFF
--- a/src/stack.cpp
+++ b/src/stack.cpp
@@ -247,7 +247,7 @@ void init_pjsip_logging(int log_level,
   pj_log_set_level(log_level);
   pj_log_set_decor(PJ_LOG_HAS_SENDER);
   pj_log_set_log_func(&pjsip_log_handler);
-  pj_log_set_ram_trace_func(&RamRecorder::record_with_context);
+  pj_log_set_ram_trace_func(&RamRecorder::record_with_context_pod);
 }
 
 


### PR DESCRIPTION
Update required as a result of https://github.com/Metaswitch/cpp-common/pull/786

Tested by building sprout and running `make full_test`